### PR TITLE
implemented exception for unreasonable calendar coordinates

### DIFF
--- a/test/test.cbp
+++ b/test/test.cbp
@@ -39,7 +39,7 @@
 					<Add directory="../bin/Release" />
 				</Linker>
 				<ExtraCommands>
-					<Add after="cd ../bin/Release &amp;&amp; ./test_shyft  sceua_test" />
+					<Add after="cd ../bin/Release &amp;&amp; ./test_shyft  utctime_utilities_test" />
 				</ExtraCommands>
 			</Target>
 		</Build>
@@ -50,6 +50,8 @@
 			<Add option="-D__UNIT_TEST__" />
 			<Add option="-DVERBOSE=0" />
 			<Add option="-DARMA_DONT_USE_WRAPPER" />
+			<Add option="-DCXXTEST_HAVE_EH" />
+			<Add option="-DCXXTEST_HAVE_STD" />
 			<Add directory="../../cxxtest" />
 			<Add directory=".." />
 			<Add directory="../../dlib" />

--- a/test/utctime_utilities_test.cpp
+++ b/test/utctime_utilities_test.cpp
@@ -11,6 +11,10 @@ void utctime_utilities_test::test_utctime() {
     YMDhms y_null;
 
     TS_ASSERT(y_null.is_null());
+    TS_ASSERT(c.time(y_null)==no_utctime);
+    TS_ASSERT(c.time(YMDhms::max())==max_utctime);
+    TS_ASSERT(c.time(YMDhms::min())==min_utctime);
+
     TS_ASSERT_EQUALS(0L,c.time(unixEra));
     YMDhms r=c.calendar_units(utctime(0L));
     TS_ASSERT_EQUALS(r,unixEra);
@@ -61,7 +65,21 @@ void utctime_utilities_test::test_calendar_month() {
 
 }
 
-
+void utctime_utilities_test::test_YMDhms_reasonable_calendar_coordinates() {
+    TS_ASSERT_THROWS({YMDhms(10000 ,1,1,0,0,0);},std::runtime_error);
+    //TS_ASSERT_EQUALS(.is_valid_coordinates(),false);
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(-10000,1,1,0,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,0,1,0,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,13,1,0,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,0,0,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,32,0,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,1,-1,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,1,24,0,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,1,0,-1,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,1,0,60,0));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,1,0,0,-1));
+    TS_ASSERT_THROWS_ANYTHING(YMDhms(2000,1,1,0,0,60));
+}
 void utctime_utilities_test::test_calendar_add_and_diff_units() {
 	calendar cet(deltahours(1));
 	int n_units = 3;

--- a/test/utctime_utilities_test.h
+++ b/test/utctime_utilities_test.h
@@ -11,6 +11,7 @@ class utctime_utilities_test: public CxxTest::TestSuite {
 	void test_calendar_day_of_week();
 	void test_calendar_trim();
 	void test_calendar_add_and_diff_units();
+	void test_YMDhms_reasonable_calendar_coordinates();
 };
 
 


### PR DESCRIPTION
Its not the exact truth, it is still possible to pass 'invalid' calendar coordinates
but this helps for those passing dates like 2001.13.44  etc.
