### PR TITLE
Netcdftime

### DIFF
--- a/shyft/repository/netcdf/arome_data_repository.py
+++ b/shyft/repository/netcdf/arome_data_repository.py
@@ -12,7 +12,7 @@ from pyproj import Proj
 from pyproj import transform
 from shyft import api
 from .. import interfaces
-
+from .time_conversion import convert_netcdf_time
 
 class AromeDataRepositoryError(Exception):
     pass
@@ -347,6 +347,7 @@ class AromeDataRepository(interfaces.GeoTsRepository):
         if not all([x, y, time]):
             raise AromeDataRepositoryError("Something is wrong with the dataset."
                                            " x/y coords or time not found.")
+        time = convert_netcdf_time(time.units,time)
         data_cs = dataset.variables.get("projection_lambert", None)
         if data_cs is None:
             raise AromeDataRepositoryError("No coordinate system information in dataset.")

--- a/shyft/repository/netcdf/time_conversion.py
+++ b/shyft/repository/netcdf/time_conversion.py
@@ -1,0 +1,17 @@
+from shyft import api
+
+from netcdftime import utime
+import numpy as np
+
+
+def convert_netcdf_time(time_spec, t):
+    """
+    :param time_spec: from netcdef  like 'hours since 1970-01-01 00:00:00'
+    :param t: numpy array
+    :return: numpy array with new units
+    """
+    u = utime(time_spec)
+    t_origin = api.Calendar(int(u.tzoffset)).time(api.YMDhms(u.origin.year,u.origin.month,u.origin.day,u.origin.hour,u.origin.minute,u.origin.second))
+    delta_t_dic = {'days':api.deltahours(24),'hours':api.deltahours(1),'minutes':api.deltaminutes(1),'seconds':api.Calendar.SECOND}
+    delta_t = delta_t_dic[u.units]
+    return (t_origin + delta_t*t[:]).astype(np.int64)

--- a/shyft/repository/netcdf/time_conversion.py
+++ b/shyft/repository/netcdf/time_conversion.py
@@ -1,17 +1,30 @@
 from shyft import api
-
 from netcdftime import utime
 import numpy as np
+
+""" These are the current supported regular time-step intervals """
+delta_t_dic = {'days': api.deltahours(24), 'hours': api.deltahours(1), 'minutes': api.deltaminutes(1),
+               'seconds': api.Calendar.SECOND}
 
 
 def convert_netcdf_time(time_spec, t):
     """
-    :param time_spec: from netcdef  like 'hours since 1970-01-01 00:00:00'
-    :param t: numpy array
-    :return: numpy array with new units
+    Converts supplied numpy array to  shyft utctime given netcdf time_spec.
+    Throws exception if time-unit is not supported, i.e. not part of delta_t_dic
+    as specified in this file.
+
+    Parameters
+    ----------
+        time_spec: string
+           from netcdef  like 'hours since 1970-01-01 00:00:00'
+        t: numpy array
+    Returns
+    -------
+        numpy array type int64 with new shyft utctime units (seconds since 1970utc)
     """
     u = utime(time_spec)
-    t_origin = api.Calendar(int(u.tzoffset)).time(api.YMDhms(u.origin.year,u.origin.month,u.origin.day,u.origin.hour,u.origin.minute,u.origin.second))
-    delta_t_dic = {'days':api.deltahours(24),'hours':api.deltahours(1),'minutes':api.deltaminutes(1),'seconds':api.Calendar.SECOND}
+    t_origin = api.Calendar(int(u.tzoffset)).time(
+        api.YMDhms(u.origin.year, u.origin.month, u.origin.day, u.origin.hour, u.origin.minute, u.origin.second))
+
     delta_t = delta_t_dic[u.units]
-    return (t_origin + delta_t*t[:]).astype(np.int64)
+    return (t_origin + delta_t * t[:]).astype(np.int64)

