### PR TITLE
Greatly improved cmake support, with native support for extensions and C++ tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - kalakris/cmake
+    - ubuntu-toolchain-r-test
+    packages:
+    - cmake
+    - g++-4.9
+    - liblapack-dev
+
+cache:
+  apt: true
+  directories:
+  - $HOME/dependencies
+
+
+language: python
+
+os:
+  - linux
+  # - osx
+
+python:
+  - 2.7
+
+before_install:
+  - uname -a
+  - free -m
+  - df -h
+  - ulimit -a
+  - ulimit -s 32768  # C++ compilers require a lot of memory
+
+  # Install conda
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+
+  # Install dependencies
+  - conda create -n shyft_env python=$TRAVIS_PYTHON_VERSION pyyaml numpy libgfortran netcdf4 gdal matplotlib requests nose coverage pip shapely pyproj swig
+  - source activate shyft_env
+  #- conda install -c https://conda.anaconda.org/minrk swig  # hits a bug in conda
+  #- conda install swig
+  - pip install descartes
+  - python -V
+
+  # The data repository dependency
+  - git clone --depth=50 --branch=master https://github.com/statkraft/shyft-data.git shyft-data
+  - ln -s `pwd`/shyft-data ../shyft-data  # make it visible to the test suite of shyft
+
+#compiler:
+#  - gcc
+#  - clang
+
+before_script:
+  - mkdir build
+  - cd build
+  - CC=gcc-4.9 CXX=g++-4.9 cmake ..
+
+script:
+  - make
+  - make test
+  - make install
+  - PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"
+  - nosetests .. ../test/python
+
+notifications:
+  email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,115 @@
+# CMake build system for SHyFT
+# ============================
+#
+# This requires SWIG and NumPy installed as well as a C++14 compliant compiler.
+#
+# Available options:
+#
+#   BUILD_TESTING: default ON
+#       build test programs and generates the "test" target
+#   BUILD_PYTHON_EXTENSIONS: default ON
+#       build Python extensions for SHYFT
+
+cmake_minimum_required(VERSION 2.8.7)
+project(shyft)
+
+# Get the full version for SHyFT
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/VERSION SHYFT_VERSION_STRING)
+
+message("Configuring for SHyFT version: " ${SHYFT_VERSION_STRING})
+
+# options
+option(BUILD_TESTING
+  "Build test programs for SHYFT C++ core library" ON)
+option(BUILD_PYTHON_EXTENSIONS
+  "Build Python extensions for SHYFT" ON)
+
+set(SHYFT_DEFAULT_BUILD_TYPE "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "No build type specified. Defaulting to '${SHYFT_DEFAULT_BUILD_TYPE}'.")
+    set(CMAKE_BUILD_TYPE ${SHYFT_DEFAULT_BUILD_TYPE} CACHE STRING
+        "Choose the type of build." FORCE)
+
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# The dependencies directory
+set(SHYFT_DEPENDENCIES "${PROJECT_SOURCE_DIR}/../dependencies")
+message("DEPENDENCIES:" ${SHYFT_DEPENDENCIES})
+# Create the dependencies directory
+file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
+
+# subdirectories
+# Python extensions
+if(BUILD_PYTHON_EXTENSIONS)
+  add_subdirectory(shyft/api)
+endif(BUILD_PYTHON_EXTENSIONS)
+
+# subdirectories
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(core)
+  add_subdirectory(test)
+endif(BUILD_TESTING)
+
+# The versions for dependencies
+set(DLIB_PREFIX "dlib")
+set(DLIB_VERSION "18.17")
+set(DLIB_TARBALL ${DLIB_PREFIX}-${DLIB_VERSION}.tar.bz2)
+set(DLIB_URL http://sourceforge.net/projects/dclib/files/dlib/v${DLIB_VERSION}/${DLIB_TARBALL}/download)
+
+set(ARMADILLO_PREFIX "armadillo")
+set(ARMADILLO_VERSION "6.100.0")
+set(ARMADILLO_TARBALL ${ARMADILLO_PREFIX}-${ARMADILLO_VERSION}.tar.gz)
+set(ARMADILLO_URL http://sourceforge.net/projects/arma/files/${ARMADILLO_TARBALL})
+
+set(BOOST_PREFIX "boost")
+set(BOOST_VERSION "1.59.0")
+string(REPLACE "." "_" BOOST__VERSION ${BOOST_VERSION})
+set(BOOST_TARBALL ${BOOST_PREFIX}_${BOOST_VERSION}.tar.gz)
+set(BOOST_URL http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/${BOOST_TARBALL}/download)
+
+set(CXXTEST_PREFIX "cxxtest")
+set(CXXTEST_VERSION "4.4")
+set(CXXTEST_TARBALL ${CXXTEST_PREFIX}-${CXXTEST_VERSION}.tar.gz)
+set(CXXTEST_URL http://sourceforge.net/projects/cxxtest/files/cxxtest/${CXXTEST_VERSION}/${CXXTEST_TARBALL}/download)
+
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include("${CMAKE_SOURCE_DIR}/cmake/DownloadAndExtractTarball.cmake")
+
+message(STATUS "Downloading dependencies.  This may take a while...")
+
+# dlib
+DownloadAndExtractTarball(
+  ${DLIB_PREFIX}
+  ${DLIB_VERSION}
+  ${DLIB_TARBALL}
+  ${DLIB_URL}
+  ${SHYFT_DEPENDENCIES})
+
+# armadillo
+DownloadAndExtractTarball(
+  ${ARMADILLO_PREFIX}
+  ${ARMADILLO_VERSION}
+  ${ARMADILLO_TARBALL}
+  ${ARMADILLO_URL}
+  ${SHYFT_DEPENDENCIES})
+
+# boost
+DownloadAndExtractTarball(
+  ${BOOST_PREFIX}
+  ${BOOST_VERSION}
+  ${BOOST_TARBALL}
+  ${BOOST_URL}
+  ${SHYFT_DEPENDENCIES})
+
+# cxxtest
+DownloadAndExtractTarball(
+  ${CXXTEST_PREFIX}
+  ${CXXTEST_VERSION}
+  ${CXXTEST_TARBALL}
+  ${CXXTEST_URL}
+  ${SHYFT_DEPENDENCIES})

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 README	
 ====================
+
+|Branch      |Status   |
+|------------|---------|
+|cmake       | [![Build Status](https://travis-ci.org/FrancescAlted/shft.svg?branch=master)](https://travis-ci.org/FrancescAlted/shyft) |
+
 SHyFT is an OpenSource hydrological toolbox developed by
 [Statkraft](http://www.statkraft.com).
 

--- a/cmake/DownloadAndExtractTarball.cmake
+++ b/cmake/DownloadAndExtractTarball.cmake
@@ -1,0 +1,104 @@
+# This is meant for SHyFT, although it would be worth to see if we can
+# use this:
+# https://github.com/neovim/neovim/blob/master/third-party/cmake/DownloadAndExtractFile.cmake
+
+function(DownloadAndExtractTarball PREFIX VERSION TARBALL URL DOWNLOAD_DIR)
+  file(MAKE_DIRECTORY ${DOWNLOAD_DIR})
+
+  set(file ${DOWNLOAD_DIR}/${TARBALL})
+
+  if(TIMEOUT)
+    set(timeout_args TIMEOUT ${timeout})
+    set(timeout_msg "${timeout} seconds")
+  else()
+    set(timeout_args "# no TIMEOUT")
+    set(timeout_msg "none")
+  endif()
+
+  # Download the tarball
+  if(NOT EXISTS "${file}")
+    message(STATUS "downloading...
+     src='${URL}'
+     dst='${file}'
+     timeout='${timeout_msg}'")
+    file(DOWNLOAD
+      ${URL}
+      ${file}
+      ${hash_args}
+      STATUS status
+      LOG log)
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
+    if(NOT status_code EQUAL 0)
+      message(FATAL_ERROR "error: downloading '${URL}' failed
+    status_code: ${status_code}
+    status_string: ${status_string}
+    log: ${log}
+    ")
+    else()
+      message(STATUS "${TARBALL} downloaded successfully [OK]")
+    endif()
+    set(NEW_DOWNLOAD TRUE)
+  else(NOT EXISTS "${file}")
+    message(STATUS "${TARBALL} already downloaded [OK]")
+    set(NEW_DOWNLOAD FALSE)
+  endif(NOT EXISTS "${file}")
+
+  set(SRC_DIR ${DOWNLOAD_DIR}/${PREFIX})
+
+  # If the source dir exists and is not a new download, skip the extraction
+  if(EXISTS "${SRC_DIR}" AND NOT NEW_DOWNLOAD)
+    RETURN()
+  endif()
+
+  # Proceed with the extraction
+  message(STATUS "downloading... done")
+  message(STATUS "extracting...
+     src='${TARBALL}'
+     dst='${SRC_DIR}'")
+
+  if(NOT EXISTS "${file}")
+    message(FATAL_ERROR "error: file to extract does not exist: '${file}'")
+  endif()
+
+  # Prepare a space for extracting
+  set(i 1234)
+  while(EXISTS "${DOWNLOAD_DIR}/ex-${PREFIX}${i}")
+    math(EXPR i "${i} + 1")
+  endwhile()
+  set(ut_dir "${DOWNLOAD_DIR}/ex-${PREFIX}${i}")
+  file(MAKE_DIRECTORY "${ut_dir}")
+
+  # Extract it
+  message(STATUS "extracting... [tar xfz]")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfz ${file}
+    WORKING_DIRECTORY ${ut_dir}
+    RESULT_VARIABLE rv)
+
+  if(NOT rv EQUAL 0)
+    message(STATUS "extracting... [error clean up]")
+    file(REMOVE_RECURSE "${ut_dir}")
+    message(FATAL_ERROR "error: extract of '${file}' failed")
+  endif()
+
+  # Analyze what came out of the tar file
+  message(STATUS "extracting... [analysis]")
+  file(GLOB contents "${ut_dir}/*")
+  list(LENGTH contents n)
+  if(NOT n EQUAL 1 OR NOT IS_DIRECTORY "${contents}")
+    set(contents "${ut_dir}")
+  endif()
+
+  # Move "the one" directory to the final directory
+  message(STATUS "extracting... [rename]")
+  file(REMOVE_RECURSE ${SRC_DIR})
+  get_filename_component(contents ${contents} ABSOLUTE)
+  file(RENAME ${contents} ${SRC_DIR})
+
+  # Clean up
+  message(STATUS "extracting... [clean up]")
+  file(REMOVE_RECURSE "${ut_dir}")
+
+  message(STATUS "extracting... done")
+
+endfunction()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,19 @@
+# CMake file for compiling the C++ core library
+
+# library sources
+FILE(GLOB headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+FILE(GLOB cpps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+list(REMOVE_ITEM cpps "core_pch.cpp")
+set(SOURCES ${headers} ${cpps})
+
+message(STATUS "Generating Makefile for the SHyFT static library...")
+
+set(CMAKE_CXX_FLAGS "-Wall -std=c++11 -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include" CACHE STRING "CXX flags." FORCE)
+add_definitions("-DARMA_DONT_USE_WRAPPER")
+
+add_library(shyftcore STATIC ${SOURCES})
+set_target_properties(shyftcore PROPERTIES OUTPUT_NAME shyftcore)
+if (MSVC)
+  set_target_properties(shyftcore PROPERTIES PREFIX lib)
+endif()
+target_link_libraries(shyftcore ${LIBS})

--- a/shyft/api/CMakeLists.txt
+++ b/shyft/api/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Create the SWIG wrappers
+#-----------------------------------------------------------------------------
+message(STATUS "Generating Python interface using SWIG...")
+
+if(WIN32 AND MSVC)
+  set(MAKE_COMMAND "nmake")
+  set(MAKE_FLAGS "/F")
+  set(MAKE_FILE "NMakefile.swig_run")
+else()
+  set(MAKE_COMMAND "make")
+  set(MAKE_FLAGS "-f")
+  set(MAKE_FILE "Makefile.swig_run")
+endif()
+
+execute_process(COMMAND ${MAKE_COMMAND} ${MAKE_FLAGS} ${MAKE_FILE}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/api/python
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE swig_output
+  ERROR_VARIABLE  swig_error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+if(NOT rv EQUAL 0)
+  message("SWIG make output:" ${swig_output})
+  message("SWIG make error:" ${swig_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+
+# Compilation step for Python extensions
+#-----------------------------------------------------------------------------
+# Python install
+find_package(PythonInterp REQUIRED)
+macro(GET_PYTHON_SITE_PACKAGE dir)
+ execute_process(
+   COMMAND ${PYTHON_EXECUTABLE} "-c" "from distutils import sysconfig; print sysconfig.get_python_lib()"
+   RESULT_VARIABLE rv
+   OUTPUT_VARIABLE import_output
+   ERROR_VARIABLE  import_error
+   OUTPUT_STRIP_TRAILING_WHITESPACE
+ )
+endmacro()
+
+GET_PYTHON_SITE_PACKAGE(python_site_package)
+if(import_output)
+  string(LENGTH ${import_output} len)
+  math(EXPR pathend "${len} - 14")  # remove "/site-packages" at the end
+  string(SUBSTRING ${import_output} 0 ${pathend} lib_python)
+  string(REPLACE "lib" "include" include_python ${lib_python})
+  #message("lib_python: " ${lib_python})
+  message("include_python: " ${include_python})
+endif()
+
+execute_process(
+ COMMAND ${PYTHON_EXECUTABLE} "-c" "import numpy as np; print np.get_include()"
+ RESULT_VARIABLE rv
+ OUTPUT_VARIABLE include_numpy
+ ERROR_VARIABLE  include_numpy_error
+ OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (rv)
+  message("numpy include:" ${include_numpy})
+  message("numpy import error:" ${include_numpy_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+message("include_numpy: " ${include_numpy}/numpy)
+
+# Include files in core directory
+include_directories(${PROJECT_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/dlib
+  ${CMAKE_SOURCE_DIR} ${include_python} ${SHYFT_DEPENDENCIES}/boost
+  ${SHYFT_DEPENDENCIES}/armadillo/include ${include_numpy})
+
+# Set the compiler flags (for gcc and clang)
+set(C_FLAGS -O3 -shared -L${lib_python} -pthread -s -fPIC -std=c++11 -DARMA_DONT_USE_WRAPPER)
+#set(CMAKE_CXX_FLAGS ${C_FLAGS} CACHE STRING "CXX flags." FORCE)
+
+# Set the common C++ files
+set(CXX_FILES ${CMAKE_SOURCE_DIR}/core/utctime_utilities.cpp ${CMAKE_SOURCE_DIR}/core/sceua_optimizer.cpp ${CMAKE_SOURCE_DIR}/core/dream_optimizer.cpp ${CMAKE_SOURCE_DIR}/api/api.cpp)
+
+# Create the API destination directory
+file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
+
+# Additional libraries
+set(LIBS "-lblas -llapack")
+
+# Compile extensions
+foreach(python_extension "__init__" "pt_gs_k" "pt_ss_k")
+  add_library(${python_extension} SHARED ${CXX_FILES} ${CMAKE_SOURCE_DIR}/api/python/${python_extension}_wrap.cxx)
+  set_target_properties(${python_extension} PROPERTIES OUTPUT_NAME ${python_extension})
+  # Python extensions do not use the 'lib' prefix
+  set_target_properties(${python_extension} PROPERTIES PREFIX "_")
+  set_property(TARGET ${python_extension} APPEND PROPERTY COMPILE_DEFINITIONS SHYFT_EXTENSION)
+  target_link_libraries(${python_extension} ${LIBS})
+  install(TARGETS ${python_extension} DESTINATION ${CMAKE_SOURCE_DIR}/shyft/api)
+
+endforeach(python_extension)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,46 @@
+# CMake configuration for tests
+# Sources
+file(GLOB cpps *.cpp)
+list(REMOVE_ITEM cpps "test_pch.cpp")
+file(GLOB headers *.h)
+set(sources ${cpps} ${headers})
+set(target "test_shyft")
+
+if(WIN32 AND MSVC)
+  set(MAKE_COMMAND "nmake")
+  set(MAKE_FLAGS "/F")
+  set(MAKE_FILE "NMakeFile.testupdate")
+else()
+  set(MAKE_COMMAND "make")
+  set(MAKE_FLAGS "-f")
+  set(MAKE_FILE "Makefile.testupdate")
+endif()
+
+# Generate the main.cpp file
+message(STATUS "Generating main test unit for C++ test suite...")
+execute_process(COMMAND ${MAKE_COMMAND} ${MAKE_FLAGS} ${MAKE_FILE}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE make_output
+  ERROR_VARIABLE  make_error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+if(NOT rv EQUAL 0)
+  message("test make output:" ${make_output})
+  message("test make error:" ${make_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+# Flags
+set(C_FLAGS -Wall -pthread -std=c++14 -fexceptions -Winvalid-pch)
+add_definitions("-DARMA_DONT_NO_DEBUG -DARMA_DONT_USE_WRAPPER -D__UNIT_TEST__ -DVERBOSE=0 -DCXXTEST_HAVE_EH -DCXXTEST_HAVE_STD")
+include_directories(${CMAKE_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/cxxtest ${SHYFT_DEPENDENCIES}/dlib)
+
+add_executable(${target} ${sources})
+# Additional libraries
+target_link_libraries(${target} shyftcore blas lapack boost_filesystem boost_system)
+
+# This can be made more specific, but we would need the list of tests.
+add_test(${target} ${target})


### PR DESCRIPTION
This is a new implementation of the CMake support.  This version is much more platform independent (Windows port should be easy now) and has better control on dependencies (i.e. if only a source file has been modified, then only the affected parts will be recompiled).  Only tested on Linux though.

The way to use the new cmake support is:

```
$ mkdir build      # do this inside the shyft root directory
$ cd build
$ ccmake ..        # config step via curses interface.  cmake-gui can be used too
$ cmake ..
$ make
$ make test        # this will execute the C++ tests
$ make install     # copy the python extensions in ../shyft/api
$ PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"
$ nosetests .. ../test/python
```

Again, the cmake configuration will be in charge of downloading dlib, armadillo, boost and cxxtest dependencies as needed.

Although this is still a work in progress, and open to suggestions, I find this PR much more flexible than previous PR #26 and #27, which this is overriding (so I will close them).