### PR TITLE
Shyft data handling

### DIFF
--- a/shyft/__init__.py
+++ b/shyft/__init__.py
@@ -26,9 +26,9 @@ def print_versions():
     import sys
 
     print("-=" * 38)
-    print("SHyFT version: %s" % __version__)
+    print("SHyFT version:     %s" % __version__)
     print("NumPy version:     %s" % numpy.__version__)
-    print("netCDF4 version:     %s" % netCDF4.__version__)
+    print("netCDF4 version:   %s" % netCDF4.__version__)
     print("Python version:    %s" % sys.version)
     if os.name == "posix":
         (sysname, nodename, release, version_, machine) = os.uname()
@@ -39,4 +39,5 @@ def print_versions():
 
 def run_tests():
     import nose
+    print_versions()
     nose.main()

--- a/shyft/__init__.py
+++ b/shyft/__init__.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os
+import os.path
+
 
 this_dir = __path__[0]
 __version__ = "development"
@@ -10,43 +12,23 @@ try:
 except:
     pass
 
-
-def _get_hg_description(path_):
-    """ Get the output of hg summary when executed in a given path. """
-    import subprocess
-
-    # make an absolute path if required, for example when running in a clone
-    if not os.path.isabs(path_):
-        loc_path = os.path.abspath(os.path.curdir)
-        path_ = os.path.join(loc_path, path_)
-    # look up the commit using subprocess and hg summary
-    try:
-        # redirect stderr to stdout to make sure the hg error message in case
-        # we are not in a hg repo doesn't appear on the screen and confuse the
-        # user.
-        out = subprocess.check_output(
-            ["hg", "summary"], cwd=path_, stderr=subprocess.STDOUT).strip()
-        out = "".join(['\n  ' + l for l in out.split('\n')])
-        return out
-    except OSError:  # in case hg wasn't found
-        pass
-    except subprocess.CalledProcessError:  # not in hg repo
-        pass
-
-
-_hg_description = _get_hg_description(this_dir)
+if "SHYFTDATA" in os.environ:
+    shyftdata_dir = os.environ["SHYFTDATA"]
+else:
+    # If SHYFTDATA environment variable is not here, then use a decent guess
+    shyftdata_dir = os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir, "shyft-data")
 
 
 def print_versions():
-    """Print all the versions for packages that pflexible relies on."""
+    """Print all the versions for packages that SHyFT relies on."""
     import numpy
+    import netCDF4
     import sys
 
     print("-=" * 38)
-    print("shyft version: %s" % __version__)
-    if _hg_description:
-        print("shyft hg summary:    %s" % _hg_description)
+    print("SHyFT version: %s" % __version__)
     print("NumPy version:     %s" % numpy.__version__)
+    print("netCDF4 version:     %s" % netCDF4.__version__)
     print("Python version:    %s" % sys.version)
     if os.name == "posix":
         (sysname, nodename, release, version_, machine) = os.uname()

--- a/shyft/orchestration2/base_config.py
+++ b/shyft/orchestration2/base_config.py
@@ -74,7 +74,7 @@ class BaseConfig(object):
         self.process_params(section['repository']['params'])
 
     def abspath(self, filepath):
-        """Return the absolute path to the directory of netcdf data files."""
+        """Return the absolute path to the directory of configuration files."""
         if os.path.isabs(filepath):
             return filepath
         else:

--- a/shyft/orchestration2/base_config.py
+++ b/shyft/orchestration2/base_config.py
@@ -10,8 +10,9 @@ import urlparse
 
 import yaml
 
+from shyft import shyftdata_dir
 from . import state
-from .utils import utctime_from_datetime, get_class
+from .utils import utctime_from_datetime, get_class, abs_datafilepath
 
 
 def config_constructor(config_file, config_section, **overrides):
@@ -151,7 +152,7 @@ class BaseTarget(object):
 
     def __init__(self, data_file, config):
         self._config_file = config._config_file
-        self.data_file = os.path.join(self.absdir(config.data_dir), data_file)
+        self.data_file = os.path.join(shyftdata_dir, data_file)
 
     def __repr__(self):
         repr = "%s(" % self.__class__.__name__
@@ -216,10 +217,7 @@ class BaseRegion(BaseAncillaryConfig):
 
     def absdir(self, filepath):
         """Return the absolute path to the directory of data files."""
-        if os.path.isabs(filepath):
-            return filepath
-        else:
-            return os.path.join(os.path.dirname(self._config_file), filepath)
+        return abs_datafilepath(filepath)
 
 
 # *** Model ***

--- a/shyft/orchestration2/generic/region.py
+++ b/shyft/orchestration2/generic/region.py
@@ -20,7 +20,9 @@ class Region(BaseRegion):
         # Get an instance of the class for the repository
         repo = self.repository
         repo_cls = get_class(repo['class'])
+        print("data_file 0:", repo['data_file'])
         data_file = self.absdir(repo['data_file'])
+        print("data_file 1:", data_file)
         repo_instance = repo_cls(config_file, data_file)
         if not isinstance(repo_instance, BaseRegion):
             raise ValueError("The repository class is not an instance of 'BaseRegion'")

--- a/shyft/orchestration2/generic/region.py
+++ b/shyft/orchestration2/generic/region.py
@@ -20,9 +20,7 @@ class Region(BaseRegion):
         # Get an instance of the class for the repository
         repo = self.repository
         repo_cls = get_class(repo['class'])