--- a/shyft/tests/api/test_calendar_and_time.py
+++ b/shyft/tests/api/test_calendar_and_time.py
@@ -9,6 +9,7 @@ class Calendar(unittest.TestCase):
     plan to do so) Nevertheless, keeping it here allow users of api-Core to
     use start practicing utctime/calendar perimeter.
     """
+
     def setUp(self):
         self.utc = api.Calendar()  # A utc calendar
         self.std = api.Calendar(3600)  # UTC+01
@@ -30,7 +31,6 @@ class Calendar(unittest.TestCase):
         self.assertEqual(a.day, c.day, 'should leave same day')
 
     def test_conversion_roundtrip(self):
-        #c1 = api.YMDhms(2000, 1, 2, 3, 4, 5)
         c1 = api.YMDhms(1960, 1, 2, 3, 4, 5)
         t1 = self.std.time(c1)
         c2 = self.std.calendar_units(t1)
@@ -44,7 +44,7 @@ class Calendar(unittest.TestCase):
         a = api.utctime_now()
         x = dt.datetime.utcnow()
         b = self.utc.time(api.YMDhms(x.year, x.month, x.day,
-                          x.hour, x.minute, x.second))
+                                     x.hour, x.minute, x.second))
         self.assertLess(abs(a - b), 2, 'Should be less than 2 seconds')
 
     def test_utc_time_to_string(self):
@@ -70,10 +70,18 @@ class Calendar(unittest.TestCase):
         self.assertEqual(s, "[2000.01.02T03:04:05,2000.01.02T04:04:05>")
 
     def test_swig_python_time(self):
+        """
+        This particular test is here to point out a platform specific bug detected
+        on windows.
+
+        """
         c1 = api.YMDhms(1969, 12, 31, 23, 0, 0)
-        t = self.utc.time(c1)
-        t_str= self.utc.to_string(t)
-        self.assertEquals(t,api.deltahours(-1))
+        t = self.utc.time(c1)  # at this point, the value returned from c++ is correct, but on its
+        # way through swig layer to python it goes via int32 and then to int64, proper signhandling
+        #
+        t_str = self.utc.to_string(t)  # this one just to show it's still working as it should internally
+        self.assertEquals(t_str, "1969.12.31T23:00:00")
+        self.assertEquals(t, api.deltahours(-1))
 
 
 if __name__ == "__main__":

--- a/shyft/tests/api/test_calendar_and_time.py
+++ b/shyft/tests/api/test_calendar_and_time.py
@@ -30,7 +30,8 @@ class Calendar(unittest.TestCase):
         self.assertEqual(a.day, c.day, 'should leave same day')
 
     def test_conversion_roundtrip(self):
-        c1 = api.YMDhms(2000, 1, 2, 3, 4, 5)
+        #c1 = api.YMDhms(2000, 1, 2, 3, 4, 5)
+        c1 = api.YMDhms(1960, 1, 2, 3, 4, 5)
         t1 = self.std.time(c1)
         c2 = self.std.calendar_units(t1)
         self.assertEqual(c1.year, c2.year, 'roundtrip should keep year')
@@ -67,6 +68,12 @@ class Calendar(unittest.TestCase):
         p = api.UtcPeriod(t, t + api.deltahours(1))
         s = str(p)
         self.assertEqual(s, "[2000.01.02T03:04:05,2000.01.02T04:04:05>")
+
+    def test_swig_python_time(self):
+        c1 = api.YMDhms(1969, 12, 31, 23, 0, 0)
+        t = self.utc.time(c1)
+        t_str= self.utc.to_string(t)
+        self.assertEquals(t,api.deltahours(-1))
 
 
 if __name__ == "__main__":

--- a/shyft/tests/api/test_time_axis.py
+++ b/shyft/tests/api/test_time_axis.py
@@ -12,7 +12,8 @@ class TimeAxis(unittest.TestCase):
         self.c=api.Calendar()
         self.d=api.deltahours(1)
         self.n=24
-        self.t= self.c.trim(api.utctime_now(),self.d)
+        #self.t= self.c.trim(api.utctime_now(),self.d)
+        self.t= self.c.trim(self.c.time(api.YMDhms(1969,12,31,0,0,0)),self.d)
         self.ta=api.Timeaxis(self.t,self.d,self.n)
         
     def tearDown(self):

--- a/shyft/tests/test_arome_respository.py
+++ b/shyft/tests/test_arome_respository.py
@@ -17,18 +17,14 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         EPSG, bbox = self.arome_epsg_bbox
 
         # Period start
-        year = 2015
-        month = 8
-        day = 23
-        hour = 6
         n_hours = 30
-        date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
+        t0 = api.YMDhms(2015, 8, 24, 0)
+        date_str = "{}{:02}{:02}_{:02}".format(t0.year,t0.month, t0.day, t0.hour)
         utc = api.Calendar()  # No offset gives Utc
-        t0 = api.YMDhms(year, month, day, hour)
         period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(n_hours))
 
         base_dir = path.join(shyftdata_dir, "repository", "arome_data_repository")
-        f1 = "arome_metcoop_red_default2_5km_{}.nc".format(date_str)
+        f1 = "arome_metcoop_red_default2_5km_{}_diff_time_unit.nc".format(date_str)
         f2 = "arome_metcoop_red_test2_5km_{}.nc".format(date_str)
 
         ar1 = AromeDataRepository(EPSG, base_dir, filename=f1, bounding_box=bbox)
@@ -51,6 +47,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         self.assertTrue(p0.time(0) == temp0.time(0))
         self.assertTrue(r0.time(r0.size() - 1) == temp0.time(temp0.size() - 1))
         self.assertTrue(p0.time(r0.size() - 1) == temp0.time(temp0.size() - 1))
+        self.assertTrue(p0.time(0),period.start)
 
     @property
     def arome_epsg_bbox(self):
@@ -68,7 +65,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         # Period start
         year = 2015
         month = 8
-        day = 23
+        day = 24
         hour = 6
         n_hours = 65
         utc = api.Calendar()  # No offset gives Utc
@@ -144,7 +141,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
     def test_wrong_file(self):
         with self.assertRaises(AromeDataRepositoryError) as context:
             utc = api.Calendar()  # No offset gives Utc
-            t0 = api.YMDhms(2015, 12, 24, 18)
+            t0 = api.YMDhms(2015, 12, 25, 18)
             period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(30))
             ar1 = AromeDataRepository(32632, shyftdata_dir, filename="plain_wrong.nc")
             ar1.get_timeseries(("temperature",), period, None)
@@ -153,7 +150,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
     def test_wrong_forecast(self):
         with self.assertRaises(AromeDataRepositoryError) as context:
             utc = api.Calendar()  # No offset gives Utc
-            t0 = api.YMDhms(2015, 12, 24, 18)
+            t0 = api.YMDhms(2015, 12, 25, 18)
             period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(30))
             ar1 = AromeDataRepository(32632, shyftdata_dir, filename="plain_wrong_*.nc")
             ar1.get_forecast(("temperature",), period, utc.time(t0), None)
@@ -167,7 +164,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         # Period start
         year = 2015
         month = 8
-        day = 23
+        day = 24
         hour = 6
         n_hours = 30
         date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
@@ -191,7 +188,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         # Period start
         year = 2015
         month = 8
-        day = 23
+        day = 24
         hour = 6
         n_hours = 30
         date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
@@ -213,7 +210,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         # Period start
         year = 2015
         month = 8
-        day = 23
+        day = 24
         hour = 6
         n_hours = 30
         date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
@@ -244,7 +241,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         # Period start
         year = 2015
         month = 8
-        day = 23
+        day = 24
         hour = 6
         n_hours = 30
         date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
@@ -268,7 +265,7 @@ class AromeDataRepositoryTestCase(unittest.TestCase):
         # Period start
         year = 2015
         month = 8
-        day = 23
+        day = 24
         hour = 6
         n_hours = 30
         date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)

--- a/shyft/tests/test_geo_ts_repository_collection.py
+++ b/shyft/tests/test_geo_ts_repository_collection.py
@@ -3,11 +3,10 @@ Tests GeoTsRepositoryCollection
 """
 from __future__ import print_function
 from __future__ import absolute_import
