### PR TITLE
GammaSnow: added snow_cv sensitive to forest and altitude 

### DIFF
--- a/api/python/__init__.i
+++ b/api/python/__init__.i
@@ -13,6 +13,8 @@
 
 %feature("autodoc", "2");
 %feature("kwargs");
+%feature("naturalvar");
+
 %begin %{ // gcc win-compile needs this to avoid problems in cmath, fix: to include first
 #include <cmath>
 %}

--- a/api/python/pt_gs_k.i
+++ b/api/python/pt_gs_k.i
@@ -1,4 +1,7 @@
 %module(package="shyft.api") pt_gs_k
+%feature("autodoc", "2");
+%feature("kwargs");
+%feature("naturalvar");
 
 #define SWIG_FILE_WITH_INIT
 %begin %{ // gcc win-compile needs this to avoid problems in cmath, fix: to include first

--- a/api/python/pt_hs_k.i
+++ b/api/python/pt_hs_k.i
@@ -1,5 +1,9 @@
 %module(package="shyft.api") pt_hs_k
 
+%feature("autodoc", "2");
+%feature("kwargs");
+%feature("naturalvar");
+
 #define SWIG_FILE_WITH_INIT
 %begin %{ // gcc win-compile needs this to avoid problems in cmath, fix: to include first
 #include <cmath>

--- a/api/python/pt_ss_k.i
+++ b/api/python/pt_ss_k.i
@@ -1,5 +1,9 @@
 %module(package="shyft.api") pt_ss_k
 
+%feature("autodoc", "2");
+%feature("kwargs");
+%feature("naturalvar");
+
 #define SWIG_FILE_WITH_INIT
 %begin %{ // gcc win-compile needs this to avoid problems in cmath, fix: to include first
 #include <cmath>

--- a/test/gamma_snow_test.h
+++ b/test/gamma_snow_test.h
@@ -10,6 +10,7 @@ class gamma_snow_test: public CxxTest::TestSuite {
     void test_step();
     void test_warm_winter_effect();
     void test_output_independent_of_timestep();
+    void test_forest_altitude_dependent_snow_cv();
 };
 
 /* vim: set filetype=cpp: */

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -30,7 +30,7 @@
 				<Option object_output="obj/Release/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="api_test" />
+				<Option parameters="gamma_snow_test" />
 				<Compiler>
 					<Add option="-O3" />
 					<Add option="-DARMA_NO_DEBUG" />


### PR DESCRIPTION
A minor change to gamma_snow:

effective_snow_cv  ::= snow_cv + snow_cv_forest_factor* forest_fraction + snow_cv_altitude_factor*cell_altitude.

All parameters defaults to 0.0, so it is 100% backward compatible, no changes needed.

To enable feature, set the gs.*_cv_factors to the value you want, and the snow_cv is adjusted according to the cell altitude and| or forest-fraction.

Note: ensure that you get the snow_cv you want by testing for forest_fraction 0.0..1.0, and altitudes 0.. max elevation in your cell model.