-        print("data_file 0:", repo['data_file'])
         data_file = self.absdir(repo['data_file'])
-        print("data_file 1:", data_file)
         repo_instance = repo_cls(config_file, data_file)
         if not isinstance(repo_instance, BaseRegion):
             raise ValueError("The repository class is not an instance of 'BaseRegion'")

--- a/shyft/orchestration2/netcdf/region.py
+++ b/shyft/orchestration2/netcdf/region.py
@@ -16,6 +16,7 @@ class Region(BaseRegion):
     def __init__(self, config_file, data_file):
         super(Region, self).__init__(config_file)
         self._mask = None
+        print("data_file:", data_file)
         self._data_file = data_file
 
     @property

--- a/shyft/orchestration2/netcdf/source_dataset.py
+++ b/shyft/orchestration2/netcdf/source_dataset.py
@@ -3,6 +3,7 @@ Module for reading dataset files needed for an SHyFT run.
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 
@@ -10,25 +11,20 @@ import numpy as np
 from netCDF4 import Dataset
 
 from ..base_config import BaseSourceDataset
-from shyft import api
+from shyft import api, shyftdata_dir
+from ..utils import abs_datafilepath
 
 
 class SourceDataset(BaseSourceDataset):
 
-    def absdir(self, filepath):
-        """Return the absolute path to the directory of netcdf data files."""
-        if os.path.isabs(filepath):
-            return filepath
-        else:
-            return os.path.join(os.path.dirname(self._config_file), filepath)
-
     @property
     def _stations_met(self):
-        return self.absdir(self.stations_met)
+        print("stations_met:", self.stations_met)
+        return abs_datafilepath(self.stations_met)
 
     @property
     def _stations_discharge(self):
-        return self.absdir(self.stations_discharge)
+        return abs_datafilepath(self.stations_discharge)
 
     def __repr__(self):
         return "%s(stations_met=%r, stations_discharge=%r)" % (

--- a/shyft/orchestration2/netcdf/source_dataset.py
+++ b/shyft/orchestration2/netcdf/source_dataset.py
@@ -19,7 +19,6 @@ class SourceDataset(BaseSourceDataset):
 
     @property
     def _stations_met(self):
-        print("stations_met:", self.stations_met)
         return abs_datafilepath(self.stations_met)
 
     @property

--- a/shyft/orchestration2/netcdf/target.py
+++ b/shyft/orchestration2/netcdf/target.py
@@ -25,7 +25,6 @@ class Target(BaseTarget):
 
     def __init__(self, data_file, config):
         super(Target, self).__init__(data_file, config)
-        print("data_file:", self.data_file)
 
     def fetch_id(self, internal_id, uids, period):
         """Fetch all the time series given in `uids` list within date `period`.
@@ -39,7 +38,6 @@ class Target(BaseTarget):
             time = dset.groups[internal_id].variables['time'][:]
             nptime = np.array(time, dtype='datetime64[s]')
             # Index of time in the interesting period
-            print("period:", np_period)
             idx = np.where((nptime >= np_period[0]) & (nptime < np_period[1]))[0]
             times = api.UtcTimeVector.FromNdArray(nptime[idx].astype(np.long))
             for uid in uids:

--- a/shyft/orchestration2/utils.py
+++ b/shyft/orchestration2/utils.py
@@ -3,8 +3,9 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import numpy as np
-from shyft import api
+from shyft import api, shyftdata_dir
 
 
 utc_calendar = api.Calendar()
@@ -45,3 +46,11 @@ def get_class(repo):
     except ImportError:
         print("Repository '%s' cannot be imported.  Please check the path.")
     return eval(repo_cls)
+
+def abs_datafilepath(filepath):
+    """Get the absolute path for a data `filepath`.
+    """
+    if os.path.isabs(filepath):
+        return filepath
+    else:
+        return os.path.join(shyftdata_dir, filepath)

--- a/shyft/tests/netcdf/calibration.yaml
+++ b/shyft/tests/netcdf/calibration.yaml
@@ -6,7 +6,7 @@ Himalayas:
   target:
   - repository:
     class: shyft.orchestration2.netcdf.Target
-    file: stations_discharge.nc
+    file: netcdf/orchestration-testdata/stations_discharge.nc
     1D_timeseries:
     - internal_id: subcatchment2
       # uid: /SHyFT/STS/Runoff/Vikf-Tistel, 2015-09-01T00:00:00

--- a/shyft/tests/netcdf/datasets.yaml
+++ b/shyft/tests/netcdf/datasets.yaml
@@ -3,7 +3,7 @@ sources:
   - repository: source_repo1
     class: shyft.orchestration2.netcdf.SourceDataset
     params:
-      stations_met: stations_met.nc
+      stations_met: netcdf/orchestration-testdata/stations_met.nc
       types:
         - type: precipitation
           stations:

--- a/shyft/tests/netcdf/region.yaml
+++ b/shyft/tests/netcdf/region.yaml
@@ -1,7 +1,7 @@
 ---
 repository:
   class: shyft.orchestration2.netcdf.Region
-  data_file: cell_info.nc
+  data_file: netcdf/orchestration-testdata/cell_info.nc
 
 domain:
   EPSG: 32632


### PR DESCRIPTION
Uses new location of datafiles for orchestration2 testing in '../shyft-data'.

Also, this honors a new `SHYFTDATA` environment variable for telling where the `shyft-data` local repository is located.   If not found, it defaults to '../shyft-data'.

This should be ready for merging.