### PR TITLE
fixing calibration result saving in orchestration2.

### DIFF
--- a/shyft/orchestration2/calibrator.py
+++ b/shyft/orchestration2/calibrator.py
@@ -98,7 +98,7 @@ class Calibrator(object):
         }
 
         # Existing model parameters structure
-        model_file = self._model_config._config_file
+        model_file = self._model_config.model_config_file
         model_dict = yaml.load(open(model_file))
         model = model_dict['parameters']['model']
         # Overwrite overlapping params

--- a/shyft/orchestration2/shyft_runner.py
+++ b/shyft/orchestration2/shyft_runner.py
@@ -49,8 +49,8 @@ def main_calibration_runner(config_file, section):
     calibrator.init(time_axis)
     calibr_results = calibrator.calibrate(tol=1.0e-5)
     print("Calibration result:", calibr_results)
-    if hasattr(config, "calibrated_model"):
-        calibrator.save_calibrated_model(config.calibrated_model, calibr_results)
+    if hasattr(config, "calibrated_model_file"):
+        calibrator.save_calibrated_model(config.calibrated_model_file, calibr_results)
     return calibrator
 
 


### PR DESCRIPTION
Simple fix: Saving of calibration results using orchestration2 should work now.