-
 from os import path
-#import random
+# import random
 import unittest
-#import numpy as np
+# import numpy as np
 
 from shyft import api
 from shyft import shyftdata_dir
@@ -16,28 +15,28 @@ from shyft.repository.geo_ts_repository_collection import GeoTsRepositoryCollect
 from shyft.repository.netcdf import AromeDataRepository
 from shyft.repository.netcdf import AromeDataRepositoryError
 
-class GeoTsRepositoryCollectionTestCase(unittest.TestCase):
 
+class GeoTsRepositoryCollectionTestCase(unittest.TestCase):
     @property
     def arome_epsg_bbox(self):
         """A slice of test-data located in shyft-data repository/arome."""
         EPSG = 32632
-        x0 = 436100.0   # lower left
+        x0 = 436100.0  # lower left
         y0 = 6823000.0  # lower right
         nx = 74
         ny = 24
         dx = 1000.0
         dy = 1000.0
-        return EPSG, ([x0, x0 + nx*dx, x0 + nx*dx, x0], [y0, y0, y0 + ny*dy, y0 + ny*dy])
+        return EPSG, ([x0, x0 + nx * dx, x0 + nx * dx, x0], [y0, y0, y0 + ny * dy, y0 + ny * dy])
 
     def test_get_timeseries_collection(self):
