### PR TITLE
Removed swig in requirements.txt as it is not in the PyPI repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-swig
 numpy
 netcdf4
 pyyaml


### PR DESCRIPTION
swig is a requirement, but it is not installable from PyPI, so this PR removes it from requirements.txt.  The TravisCI build script does not require this (conda is used instead), so this PR is not breaking it.