### PR TITLE
Support for CMake (ported to Python 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install liblapack-dev
+  - sudo apt-get --assume-yes install liblapack-dev
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 sudo: required
 dist: trusty
 
+env:
+  global:
+    - SHYFT_DEPENDENCIES_DIR=$HOME/shyft-dependencies
+
 install:
   - sudo apt-get update -qq
   - sudo apt-get --assume-yes install liblapack-dev
 
 cache:
   directories:
-    - $HOME/dependencies
+    - $SHYFT_DEPENDENCIES_DIR
 
 language:
   - python
@@ -21,7 +25,6 @@ python:
   - 3.4
 
 before_install:
-  # - echo "HOME is in: " $HOME  # this is giving a YAML error (?)
   - uname -a
   - free -m
   - df -h
@@ -58,7 +61,7 @@ before_script:
 
 script:
   - make -j 2 VERBOSE=1  # 2 paralel g++ process should take up to 3.5 GB RAM!
-  - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/../dependencies/local/lib
+  - export LD_LIBRARY_PATH=$SHYFT_DEPENDENCIES_DIR/local/lib
   - make test
   - make install
   - PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ addons:
     sources:
     - kalakris/cmake
     - ubuntu-toolchain-r-test
-    #- boost-latest
+    # - boost-latest
     packages:
     - cmake
     - g++-4.9
     - liblapack-dev
-    #- libboost1.55-all-dev
+    # - libboost1.55-all-dev
 
 cache:
   directories:
@@ -27,7 +27,7 @@ python:
   - 3.4
 
 before_install:
-  - echo "HOME is in: " $HOME
+  # - echo "HOME is in: " $HOME  # this is giving a YAML error (?)
   - uname -a
   - free -m
   - df -h

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - kalakris/cmake
+    - ubuntu-toolchain-r-test
+    packages:
+    - cmake
+    - g++-4.9
+    - liblapack-dev
+
+cache:
+  apt: true
+  directories:
+  - $HOME/dependencies
+
+
+language: python
+
+os:
+  - linux
+  # - osx
+
+python:
+  - 3.4
+
+before_install:
+  - uname -a
+  - free -m
+  - df -h
+  - ulimit -a
+  - ulimit -s 32768  # C++ compilers require a lot of memory
+
+  # Install conda
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+
+  # Install dependencies
+  - conda create -n shyft_env python=$TRAVIS_PYTHON_VERSION pyyaml numpy libgfortran netcdf4 gdal matplotlib requests nose coverage pip shapely pyproj swig
+  - source activate shyft_env
+  #- conda install -c https://conda.anaconda.org/minrk swig  # hits a bug in conda
+  #- conda install swig
+  - pip install descartes
+  - python -V
+
+  # The data repository dependency
+  - git clone --depth=50 --branch=master https://github.com/statkraft/shyft-data.git shyft-data
+  - ln -s `pwd`/shyft-data ../shyft-data  # make it visible to the test suite of shyft
+
+#compiler:
+#  - gcc
+#  - clang
+
+before_script:
+  - mkdir build
+  - cd build
+  - CC=gcc-4.9 CXX=g++-4.9 cmake ..
+
+script:
+  - make
+  - make test
+  - make install
+  - PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"
+  - nosetests ..
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ addons:
     sources:
     - kalakris/cmake
     - ubuntu-toolchain-r-test
+    - boost-latest
     packages:
     - cmake
     - g++-4.9
     - liblapack-dev
+    - boost1.55
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     - cmake
     - g++-4.9
     - liblapack-dev
-    - libboost-all-dev
+    - libboost1.55-all-dev
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
 
 script:
   - make -j 2 VERBOSE=1  # 2 paralel g++ process should take up to 3.5 GB RAM!
-  - export LD_LIBRARY_PATH=$HOME/dependencies/local/lib
+  - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/../dependencies/local/lib
   - make test
   - make install
   - PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_script:
 
 script:
   - make -j 2 VERBOSE=1  # 2 paralel g++ process should take up to 3.5 GB RAM!
-  - export LD_LIBRARY_PATH=../../dependencies/local/lib
+  - export LD_LIBRARY_PATH=$HOME/dependencies/local/lib
   - make test
   - make install
   - PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     - cmake
     - g++-4.9
     - liblapack-dev
-    - boost1.55
+    - libboost-all-dev
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
-sudo: false
+sudo: required
+dist: trusty
 
-addons:
-  apt:
-    sources:
-    - kalakris/cmake
-    - ubuntu-toolchain-r-test
-    # - boost-latest
-    packages:
-    - cmake
-    - g++-4.9
-    - liblapack-dev
-    # - libboost1.55-all-dev
+install: sudo apt-get install liblapack-dev
 
 cache:
   directories:
     - $HOME/dependencies
 
-
-language: python
+language:
+  - python
+  - cpp
 
 os:
   - linux
@@ -60,7 +52,7 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - CC=gcc-4.9 CXX=g++-4.9 cmake ..
+  - cmake ..
 
 script:
   - make -j 2 VERBOSE=1  # 2 paralel g++ process should take up to 3.5 GB RAM!

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,16 @@ addons:
     sources:
     - kalakris/cmake
     - ubuntu-toolchain-r-test
-    - boost-latest
+    #- boost-latest
     packages:
     - cmake
     - g++-4.9
     - liblapack-dev
-    - libboost1.55-all-dev
+    #- libboost1.55-all-dev
 
 cache:
-  apt: true
   directories:
-  - $HOME/dependencies
+    - $HOME/dependencies
 
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: required
 dist: trusty
 
-install: sudo apt-get install liblapack-dev
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install liblapack-dev
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_script:
   - cmake ..
 
 script:
-  - make -j 2 VERBOSE=1  # 2 paralel g++ process should take up to 3.5 GB RAM!
+  - make -j 3 VERBOSE=1  # 3 paralel compiler processes can take up to 5 GB RAM!
   - export LD_LIBRARY_PATH=$SHYFT_DEPENDENCIES_DIR/local/lib
   - make test
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ python:
   - 3.4
 
 before_install:
+  - echo "HOME is in: " $HOME
   - uname -a
   - free -m
   - df -h
@@ -62,7 +63,8 @@ before_script:
   - CC=gcc-4.9 CXX=g++-4.9 cmake ..
 
 script:
-  - make
+  - make -j 2 VERBOSE=1  # 2 paralel g++ process should take up to 3.5 GB RAM!
+  - export LD_LIBRARY_PATH=../../dependencies/local/lib
   - make test
   - make install
   - PYTHONPATH=.. python -c"import shyft; shyft.print_versions()"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,115 @@
+# CMake build system for SHyFT
+# ============================
+#
+# This requires SWIG and NumPy installed as well as a C++14 compliant compiler.
+#
+# Available options:
+#
+#   BUILD_TESTING: default ON
+#       build test programs and generates the "test" target
+#   BUILD_PYTHON_EXTENSIONS: default ON
+#       build Python extensions for SHYFT
+
+cmake_minimum_required(VERSION 2.8.7)
+project(shyft)
+
+# Get the full version for SHyFT
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/VERSION SHYFT_VERSION_STRING)
+
+message("Configuring for SHyFT version: " ${SHYFT_VERSION_STRING})
+
+# options
+option(BUILD_TESTING
+  "Build test programs for SHYFT C++ core library" ON)
+option(BUILD_PYTHON_EXTENSIONS
+  "Build Python extensions for SHYFT" ON)
+
+set(SHYFT_DEFAULT_BUILD_TYPE "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "No build type specified. Defaulting to '${SHYFT_DEFAULT_BUILD_TYPE}'.")
+    set(CMAKE_BUILD_TYPE ${SHYFT_DEFAULT_BUILD_TYPE} CACHE STRING
+        "Choose the type of build." FORCE)
+
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# The dependencies directory
+set(SHYFT_DEPENDENCIES "${PROJECT_SOURCE_DIR}/../dependencies")
+message("DEPENDENCIES:" ${SHYFT_DEPENDENCIES})
+# Create the dependencies directory
+file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
+
+# subdirectories
+# Python extensions
+if(BUILD_PYTHON_EXTENSIONS)
+  add_subdirectory(shyft/api)
+endif(BUILD_PYTHON_EXTENSIONS)
+
+# subdirectories
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(core)
+  add_subdirectory(test)
+endif(BUILD_TESTING)
+
+# The versions for dependencies
+set(DLIB_PREFIX "dlib")
+set(DLIB_VERSION "18.17")
+set(DLIB_TARBALL ${DLIB_PREFIX}-${DLIB_VERSION}.tar.bz2)
+set(DLIB_URL http://sourceforge.net/projects/dclib/files/dlib/v${DLIB_VERSION}/${DLIB_TARBALL}/download)
+
+set(ARMADILLO_PREFIX "armadillo")
+set(ARMADILLO_VERSION "6.100.0")
+set(ARMADILLO_TARBALL ${ARMADILLO_PREFIX}-${ARMADILLO_VERSION}.tar.gz)
+set(ARMADILLO_URL http://sourceforge.net/projects/arma/files/${ARMADILLO_TARBALL})
+
+set(BOOST_PREFIX "boost")
+set(BOOST_VERSION "1.59.0")
+string(REPLACE "." "_" BOOST__VERSION ${BOOST_VERSION})
+set(BOOST_TARBALL ${BOOST_PREFIX}_${BOOST_VERSION}.tar.gz)
+set(BOOST_URL http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/${BOOST_TARBALL}/download)
+
+set(CXXTEST_PREFIX "cxxtest")
+set(CXXTEST_VERSION "4.4")
+set(CXXTEST_TARBALL ${CXXTEST_PREFIX}-${CXXTEST_VERSION}.tar.gz)
+set(CXXTEST_URL http://sourceforge.net/projects/cxxtest/files/cxxtest/${CXXTEST_VERSION}/${CXXTEST_TARBALL}/download)
+
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include("${CMAKE_SOURCE_DIR}/cmake/DownloadAndExtractTarball.cmake")
+
+message(STATUS "Downloading dependencies.  This may take a while...")
+
+# dlib
+DownloadAndExtractTarball(
+  ${DLIB_PREFIX}
+  ${DLIB_VERSION}
+  ${DLIB_TARBALL}
+  ${DLIB_URL}
+  ${SHYFT_DEPENDENCIES})
+
+# armadillo
+DownloadAndExtractTarball(
+  ${ARMADILLO_PREFIX}
+  ${ARMADILLO_VERSION}
+  ${ARMADILLO_TARBALL}
+  ${ARMADILLO_URL}
+  ${SHYFT_DEPENDENCIES})
+
+# boost
+DownloadAndExtractTarball(
+  ${BOOST_PREFIX}
+  ${BOOST_VERSION}
+  ${BOOST_TARBALL}
+  ${BOOST_URL}
+  ${SHYFT_DEPENDENCIES})
+
+# cxxtest
+DownloadAndExtractTarball(
+  ${CXXTEST_PREFIX}
+  ${CXXTEST_VERSION}
+  ${CXXTEST_TARBALL}
+  ${CXXTEST_URL}
+  ${SHYFT_DEPENDENCIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,13 @@ message("DEPENDENCIES:" ${SHYFT_DEPENDENCIES})
 # Create the dependencies directory
 file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
 
+# The flags for compile the beast
+set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -L${SHYFT_DEPENDENCIES}/local/lib" CACHE STRING "CXX flags." FORCE)
+
+# The directories to be included
+include_directories(${CMAKE_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/cxxtest ${SHYFT_DEPENDENCIES}/dlib ${SHYFT_DEPENDENCIES}/armadillo/include ${SHYFT_DEPENDENCIES}/local/include)
+
+
 # The versions for dependencies
 set(DLIB_PREFIX "dlib")
 set(DLIB_VERSION "18.17")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake build system for SHyFT
 # ============================
 #
-# This requires SWIG and NumPy installed as well as a C++14 compliant compiler.
+# This requires SWIG and NumPy installed as well as a C++11 compliant compiler.
 #
 # Available options:
 #
@@ -9,6 +9,12 @@
 #       build test programs and generates the "test" target
 #   BUILD_PYTHON_EXTENSIONS: default ON
 #       build Python extensions for SHYFT
+#
+# The next environment variables are honored:
+#
+#   SHYFT_DEPENDENCIES_DIR: default ${PROJECT_SOURCE_DIR}/../shyft-dependencies
+#
+
 
 cmake_minimum_required(VERSION 2.8.7)
 project(shyft)
@@ -36,8 +42,15 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # The dependencies directory
-set(SHYFT_DEPENDENCIES "${PROJECT_SOURCE_DIR}/../dependencies")
-message("DEPENDENCIES:" ${SHYFT_DEPENDENCIES})
+if(DEFINED ENV{SHYFT_DEPENDENCIES_DIR})
+  set(SHYFT_DEPENDENCIES_DIR $ENV{SHYFT_DEPENDENCIES_DIR})
+else()
+  set(SHYFT_DEPENDENCIES_DIR "${PROJECT_SOURCE_DIR}/../shyft-dependencies")
+endif()
+# Our code requires an absolute directory for the dependencies
+get_filename_component(SHYFT_DEPENDENCIES ${SHYFT_DEPENDENCIES_DIR} ABSOLUTE)
+message("SHYFT_DEPENDENCIES directory: " ${SHYFT_DEPENDENCIES})
+message("You can override the above via the $SHYFT_DEPENDENCIES environment variable.")
 # Create the dependencies directory
 file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,19 +41,6 @@ message("DEPENDENCIES:" ${SHYFT_DEPENDENCIES})
 # Create the dependencies directory
 file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
 
-# subdirectories
-# Python extensions
-if(BUILD_PYTHON_EXTENSIONS)
-  add_subdirectory(shyft/api)
-endif(BUILD_PYTHON_EXTENSIONS)
-
-# subdirectories
-if(BUILD_TESTING)
-  enable_testing()
-  add_subdirectory(core)
-  add_subdirectory(test)
-endif(BUILD_TESTING)
-
 # The versions for dependencies
 set(DLIB_PREFIX "dlib")
 set(DLIB_VERSION "18.17")
@@ -68,7 +55,7 @@ set(ARMADILLO_URL http://sourceforge.net/projects/arma/files/${ARMADILLO_TARBALL
 set(BOOST_PREFIX "boost")
 set(BOOST_VERSION "1.59.0")
 string(REPLACE "." "_" BOOST__VERSION ${BOOST_VERSION})
-set(BOOST_TARBALL ${BOOST_PREFIX}_${BOOST_VERSION}.tar.gz)
+set(BOOST_TARBALL ${BOOST_PREFIX}_${BOOST__VERSION}.tar.gz)
 set(BOOST_URL http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/${BOOST_TARBALL}/download)
 
 set(CXXTEST_PREFIX "cxxtest")
@@ -113,3 +100,18 @@ DownloadAndExtractTarball(
   ${CXXTEST_TARBALL}
   ${CXXTEST_URL}
   ${SHYFT_DEPENDENCIES})
+
+
+# Once we have the dependencies solved, let's go with cmake subdirectories
+
+# C++ core and tests
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(core)
+  add_subdirectory(test)
+endif(BUILD_TESTING)
+
+# Python extensions
+if(BUILD_PYTHON_EXTENSIONS)
+  add_subdirectory(shyft/api)
+endif(BUILD_PYTHON_EXTENSIONS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 # The next environment variables are honored:
 #
-#   SHYFT_DEPENDENCIES_DIR: default ${PROJECT_SOURCE_DIR}/../shyft-dependencies
+#   SHYFT_DEPENDENCIES_DIR: default ${PROJECT_SOURCE_DIR}/shyft-dependencies
 #
 
 
@@ -45,7 +45,7 @@ endif()
 if(DEFINED ENV{SHYFT_DEPENDENCIES_DIR})
   set(SHYFT_DEPENDENCIES_DIR $ENV{SHYFT_DEPENDENCIES_DIR})
 else()
-  set(SHYFT_DEPENDENCIES_DIR "${PROJECT_SOURCE_DIR}/../shyft-dependencies")
+  set(SHYFT_DEPENDENCIES_DIR "${PROJECT_SOURCE_DIR}/shyft-dependencies")
 endif()
 # Our code requires an absolute directory for the dependencies
 get_filename_component(SHYFT_DEPENDENCIES ${SHYFT_DEPENDENCIES_DIR} ABSOLUTE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 README	
 ====================
+
+|Branch      |Status   |
+|------------|---------|
+|cmake       | [![Build Status](https://travis-ci.org/FrancescAlted/shft.svg?branch=master)](https://travis-ci.org/FrancescAlted/shyft) |
+
 SHyFT is an OpenSource hydrological toolbox developed by
 [Statkraft](http://www.statkraft.com).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-README	
-====================
+README
+======
 
 |Branch      |Status   |
 |------------|---------|
@@ -19,36 +19,75 @@ developed at Sintef by Sjur Kolberg with contributions from Kolbjorn Engeland
 and Oddbjorn Bruland.
 
 COMPILING
-=====================
-You can compile SHyFT by using the typical procedure for Python packages::
+=========
+
+You can compile SHyFT by using the typical procedure for Python packages:
+
 ```bash
 $ python setup.py build_ext --inplace
 ```
 from the root directory.
 
+COMPILING VIA CMAKE
+=====================
+
+You can also compile SHyFT with CMake building tool which is available
+for the most of the platforms out there.  The steps are the usual ones:
+
+```bash
+$ export SHYFT_SOURCES=shyft_sources_directory  # absolute path!
+$ cd $SHYFT_SOURCES
+$ mkdir build
+$ export SHYFT_DEPENDENCIES_DIR=directory_to_keep_dependencies  # absolute path
+$ cmake ..      # configuration step; or just "ccmake .." for curses interface
+$ make -j 4     # do the actual compilation of C++ sources (using 4 processes)
+$ make install  # copy Python extensions somewhere in $SHYFT_SOURCES
+```
+
+We have the beast compiled by now.  For testing:
+
+```bash
+$ export LD_LIBRARY_PATH=$SHYFT_DEPENDENCIES_DIR/local/lib
+$ make test     # run the C++ tests
+$ export PYTHONPATH=$SHYFT_SOURCES
+$ nosetests ..  # run the Python tests
+```
+
+If all the tests pass, then you have an instance of SHyFT that is
+fully functional.  In case this directory is going to act as a
+long-term installation it is recommended to persist your
+$LD_LIBRARY_PATH and $PYTHONPATH environment variables (in ~/.bashrc
+or similar).
+
+
 TESTING
 ====================
+
 The way to test SHyFT is by running::
 
 ```bash
 $ nosetests
 ```
-from the root directory (your will need the numpy and pytest packages).
+from the root directory (your will need the numpy and nosetest packages).
 
 The test suite is not very comprehensive yet, but at least would provide
 indications that your installation is sane.
 
 INSTALLING
 ====================
+
 Once you tested you SHyFT package you can install it in your system via::
 
 ```bash
 $ python setup.py install
 ```
+
 AUTHORS
 ====================
-SHyFT is developed by Statkraft, and the two main initial authors to the C++ core were
-Sigbjørn Helset <Sigbjorn.Helset@statkraft.com> and Ola Skavhaug <ola@xal.no>. 
+
+SHyFT is developed by Statkraft, and the two main initial authors to
+the C++ core were Sigbjørn Helset <Sigbjorn.Helset@statkraft.com> and
+Ola Skavhaug <ola@xal.no>.
 
 Orchestration and the Python wrappers were originally developed by
 John F. Burkhart <john.burkhart@statkraft.com>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ from the root directory.
 TESTING
 ====================
 The way to test SHyFT is by running::
+
 ```bash
 $ nosetests
 ```
@@ -40,6 +41,7 @@ indications that your installation is sane.
 INSTALLING
 ====================
 Once you tested you SHyFT package you can install it in your system via::
+
 ```bash
 $ python setup.py install
 ```

--- a/cmake/DownloadAndExtractTarball.cmake
+++ b/cmake/DownloadAndExtractTarball.cmake
@@ -1,0 +1,104 @@
+# This is meant for SHyFT, although it would be worth to see if we can
+# use this:
+# https://github.com/neovim/neovim/blob/master/third-party/cmake/DownloadAndExtractFile.cmake
+
+function(DownloadAndExtractTarball PREFIX VERSION TARBALL URL DOWNLOAD_DIR)
+  file(MAKE_DIRECTORY ${DOWNLOAD_DIR})
+
+  set(file ${DOWNLOAD_DIR}/${TARBALL})
+
+  if(TIMEOUT)
+    set(timeout_args TIMEOUT ${timeout})
+    set(timeout_msg "${timeout} seconds")
+  else()
+    set(timeout_args "# no TIMEOUT")
+    set(timeout_msg "none")
+  endif()
+
+  # Download the tarball
+  if(NOT EXISTS "${file}")
+    message(STATUS "downloading...
+     src='${URL}'
+     dst='${file}'
+     timeout='${timeout_msg}'")
+    file(DOWNLOAD
+      ${URL}
+      ${file}
+      ${hash_args}
+      STATUS status
+      LOG log)
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
+    if(NOT status_code EQUAL 0)
+      message(FATAL_ERROR "error: downloading '${URL}' failed
+    status_code: ${status_code}
+    status_string: ${status_string}
+    log: ${log}
+    ")
+    else()
+      message(STATUS "${TARBALL} downloaded successfully [OK]")
+    endif()
+    set(NEW_DOWNLOAD TRUE)
+  else(NOT EXISTS "${file}")
+    message(STATUS "${TARBALL} already downloaded [OK]")
+    set(NEW_DOWNLOAD FALSE)
+  endif(NOT EXISTS "${file}")
+
+  set(SRC_DIR ${DOWNLOAD_DIR}/${PREFIX})
+
+  # If the source dir exists and is not a new download, skip the extraction
+  if(EXISTS "${SRC_DIR}" AND NOT NEW_DOWNLOAD)
+    RETURN()
+  endif()
+
+  # Proceed with the extraction
+  message(STATUS "downloading... done")
+  message(STATUS "extracting...
+     src='${TARBALL}'
+     dst='${SRC_DIR}'")
+
+  if(NOT EXISTS "${file}")
+    message(FATAL_ERROR "error: file to extract does not exist: '${file}'")
+  endif()
+
+  # Prepare a space for extracting
+  set(i 1234)
+  while(EXISTS "${DOWNLOAD_DIR}/ex-${PREFIX}${i}")
+    math(EXPR i "${i} + 1")
+  endwhile()
+  set(ut_dir "${DOWNLOAD_DIR}/ex-${PREFIX}${i}")
+  file(MAKE_DIRECTORY "${ut_dir}")
+
+  # Extract it
+  message(STATUS "extracting... [tar xfz]")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfz ${file}
+    WORKING_DIRECTORY ${ut_dir}
+    RESULT_VARIABLE rv)
+
+  if(NOT rv EQUAL 0)
+    message(STATUS "extracting... [error clean up]")
+    file(REMOVE_RECURSE "${ut_dir}")
+    message(FATAL_ERROR "error: extract of '${file}' failed")
+  endif()
+
+  # Analyze what came out of the tar file
+  message(STATUS "extracting... [analysis]")
+  file(GLOB contents "${ut_dir}/*")
+  list(LENGTH contents n)
+  if(NOT n EQUAL 1 OR NOT IS_DIRECTORY "${contents}")
+    set(contents "${ut_dir}")
+  endif()
+
+  # Move "the one" directory to the final directory
+  message(STATUS "extracting... [rename]")
+  file(REMOVE_RECURSE ${SRC_DIR})
+  get_filename_component(contents ${contents} ABSOLUTE)
+  file(RENAME ${contents} ${SRC_DIR})
+
+  # Clean up
+  message(STATUS "extracting... [clean up]")
+  file(REMOVE_RECURSE "${ut_dir}")
+
+  message(STATUS "extracting... done")
+
+endfunction()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,19 @@
+# CMake file for compiling the C++ core library
+
+# library sources
+FILE(GLOB headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+FILE(GLOB cpps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+list(REMOVE_ITEM cpps "core_pch.cpp")
+set(SOURCES ${headers} ${cpps})
+
+message(STATUS "Generating Makefile for the SHyFT static library...")
+
+set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include" CACHE STRING "CXX flags." FORCE)
+add_definitions("-DARMA_DONT_USE_WRAPPER")
+
+add_library(shyftcore STATIC ${SOURCES})
+set_target_properties(shyftcore PROPERTIES OUTPUT_NAME shyftcore)
+if (MSVC)
+  set_target_properties(shyftcore PROPERTIES PREFIX lib)
+endif()
+target_link_libraries(shyftcore ${LIBS})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,9 +6,39 @@ FILE(GLOB cpps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}
 list(REMOVE_ITEM cpps "core_pch.cpp")
 set(SOURCES ${headers} ${cpps})
 
+message(STATUS "Compiling boost library (only selected components)...")
+execute_process(COMMAND ./bootstrap.sh --prefix=${SHYFT_DEPENDENCIES}/local --with-libraries=filesystem,system
+  WORKING_DIRECTORY ${SHYFT_DEPENDENCIES}/boost
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE output
+  ERROR_VARIABLE  error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+if(NOT rv EQUAL 0)
+  message("boost bootstrap output:" ${output})
+  message("boost bootstart error:" ${error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+execute_process(COMMAND ./b2 install
+  WORKING_DIRECTORY ${SHYFT_DEPENDENCIES}/boost
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE output
+  ERROR_VARIABLE  error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+if(NOT rv EQUAL 0)
+  message("boost b2 output:" ${output})
+  message("boost b2 error:" ${error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+
 message(STATUS "Generating Makefile for the SHyFT static library...")
 
-set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include -I${SHYFT_DEPENDENCIES}/boost" CACHE STRING "CXX flags." FORCE)
+set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include -I${SHYFT_DEPENDENCIES}/local -L${SHYFT_DEPENDENCIES}/local/lib" CACHE STRING "CXX flags." FORCE)
 add_definitions("-DARMA_DONT_USE_WRAPPER")
 
 add_library(shyftcore STATIC ${SOURCES})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,7 +8,7 @@ set(SOURCES ${headers} ${cpps})
 
 message(STATUS "Generating Makefile for the SHyFT static library...")
 
-set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include" CACHE STRING "CXX flags." FORCE)
+set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include -I${SHYFT_DEPENDENCIES}/boost" CACHE STRING "CXX flags." FORCE)
 add_definitions("-DARMA_DONT_USE_WRAPPER")
 
 add_library(shyftcore STATIC ${SOURCES})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,7 +38,6 @@ endif()
 
 message(STATUS "Generating Makefile for the SHyFT static library...")
 
-set(CMAKE_CXX_FLAGS "-Wall -std=c++1y -fexceptions -pthread -Winvalid-pch -I${SHYFT_DEPENDENCIES}/armadillo/include -I${SHYFT_DEPENDENCIES}/local -L${SHYFT_DEPENDENCIES}/local/lib" CACHE STRING "CXX flags." FORCE)
 add_definitions("-DARMA_DONT_USE_WRAPPER")
 
 add_library(shyftcore STATIC ${SOURCES})

--- a/shyft/api/CMakeLists.txt
+++ b/shyft/api/CMakeLists.txt
@@ -1,0 +1,116 @@
+# Create the SWIG wrappers
+#-----------------------------------------------------------------------------
+message(STATUS "Generating Python interface using SWIG...")
+
+if(WIN32 AND MSVC)
+  set(MAKE_COMMAND "nmake")
+  set(MAKE_FLAGS "/F")
+  set(MAKE_FILE "NMakefile.swig_run")
+else()
+  set(MAKE_COMMAND "make")
+  set(MAKE_FLAGS -j 2 -f)  # use 2 processes to not overload TravisCI too much
+  set(MAKE_FILE "Makefile.swig_run")
+endif()
+
+execute_process(COMMAND ${MAKE_COMMAND} ${MAKE_FLAGS} ${MAKE_FILE}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/api/python
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE swig_output
+  ERROR_VARIABLE  swig_error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+if(NOT rv EQUAL 0)
+  message("SWIG make output:" ${swig_output})
+  message("SWIG make error:" ${swig_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+
+# Compilation step for Python extensions
+#-----------------------------------------------------------------------------
+# Python install
+find_package(PythonInterp REQUIRED)
+
+execute_process(
+  COMMAND ${PYTHON_EXECUTABLE} "-c" "from distutils import sysconfig; print(sysconfig.get_python_lib())"
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE lib_python_output
+  ERROR_VARIABLE  lib_python_error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(rv)
+  message("Python lib output:" ${lib_python_output})
+  message("Python lib error:" ${lib_python_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+else()
+  string(LENGTH ${lib_python_output} len)
+  math(EXPR pathend "${len} - 14")  # remove "/site-packages" at the end
+  string(SUBSTRING ${lib_python_output} 0 ${pathend} lib_python)
+endif()
+message("lib_python: " ${lib_python})
+
+execute_process(
+  COMMAND ${PYTHON_EXECUTABLE} "-c" "from distutils import sysconfig; print(sysconfig.get_python_inc())"
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE include_python
+  ERROR_VARIABLE  include_python_error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+if (rv)
+  message("Python include:" ${include_python})
+  message("Python import error:" ${include_python_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+message("include_python: " ${include_python})
+
+execute_process(
+ COMMAND ${PYTHON_EXECUTABLE} "-c" "import numpy as np; print(np.get_include())"
+ RESULT_VARIABLE rv
+ OUTPUT_VARIABLE include_numpy
+ ERROR_VARIABLE  include_numpy_error
+ OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (rv)
+  message("NumPy include:" ${include_numpy})
+  message("NumPy import error:" ${include_numpy_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+message("include_numpy: " ${include_numpy})
+
+# Include files in core directory
+include_directories(${PROJECT_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/dlib
+  ${CMAKE_SOURCE_DIR} ${include_python} ${SHYFT_DEPENDENCIES}/boost
+  ${SHYFT_DEPENDENCIES}/armadillo/include ${include_numpy})
+
+# Set the compiler flags (for gcc and clang)
+set(C_FLAGS -O3 -shared -L${lib_python} -pthread -s -fPIC -std=c++11 -DARMA_DONT_USE_WRAPPER)
+#set(CMAKE_CXX_FLAGS ${C_FLAGS} CACHE STRING "CXX flags." FORCE)
+
+# Set the common C++ files
+set(CXX_FILES ${CMAKE_SOURCE_DIR}/core/utctime_utilities.cpp ${CMAKE_SOURCE_DIR}/core/sceua_optimizer.cpp ${CMAKE_SOURCE_DIR}/core/dream_optimizer.cpp ${CMAKE_SOURCE_DIR}/api/api.cpp)
+
+# Create the API destination directory
+file(MAKE_DIRECTORY ${SHYFT_DEPENDENCIES}/api)
+
+# Additional libraries
+set(LIBS "-lblas -llapack")
+
+# Compile extensions
+foreach(python_extension "__init__" "pt_gs_k" "pt_ss_k")
+  add_library(${python_extension} SHARED ${CXX_FILES} ${CMAKE_SOURCE_DIR}/api/python/${python_extension}_wrap.cxx)
+  set_target_properties(${python_extension} PROPERTIES OUTPUT_NAME ${python_extension})
+  # Python extensions do not use the 'lib' prefix
+  set_target_properties(${python_extension} PROPERTIES PREFIX "_")
+  set_property(TARGET ${python_extension} APPEND PROPERTY COMPILE_DEFINITIONS SHYFT_EXTENSION)
+  target_link_libraries(${python_extension} ${LIBS})
+  install(TARGETS ${python_extension} DESTINATION ${CMAKE_SOURCE_DIR}/shyft/api)
+
+endforeach(python_extension)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,9 +35,7 @@ if(NOT rv EQUAL 0)
 endif()
 
 # Flags
-#set(C_FLAGS -Wall -pthread -std=c++1y -fexceptions -Winvalid-pch)
 add_definitions("-DARMA_DONT_NO_DEBUG -DARMA_DONT_USE_WRAPPER -D__UNIT_TEST__ -DVERBOSE=0 -DCXXTEST_HAVE_EH -DCXXTEST_HAVE_STD")
-include_directories(${CMAKE_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/cxxtest ${SHYFT_DEPENDENCIES}/dlib)
 
 add_executable(${target} ${sources})
 # Additional libraries

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT rv EQUAL 0)
 endif()
 
 # Flags
-set(C_FLAGS -Wall -pthread -std=c++14 -fexceptions -Winvalid-pch)
+#set(C_FLAGS -Wall -pthread -std=c++1y -fexceptions -Winvalid-pch)
 add_definitions("-DARMA_DONT_NO_DEBUG -DARMA_DONT_USE_WRAPPER -D__UNIT_TEST__ -DVERBOSE=0 -DCXXTEST_HAVE_EH -DCXXTEST_HAVE_STD")
 include_directories(${CMAKE_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/cxxtest ${SHYFT_DEPENDENCIES}/dlib)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,46 @@
+# CMake configuration for tests
+# Sources
+file(GLOB cpps *.cpp)
+list(REMOVE_ITEM cpps "test_pch.cpp")
+file(GLOB headers *.h)
+set(sources ${cpps} ${headers})
+set(target "test_shyft")
+
+if(WIN32 AND MSVC)
+  set(MAKE_COMMAND "nmake")
+  set(MAKE_FLAGS "/F")
+  set(MAKE_FILE "NMakeFile.testupdate")
+else()
+  set(MAKE_COMMAND "make")
+  set(MAKE_FLAGS -j 4 -f)
+  set(MAKE_FILE "Makefile.testupdate")
+endif()
+
+# Generate the main.cpp file
+message(STATUS "Generating main test unit for C++ test suite...")
+execute_process(COMMAND ${MAKE_COMMAND} ${MAKE_FLAGS} ${MAKE_FILE}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+  RESULT_VARIABLE rv
+  OUTPUT_VARIABLE make_output
+  ERROR_VARIABLE  make_error
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+if(NOT rv EQUAL 0)
+  message("test make output:" ${make_output})
+  message("test make error:" ${make_error})
+  message(FATAL_ERROR "Errors occurred.  Leaving now!")
+  return()
+endif()
+
+# Flags
+set(C_FLAGS -Wall -pthread -std=c++14 -fexceptions -Winvalid-pch)
+add_definitions("-DARMA_DONT_NO_DEBUG -DARMA_DONT_USE_WRAPPER -D__UNIT_TEST__ -DVERBOSE=0 -DCXXTEST_HAVE_EH -DCXXTEST_HAVE_STD")
+include_directories(${CMAKE_SOURCE_DIR} ${SHYFT_DEPENDENCIES}/cxxtest ${SHYFT_DEPENDENCIES}/dlib)
+
+add_executable(${target} ${sources})
+# Additional libraries
+target_link_libraries(${target} shyftcore blas lapack boost_filesystem boost_system)
+
+# This can be made more specific, but we would need the list of tests.
+add_test(${target} ${target})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,4 @@
 # CMake configuration for tests
-# Sources
-file(GLOB cpps *.cpp)
-list(REMOVE_ITEM cpps "test_pch.cpp")
-file(GLOB headers *.h)
-set(sources ${cpps} ${headers})
-set(target "test_shyft")
 
 if(WIN32 AND MSVC)
   set(MAKE_COMMAND "nmake")
@@ -12,7 +6,7 @@ if(WIN32 AND MSVC)
   set(MAKE_FILE "NMakeFile.testupdate")
 else()
   set(MAKE_COMMAND "make")
-  set(MAKE_FLAGS -j 4 -f)
+  set(MAKE_FLAGS -f)
   set(MAKE_FILE "Makefile.testupdate")
 endif()
 
@@ -33,6 +27,13 @@ if(NOT rv EQUAL 0)
   message(FATAL_ERROR "Errors occurred.  Leaving now!")
   return()
 endif()
+
+# Sources
+file(GLOB cpps *.cpp)
+list(REMOVE_ITEM cpps "test_pch.cpp")
+file(GLOB headers *.h)
+set(sources ${cpps} ${headers})
+set(target "test_shyft")
 
 # Flags
 add_definitions("-DARMA_DONT_NO_DEBUG -DARMA_DONT_USE_WRAPPER -D__UNIT_TEST__ -DVERBOSE=0 -DCXXTEST_HAVE_EH -DCXXTEST_HAVE_STD")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 
 # Generate the main.cpp file
 message(STATUS "Generating main test unit for C++ test suite...")
-execute_process(COMMAND ${MAKE_COMMAND} ${MAKE_FLAGS} ${MAKE_FILE}
+set(CXXTESTGEN "TestGenerator=${SHYFT_DEPENDENCIES}/cxxtest/bin/cxxtestgen")
+execute_process(COMMAND ${MAKE_COMMAND} ${MAKE_FLAGS} ${MAKE_FILE} ${CXXTESTGEN}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
   RESULT_VARIABLE rv
   OUTPUT_VARIABLE make_output


### PR DESCRIPTION
Here it is another PR for CMake support.  This time the support has been ported to Python 3 (no support for Python2 is here).  Although cmake seems to work just fine in my local box, I am still having problems with TravisCI of this style:

```
kirchner_test.cpp:(.text+0x1d4f): undefined reference to `CxxTest::TestTracker::tracker()'

kirchner_test.cpp:(.text+0x1d9b): undefined reference to `CxxTest::TestTracker::tracker()'

kirchner_test.cpp:(.text+0x1de7): undefined reference to `CxxTest::TestTracker::tracker()'

kirchner_test.cpp:(.text+0x1e28): undefined reference to `CxxTest::TestTracker::tracker()'

CMakeFiles/test_shyft.dir/kirchner_test.cpp.o: In function `kirchner_test::test_solve_from_zero_q()':

kirchner_test.cpp:(.text+0x2126): undefined reference to `CxxTest::TestTracker::tracker()'

CMakeFiles/test_shyft.dir/kirchner_test.cpp.o:kirchner_test.cpp:(.text+0x2173): more undefined references to `CxxTest::TestTracker::tracker()' follow
```

Tomorrow I am going to continue with that, but if someone is seeing this I would appreciate any feedback.  The full Travis log is here:

https://travis-ci.org/FrancescAlted/shyft/jobs/85554087