-        year, month, day, hour = 2015, 8, 23, 6
+        tc= api.YMDhms(2015, 8, 24, 6)
         n_hours = 30
         dt = api.deltahours(1)
         utc = api.Calendar()  # No offset gives Utc
-        t0 = utc.time(api.YMDhms(year, month, day, hour))
+        t0 = utc.time(tc)
         period = api.UtcPeriod(t0, t0 + api.deltahours(n_hours))
-        date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
+        date_str = "{}{:02}{:02}_{:02}".format(tc.year, tc.month, tc.day, tc.hour)
 
         epsg, bbox = self.arome_epsg_bbox
 
@@ -61,13 +60,13 @@ class GeoTsRepositoryCollectionTestCase(unittest.TestCase):
                                                        period, geo_location_criteria=bbox)
 
     def test_get_forecast_collection(self):
-        year, month, day, hour = 2015, 8, 23, 6
         n_hours = 30
         dt = api.deltahours(1)
         utc = api.Calendar()  # No offset gives Utc
-        t0 = utc.time(api.YMDhms(year, month, day, hour))
+        tc = api.YMDhms(2015, 8, 24, 6)
+        t0 = utc.time(tc)
         period = api.UtcPeriod(t0, t0 + api.deltahours(n_hours))
-        date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
+        date_str = "{}{:02}{:02}_{:02}".format(tc.year, tc.month, tc.day, tc.hour)
 
         epsg, bbox = self.arome_epsg_bbox
 
@@ -97,23 +96,18 @@ class GeoTsRepositoryCollectionTestCase(unittest.TestCase):
         ny = 94
         dx = 1000.0
         dy = 1000.0
-        # Period start
-        year = 2015
-        month = 7
-        day = 26
-        hour = 0
+        t0 = api.YMDhms(2015, 7, 26, 0)
         n_hours = 30
         utc = api.Calendar()  # No offset gives Utc
-        t0 = api.YMDhms(year, month, day, hour)
         period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(n_hours))
         t_c = utc.time(t0) + api.deltahours(1)
 
         base_dir = path.join(shyftdata_dir, "netcdf", "arome")
         pattern = "fc2015072600.nc"
-        bbox = ([upper_left_x, upper_left_x + nx*dx,
-                 upper_left_x + nx*dx, upper_left_x],
+        bbox = ([upper_left_x, upper_left_x + nx * dx,
+                 upper_left_x + nx * dx, upper_left_x],
                 [upper_left_y, upper_left_y,
-                 upper_left_y - ny*dy, upper_left_y - ny*dy])
+                 upper_left_y - ny * dy, upper_left_y - ny * dy])
         try:
             ar1 = AromeDataRepository(EPSG, base_dir, filename=pattern, bounding_box=bbox)
             ar2 = AromeDataRepository(EPSG, base_dir, filename=pattern, bounding_box=bbox)
@@ -128,6 +122,7 @@ class GeoTsRepositoryCollectionTestCase(unittest.TestCase):
             self.assertEqual("Only replace is supported yet", context.exception.args[0])
         except AromeDataRepositoryError as adre:
             self.skipTest("(test inconclusive- missing arome-data {0})".format(adre))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/shyft/tests/test_netcdftime.py
+++ b/shyft/tests/test_netcdftime.py
@@ -1,0 +1,14 @@
+import unittest
+#from os import path
+
+#from shyft import shyftdata_dir
+#from shyft import api
+
+from netcdftime import utime
+
+
+class NetCdfTimeTestCase(unittest.TestCase):
+
+    def test_extract_conversion_factors_from_string(self):
+        u = utime('hours since 2000-01-01 00:00:00')
+        self.assertIsNotNone(u)

--- a/shyft/tests/test_netcdftime.py
+++ b/shyft/tests/test_netcdftime.py
@@ -2,13 +2,27 @@ import unittest
 #from os import path
 
 #from shyft import shyftdata_dir
-#from shyft import api
+from shyft import api
+from shyft.repository.netcdf.time_conversion import convert_netcdf_time
 
 from netcdftime import utime
+import numpy as np
 
 
 class NetCdfTimeTestCase(unittest.TestCase):
 
     def test_extract_conversion_factors_from_string(self):
-        u = utime('hours since 2000-01-01 00:00:00')
+        u = utime('hours since 1970-01-01 00:00:00')
+        t_origin = api.Calendar(u.tzoffset).time(api.YMDhms(u.origin.year,u.origin.month,u.origin.day,u.origin.hour,u.origin.minute,u.origin.second))
+        delta_t_dic = {'days':api.deltahours(24),'hours':api.deltahours(1),'minutes':api.deltaminutes(1)}
+        delta_t = delta_t_dic[u.units]
         self.assertIsNotNone(u)
+        self.assertEqual(delta_t,api.deltahours(1))
+        self.assertEqual(t_origin,0)
+
+    def test_unit_conversion(self):
+        utc = api.Calendar()
+        t_num = np.arange(0,48,1, dtype=np.float64)
+        t_converted = convert_netcdf_time('hours since 1970-01-01 00:00:00', t_num)
+        t_axis = api.Timeaxis(utc.time(api.YMDhms(1970,1,1,0,0,0)),api.deltahours(1),2*24)
+        [self.assertEqual(t_converted[i],t_axis(i).start) for i in range(t_axis.size())]

--- a/shyft/tests/test_netcdftime.py
+++ b/shyft/tests/test_netcdftime.py
@@ -1,28 +1,24 @@
 import unittest
-#from os import path
-
-#from shyft import shyftdata_dir
 from shyft import api
 from shyft.repository.netcdf.time_conversion import convert_netcdf_time
-
 from netcdftime import utime
 import numpy as np
 
 
 class NetCdfTimeTestCase(unittest.TestCase):
-
     def test_extract_conversion_factors_from_string(self):
         u = utime('hours since 1970-01-01 00:00:00')
-        t_origin = api.Calendar(u.tzoffset).time(api.YMDhms(u.origin.year,u.origin.month,u.origin.day,u.origin.hour,u.origin.minute,u.origin.second))
-        delta_t_dic = {'days':api.deltahours(24),'hours':api.deltahours(1),'minutes':api.deltaminutes(1)}
+        t_origin = api.Calendar(u.tzoffset).time(
+            api.YMDhms(u.origin.year, u.origin.month, u.origin.day, u.origin.hour, u.origin.minute, u.origin.second))
+        delta_t_dic = {'days': api.deltahours(24), 'hours': api.deltahours(1), 'minutes': api.deltaminutes(1)}
         delta_t = delta_t_dic[u.units]
         self.assertIsNotNone(u)
-        self.assertEqual(delta_t,api.deltahours(1))
-        self.assertEqual(t_origin,0)
+        self.assertEqual(delta_t, api.deltahours(1))
+        self.assertEqual(t_origin, 0)
 
     def test_unit_conversion(self):
         utc = api.Calendar()
-        t_num = np.arange(0,48,1, dtype=np.float64)
+        t_num = np.arange(0, 48, 1, dtype=np.float64)
         t_converted = convert_netcdf_time('hours since 1970-01-01 00:00:00', t_num)
-        t_axis = api.Timeaxis(utc.time(api.YMDhms(1970,1,1,0,0,0)),api.deltahours(1),2*24)
-        [self.assertEqual(t_converted[i],t_axis(i).start) for i in range(t_axis.size())]
+        t_axis = api.Timeaxis(utc.time(api.YMDhms(1970, 1, 1, 0, 0, 0)), api.deltahours(1), 2 * 24)
+        [self.assertEqual(t_converted[i], t_axis(i).start) for i in range(t_axis.size())]

--- a/shyft/tests/test_simple_simulator.py
+++ b/shyft/tests/test_simple_simulator.py
@@ -46,11 +46,11 @@ class SimulationTestCase(unittest.TestCase):
 
     def run_simulator(self, model_t):
         # Simulation time axis
-        year, month, day, hour = 2015, 8, 23, 6
+        dt0 = api.YMDhms(2015, 8, 24, 6)
         n_hours = 30
         dt = api.deltahours(1)
         utc = api.Calendar()  # No offset gives Utc
-        t0 = utc.time(api.YMDhms(year, month, day, hour))
+        t0 = utc.time(dt0)
         time_axis = api.Timeaxis(t0, dt, n_hours)
 
         # Some dummy ids not needed for the netcdf based repositories
@@ -65,7 +65,7 @@ class SimulationTestCase(unittest.TestCase):
         model_config = ModelConfig(self.model_config_file)
         region_model_repository = RegionModelRepository(region_config, model_config, model_t, epsg)
         interp_repos = InterpolationParameterRepository(model_config)
-        date_str = "{}{:02}{:02}_{:02}".format(year, month, day, hour)
+        date_str = "{}{:02}{:02}_{:02}".format(dt0.year, dt0.month, dt0.day, dt0.hour)
         base_dir = path.join(shyftdata_dir, "repository", "arome_data_repository")
         f1 = "arome_metcoop_red_default2_5km_{}.nc".format(date_str)
         f2 = "arome_metcoop_red_test2_5km_{}.nc".format(date_str)

--- a/shyft/tests/tests.pyproj
+++ b/shyft/tests/tests.pyproj
@@ -28,6 +28,7 @@
     <Compile Include="test_gis_region_model_repository.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="test_netcdftime.py" />
     <Compile Include="test_netcdf_geo_ts_repository.py" />
     <Compile Include="test_netcdf_region_model_repository.py" />
     <Compile Include="test_opendap_repository.py" />


### PR DESCRIPTION
We  (Yisak and myself) made this minor change to add handling of CF compliant netcdf-time.

During the work we used pycharm, and the shyft pycharm project, testing out features in pycharm to drive the test-driven development process. It worked nice!

Now we require netcdf/arome file to provide CF compliant time description.
We support only trivial calendar/steps, seconds, minutes, hours, days as a starting point.
We use  t_utc[i] = t_origin + delta_t* t_netcdf[i], in np. array form hoping for great performance.

We deliberately avoid converting a number (linear time) to calendar-coordinate (aka datetime) and back to number (linear time), for performance and robustness reasons.
