### PR TITLE
Timezone and DST support for utctime and calendar library

### DIFF
--- a/api/python/__init__.i
+++ b/api/python/__init__.i
@@ -39,7 +39,7 @@
     #define SWIG_FILE_WITH_INIT
     #define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
     #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-
+    #include "core/core_pch.h"
     #include "core/utctime_utilities.h"
 
     #include "api/api.h"
@@ -68,6 +68,7 @@
     %include <windows.i>
     %include <std_string.i>
     %include <std_vector.i>
+    %include <std_map.i>
     %include <stl.i>
     %include <exception.i>
 
@@ -90,6 +91,7 @@
 %shared_ptr( shyft::api::GenericTs<shyft::timeseries::function_timeseries<shyft::timeseries::timeaxis,shyft::timeseries::sin_fx>>)
 //%shared_ptr( shyft::core::pts_t )
 %shared_ptr( shyft::timeseries::point_timeseries<shyft::timeseries::timeaxis> )
+%shared_ptr( shyft::core::time_zone::tz_info<shyft::core::time_zone::tz_table> )
 
 // -- Now we let SWIG parse and interpret the types in enki_api.h
 // swig will do its best to reflect all types/methods exposed there into the python wrapper.
@@ -203,6 +205,15 @@
     %include "core/model_calibration.h"
 
     %include "api.h"
+
+namespace shyft {
+  namespace core {
+     namespace time_zone {
+         %template(TzTableInfo) tz_info<shyft::core::time_zone::tz_table>;
+         //%template(NameToTzInfoMap) std::map<string,shared_ptr<shyft::core::time_zone::tz_info<shyft::core::time_zone::tz_table> >>;
+     }
+  }
+}
 
 namespace shyft {
   namespace core {

--- a/core/utctime_utilities.cpp
+++ b/core/utctime_utilities.cpp
@@ -138,13 +138,13 @@ namespace shyft {
             switch (deltaT) {
                 case YEAR: {
                     auto c=calendar_units(t);
-                    c.year += dt/YEAR;// gives signed number of units.
+                    c.year += int(dt/YEAR);// gives signed number of units.
                     return time(c);
                 } break;
                 case MONTH:{
                     auto c=calendar_units(t);
                     // calculate number of years..
-                    int nyears= dt/MONTH/12; // with correct sign
+                    int nyears= int(dt/MONTH/12); // with correct sign
                     c.year +=  nyears; // done with years, now single step remaining months.
                     int nmonths= n-nyears*12;// remaining months to deal with
                     c.month += nmonths;// just add them
@@ -188,13 +188,13 @@ namespace shyft {
                 case calendar::YEAR:
                 case calendar::WEEK:
                 case calendar::DAY:{
-                    auto t2x=add(t1,deltaT,n_units);
+                    auto t2x=add(t1,deltaT,long(n_units));
                     if(t2x>t2) { // got one step to far
                         --n_units;// reduce n_units, and calculate remainder
-                        remainder= t2 - add(t1,deltaT,n_units);
+                        remainder= t2 - add(t1,deltaT,long(n_units));
                     } else if(t2x<t2) {// got one step short, there might be a hope for one more
                         ++n_units;// try adding one unit
-                        auto t2xx= add(t1,deltaT,n_units);//calc new t2x
+                        auto t2xx= add(t1,deltaT,long(n_units));//calc new t2x
                         if(t2xx>t2) { // to much ?
                             --n_units;// reduce, and
                             remainder = t2 - t2x;// remainder is as with previous t2x

--- a/core/utctime_utilities.cpp
+++ b/core/utctime_utilities.cpp
@@ -2,9 +2,12 @@
 #include "utctime_utilities.h"
 #include <ostream>
 
+#include <boost/date_time/local_time/local_time.hpp>
+
 namespace shyft {
     namespace core {
-    using namespace std;
+
+        using namespace std;
         std::ostream& operator<<(std::ostream& os, const utcperiod& p) {
             os << p.to_string();
             return os;
@@ -14,6 +17,7 @@ namespace shyft {
             calendar utc;
             return utc.to_string(*this);
         }
+
         string calendar::to_string(utctime t) const {
             char s[100];
             switch(t) {
@@ -22,16 +26,658 @@ namespace shyft {
                 case max_utctime:sprintf(s, "+oo"); break;
                 default: {
                     auto c = calendar_units(t);
-                    sprintf(s, "%04d.%02d.%02dT%02d:%02d:%02d", c.year, c.month, c.day, c.hour, c.minute, c.second);
+                    auto tz= tz_info->utc_offset(t);
+                    auto tz_hours= int(tz/deltahours(1));
+                    auto tz_minutes= int(abs(tz-tz_hours*deltahours(1))/deltaminutes(1));
+                    char tzs[100];
+                    if(tz) {
+                        if(tz_minutes)
+                            sprintf(tzs,"%+03d:%02d",tz_hours,tz_minutes);
+                        else
+                            sprintf(tzs,"%+03d",tz_hours);
+                    } else {
+                        strcpy(tzs,"Z");
+                    }
+                    sprintf(s, "%04d-%02d-%02dT%02d:%02d:%02d%s", c.year, c.month, c.day, c.hour, c.minute, c.second,tzs);
                 }break;
             }
             return string(s);
         }
+
         string calendar::to_string(utcperiod p) const {
             if(p.valid()) {
                 return string("[") + to_string(p.start) + "," + to_string(p.end) + ">";
             }
             return string("[not-valid-period>");
         }
+
+        utctime calendar::time(YMDhms c) const {
+            if(c.is_null()) return no_utctime;
+            if(c==YMDhms::max()) return max_utctime;
+            if(c==YMDhms::min()) return min_utctime;
+            if (!c.is_valid_coordinates())
+                throw std::runtime_error("Calendar.time with invalid YMDhms coordinates attempted");
+
+            utctime r= ((int(day_number(c)) - UnixDay)*DAY) + seconds(c.hour, c.minute, c.second);
+            auto utc_diff_1= tz_info->utc_offset(r);// detect if we are in the dst-shift hour
+            auto utc_diff_2= tz_info->utc_offset(r-utc_diff_1);
+            return (utc_diff_1==utc_diff_2)?r-utc_diff_1: r-utc_diff_2;
+        }
+
+        YMDhms  calendar::calendar_units(utctime t) const {
+            if (t == no_utctime)  return YMDhms();
+            if (t == max_utctime) return YMDhms::max();
+            if (t == min_utctime) return YMDhms::min();
+            t += tz_info->utc_offset(t);
+            auto jdn = day_number(t);
+            auto x = from_day_number(jdn);
+            YMDhms r;
+            r.year = x.year; r.month = x.month; r.day = x.day;
+            utctime tj = UnixSecond + t;
+            utctime td = DAY*(tj / DAY);
+            utctimespan dx = tj - td;// n seconds this day.
+            r.hour = int(dx / HOUR);
+            dx -= r.hour*HOUR;
+            r.minute = int(dx / MINUTE);
+            r.second = int(dx % MINUTE);
+            return r;
+        }
+
+        int calendar::day_of_week(utctime t) const {
+            if (t == no_utctime || t == min_utctime || t == max_utctime)
+                return -1;
+            auto ymd = calendar_units(t);
+            unsigned short a = static_cast<unsigned short>((14 - ymd.month) / 12);
+            unsigned short y = static_cast<unsigned short>(ymd.year - a);
+            unsigned short m = static_cast<unsigned short>(ymd.month + 12 * a - 2);
+            int d = static_cast<int>((ymd.day + y + (y / 4) - (y / 100) + (y / 400) + (31 * m) / 12) % 7);
+            return d;
+        }
+        ///< returns day_of year, 1..365..
+        size_t calendar::day_of_year(utctime t) const {
+            if (t == no_utctime || t == max_utctime || t == min_utctime) return -1;
+            auto x = calendar_units(t );
+            YMDhms y(x.year, 1, 1);
+            return 1 + day_number(x) - day_number(y);
+        }
+        ///< returns the month of t, 1..12, -1 of not valid time
+        int calendar::month(utctime t) const {
+            if (t == no_utctime || t == max_utctime || t == min_utctime) return -1;
+            return calendar_units(t ).month;
+        }
+
+        utctime calendar::trim(utctime t, utctimespan deltaT) const {
+            if (t == no_utctime || t == min_utctime || t == max_utctime || deltaT==utctimespan(0))
+                return t;
+            switch (deltaT) {
+            case YEAR: {
+                auto c = calendar_units(t);
+                c.month = c.day = 1; c.hour = c.minute = c.second = 0;
+                return time(c);
+            }break;
+            case MONTH: {
+                auto c = calendar_units(t);
+                c.day = 1; c.hour = c.minute = c.second = 0;
+                return time(c);
+            }break;
+            case DAY: {
+                auto c = calendar_units(t);
+                c.hour = c.minute = c.second = 0;
+                return time(c);
+            }break;
+            }
+            auto tz_offset=tz_info->utc_offset(t);
+            const utctime t0 = utctime(3LL * DAY) + utctime(WEEK * 52L * 2000LL);// + 3 days to get to a isoweek monday, then add 2000 years to get a positive number
+            t += t0 + tz_offset;
+            t= deltaT*(t / deltaT) - t0 ;
+            return  t - tz_info->utc_offset(t);
+        }
+
+        utctime calendar::add(utctime t, utctimespan deltaT, long n) const {
+            auto dt=n*deltaT;
+            switch (deltaT) {
+                case YEAR: {
+                    auto c=calendar_units(t);
+                    c.year += dt/YEAR;// gives signed number of units.
+                    return time(c);
+                } break;
+                case MONTH:{
+                    auto c=calendar_units(t);
+                    // calculate number of years..
+                    int nyears= dt/MONTH/12; // with correct sign
+                    c.year +=  nyears; // done with years, now single step remaining months.
+                    int nmonths= n-nyears*12;// remaining months to deal with
+                    c.month += nmonths;// just add them
+                    if(c.month <1) {c.month+=12; c.year--;}// then repair underflow
+                    else if(c.month >12 ) {c.month -=12;c.year++;}// or overflow
+                    return time(c);
+                } break;
+                default: break;
+
+            }
+            auto utc_diff_1=tz_info->utc_offset(t - (dt>0?0:deltahours(1)));//assuming dst=1h!
+            utctime r;
+            r= t+ dt;
+            auto utc_diff_2=tz_info->utc_offset(r-(dt>0?deltahours(1):0));//assuming dst=1h!
+            return r + (utc_diff_1-utc_diff_2);
+            // explanation: if t and r are in different dst, compensate for difference
+            // e.g.: t+ calendar day, in dst, will be 23, 24 or 25 hours long, this way
+            //  25: t= mm:dd   00:00, utcdiff(t) is +2h, add 24h
+            //      r= mm:dd+1 00:00, utcdiff(r) is +1h
+            //      ret r +( 2h - 1h), e.g. add one hour and we get 25h day.
+            //  24: trivial utcdiff before and after are same, 0.
+            //
+            //  23: t= mm:dd   00:00 utcdiff(t) is +1h, then we add 24h
+            //      r= mm:dd+1 00:00 utcdiff(r) is +2h (since we are in summer time)
+            //      ret r +( 1h - 2h), eg. sub one hour, and we get a 23h day.
+        };
+
+
+        utctimespan calendar::diff_units(utctime t1, utctime t2, utctimespan deltaT, utctimespan &remainder) const {
+            if (t1 == no_utctime || t2 == no_utctime || deltaT == 0L) {
+                remainder = 0L;
+                return 0L;
+            }
+            int sgn=1;
+            if(t1>t2) {sgn=-1;swap(t1,t2);}
+            utctimespan n_units= (t2-t1)/deltaT;// a *rough* estimate in case of dst or month/year
+            // recall that this should give n_unit=1, remainder=0 for dst days 23h | 25h etc.
+            // and that it should be complementary to the add(t,dt,n) function.
+            switch (deltaT) {
+                case calendar::MONTH: n_units -= n_units/72; // MONTH is 30 days, a real one  is ~ 30.41, after 72 monts this adds up to ~ 1 month error
+                case calendar::YEAR:
+                case calendar::WEEK:
+                case calendar::DAY:{
+                    auto t2x=add(t1,deltaT,n_units);
+                    if(t2x>t2) { // got one step to far
+                        --n_units;// reduce n_units, and calculate remainder
+                        remainder= t2 - add(t1,deltaT,n_units);
+                    } else if(t2x<t2) {// got one step short, there might be a hope for one more
+                        ++n_units;// try adding one unit
+                        auto t2xx= add(t1,deltaT,n_units);//calc new t2x
+                        if(t2xx>t2) { // to much ?
+                            --n_units;// reduce, and
+                            remainder = t2 - t2x;// remainder is as with previous t2x
+                        } else {// success, we could increase with one
+                            remainder = t2 - t2xx;//new remainder based on t2xx
+                        }
+                    } else {
+                        remainder=utctimespan(0);// perfect hit, zero remainder
+                    }
+                } break;
+                default: {
+                    remainder = t2 - (t1+n_units*deltaT);
+                } break;
+            }
+            return n_units*sgn;
+        };
+
+        namespace time_zone {
+            using namespace boost::gregorian;
+            using namespace boost::local_time;
+            using namespace boost::posix_time;
+            using namespace std;
+
+            ///< just a local adapter to the tz_table generator
+            struct boost_tz_info { // limitation is posix time, def from 1901 and onward
+                ptime posix_t1970;///< epoch reference in ptime, needed to convert to utctime
+                time_zone_ptr tzinfo;///< we extract boost info from this one
+                /**\brief convert a ptime to a utctime */
+                utctime to_utctime(ptime p) const { return (p-posix_t1970).total_seconds();}
+
+                boost_tz_info(time_zone_ptr tzinfo):posix_t1970((date(1970,1,1))),tzinfo(tzinfo) {}
+
+
+                utctime dst_start(int year) const {
+                    return to_utctime(tzinfo->dst_local_start_time(year)) - tzinfo->base_utc_offset().total_seconds();
+                }
+                utctime dst_end(int year) const {
+                    return to_utctime(tzinfo->dst_local_end_time(year)) - tzinfo->base_utc_offset().total_seconds() - tzinfo->dst_offset().total_seconds();
+                }
+                utctimespan base_offset() const {
+                    return utctimespan(tzinfo->base_utc_offset().total_seconds());
+                }
+                utctimespan dst_offset(int y) const {
+                    return utctimespan(tzinfo->dst_offset().total_seconds());
+                }
+                string name() const {return tzinfo->std_zone_name();}
+            };
+
+            static shared_ptr<tz_info_t> create_from_posix_definition(const string& posix_tz_string) {
+                time_zone_ptr tz=time_zone_ptr(new posix_time_zone(posix_tz_string));
+                boost_tz_info btz(tz);
+                return make_shared<tz_info_t>(tz_info_t(btz.base_offset(),tz_table(btz)));
+            }
+
+            void tz_info_database::load_from_file(const string filename) {
+                tz_database tzdb;
+                tzdb.load_from_file(filename);
+                region_tz_map.clear(); name_tz_map.clear();
+                for(const auto&id:tzdb.region_list()) {
+                    auto tz=tzdb.time_zone_from_region(id);
+                    boost_tz_info btz(tz);
+                    auto tzinfo= make_shared<tz_info_t>(tz_info_t(btz.base_offset(),tz_table(btz)));
+                    region_tz_map[id]=tzinfo;
+                    name_tz_map[tzinfo->name()]=tzinfo;
+                }
+            }
+            void tz_info_database::add_tz_info(string region_name,string posix_tz_string) {
+                auto tzinfo= create_from_posix_definition(posix_tz_string);
+                region_tz_map[region_name]=tzinfo;
+                name_tz_map[tzinfo->name()]=tzinfo;
+            }
+            struct tz_region_def {
+                const char *region;const char *posix_definition;
+            };
+            static tz_region_def tzdef[]={ // as defined in boost 1.60 date_time_zonespec.csv 2016.01.30
+                {"Africa/Abidjan","GMT+00"},
+                {"Africa/Accra","GMT+00"},
+                {"Africa/Addis_Ababa","EAT+03"},
+                {"Africa/Algiers","CET+01"},
+                {"Africa/Asmera","EAT+03"},
+                {"Africa/Bamako","GMT+00"},
+                {"Africa/Bangui","WAT+01"},
+                {"Africa/Banjul","GMT+00"},
+                {"Africa/Bissau","GMT+00"},
+                {"Africa/Blantyre","CAT+02"},
+                {"Africa/Brazzaville","WAT+01"},
+                {"Africa/Bujumbura","CAT+02"},
+                {"Africa/Cairo","EET+02EEST+01,M4.5.5/00:00,M9.5.5/00:00"},
+                {"Africa/Casablanca","WET+00"},
+                {"Africa/Ceuta","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Africa/Conakry","GMT+00"},
+                {"Africa/Dakar","GMT+00"},
+                {"Africa/Dar_es_Salaam","EAT+03"},
+                {"Africa/Djibouti","EAT+03"},
+                {"Africa/Douala","WAT+01"},
+                {"Africa/El_Aaiun","WET+00"},
+                {"Africa/Freetown","GMT+00"},
+                {"Africa/Gaborone","CAT+02"},
+                {"Africa/Harare","CAT+02"},
+                {"Africa/Johannesburg","SAST+02"},
+                {"Africa/Kampala","EAT+03"},
+                {"Africa/Khartoum","EAT+03"},
+                {"Africa/Kigali","CAT+02"},
+                {"Africa/Kinshasa","WAT+01"},
+                {"Africa/Lagos","WAT+01"},
+                {"Africa/Libreville","WAT+01"},
+                {"Africa/Lome","GMT+00"},
+                {"Africa/Luanda","WAT+01"},
+                {"Africa/Lubumbashi","CAT+02"},
+                {"Africa/Lusaka","CAT+02"},
+                {"Africa/Malabo","WAT+01"},
+                {"Africa/Maputo","CAT+02"},
+                {"Africa/Maseru","SAST+02"},
+                {"Africa/Mbabane","SAST+02"},
+                {"Africa/Mogadishu","EAT+03"},
+                {"Africa/Monrovia","GMT+00"},
+                {"Africa/Nairobi","EAT+03"},
+                {"Africa/Ndjamena","WAT+01"},
+                {"Africa/Niamey","WAT+01"},
+                {"Africa/Nouakchott","GMT+00"},
+                {"Africa/Ouagadougou","GMT+00"},
+                {"Africa/Porto-Novo","WAT+01"},
+                {"Africa/Sao_Tome","GMT+00"},
+                {"Africa/Timbuktu","GMT+00"},
+                {"Africa/Tripoli","EET+02"},
+                {"Africa/Tunis","CET+01"},
+                {"Africa/Windhoek","WAT+01WAST+01,M9.1.0/02:00,M4.1.0/02:00"},
+                {"America/Adak","HAST-10HADT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Anchorage","AKST-09AKDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Anguilla","AST-04"},
+                {"America/Antigua","AST-04"},
+                {"America/Araguaina","BRT-03BRST+01,M10.2.0/00:00,M2.3.0/00:00"},
+                {"America/Aruba","AST-04"},
+                {"America/Asuncion","PYT-04PYST+01,M10.1.0/00:00,M3.1.0/00:00"},
+                {"America/Barbados","AST-04"},
+                {"America/Belem","BRT-03"},
+                {"America/Belize","CST-06"},
+                {"America/Boa_Vista","AMT-04"},
+                {"America/Bogota","COT-05"},
+                {"America/Boise","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Buenos_Aires","ART-03"},
+                {"America/Cambridge_Bay","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Cancun","CST-06CDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Caracas","VET-04"},
+                {"America/Catamarca","ART-03"},
+                {"America/Cayenne","GFT-03"},
+                {"America/Cayman","EST-05"},
+                {"America/Chicago","CST-06CDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Chihuahua","MST-07MDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Cordoba","ART-03"},
+                {"America/Costa_Rica","CST-06"},
+                {"America/Cuiaba","AMT-04AMST+01,M10.2.0/00:00,M2.3.0/00:00"},
+                {"America/Curacao","AST-04"},
+                {"America/Danmarkshavn","GMT+00"},
+                {"America/Dawson","PST-08PDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Dawson_Creek","MST-07"},
+                {"America/Denver","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Detroit","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Dominica","AST-04"},
+                {"America/Edmonton","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Eirunepe","ACT-05"},
+                {"America/El_Salvador","CST-06"},
+                {"America/Fortaleza","BRT-03BRST+01,M10.2.0/00:00,M2.3.0/00:00"},
+                {"America/Glace_Bay","AST-04ADT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Godthab","WGT-03WGST+01,M3.5.6/22:00,M10.5.6/23:00"},
+                {"America/Goose_Bay","AST-04ADT+01,M4.1.0/00:01,M10.5.0/00:01"},
+                {"America/Grand_Turk","EST-05EDT+01,M4.1.0/00:00,M10.5.0/00:00"},
+                {"America/Grenada","AST-04"},
+                {"America/Guadeloupe","AST-04"},
+                {"America/Guatemala","CST-06"},
+                {"America/Guayaquil","ECT-05"},
+                {"America/Guyana","GYT-04"},
+                {"America/Halifax","AST-04ADT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Havana","CST-05CDT+01,M4.1.0/00:00,M10.5.0/01:00"},
+                {"America/Hermosillo","MST-07"},
+                {"America/Indiana/Indianapolis","EST-05"},
+                {"America/Indiana/Knox","EST-05"},
+                {"America/Indiana/Marengo","EST-05"},
+                {"America/Indiana/Vevay","EST-05"},
+                {"America/Indianapolis","EST-05"},
+                {"America/Inuvik","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Iqaluit","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Jamaica","EST-05"},
+                {"America/Jujuy","ART-03"},
+                {"America/Juneau","AKST-09AKDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Kentucky/Louisville","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Kentucky/Monticello","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/La_Paz","BOT-04"},
+                {"America/Lima","PET-05"},
+                {"America/Los_Angeles","PST-08PDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Louisville","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Maceio","BRT-03BRST+01,M10.2.0/00:00,M2.3.0/00:00"},
+                {"America/Managua","CST-06"},
+                {"America/Manaus","AMT-04"},
+                {"America/Martinique","AST-04"},
+                {"America/Mazatlan","MST-07MDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Mendoza","ART-03"},
+                {"America/Menominee","CST-06CDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Merida","CST-06CDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Mexico_City","CST-06CDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Miquelon","PMST-03PMDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Monterrey","CST-06CDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Montevideo","UYT-03"},
+                {"America/Montreal","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Montserrat","AST-04"},
+                {"America/Nassau","EST-05EDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/New_York","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Nipigon","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Nome","AKST-09AKDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Noronha","FNT-02"},
+                {"America/North_Dakota/Center","CST-06CDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Panama","EST-05"},
+                {"America/Pangnirtung","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Paramaribo","SRT-03"},
+                {"America/Phoenix","MST-07"},
+                {"America/Port-au-Prince","EST-05"},
+                {"America/Port_of_Spain","AST-04"},
+                {"America/Porto_Velho","AMT-04"},
+                {"America/Puerto_Rico","AST-04"},
+                {"America/Rainy_River","CST-06CDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Rankin_Inlet","CST-06CDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Recife","BRT-03BRST+01,M10.2.0/00:00,M2.3.0/00:00"},
+                {"America/Regina","CST-06"},
+                {"America/Rio_Branco","ACT-05"},
+                {"America/Rosario","ART-03"},
+                {"America/Santiago","CLT-04CLST+01,M10.2.0/00:00,M3.2.0/00:00"},
+                {"America/Santo_Domingo","AST-04"},
+                {"America/Sao_Paulo","BRT-03BRST+01,M10.2.0/00:00,M2.3.0/00:00"},
+                {"America/Scoresbysund","EGT-01EGST+01,M3.5.0/00:00,M10.5.0/01:00"},
+                {"America/Shiprock","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/St_Johns","NST-03:-30NDT+01,M4.1.0/00:01,M10.5.0/00:01"},
+                {"America/St_Kitts","AST-04"},
+                {"America/St_Lucia","AST-04"},
+                {"America/St_Thomas","AST-04"},
+                {"America/St_Vincent","AST-04"},
+                {"America/Swift_Current","CST-06"},
+                {"America/Tegucigalpa","CST-06"},
+                {"America/Thule","AST-04"},
+                {"America/Thunder_Bay","EST-05EDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Tijuana","PST-08PDT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"America/Tortola","AST-04"},
+                {"America/Vancouver","PST-08PDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Whitehorse","PST-08PDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Winnipeg","CST-06CDT+01,M3.2.0/02:00,M11.1.0/03:00"},
+                {"America/Yakutat","AKST-09AKDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"America/Yellowknife","MST-07MDT+01,M3.2.0/02:00,M11.1.0/02:00"},
+                {"Antarctica/Casey","WST+08"},
+                {"Antarctica/Davis","DAVT+07"},
+                {"Antarctica/DumontDUrville","DDUT+10"},
+                {"Antarctica/Mawson","MAWT+06"},
+                {"Antarctica/McMurdo","NZST+12NZDT+01,M10.1.0/02:00,M3.3.0/03:00"},
+                {"Antarctica/Palmer","CLT-04CLST+01,M10.2.0/00:00,M3.2.0/00:00"},
+                {"Antarctica/South_Pole","NZST+12NZDT+01,M10.1.0/02:00,M3.3.0/03:00"},
+                {"Antarctica/Syowa","SYOT+03"},
+                {"Antarctica/Vostok","VOST+06"},
+                {"Arctic/Longyearbyen","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Aden","AST+03"},
+                {"Asia/Almaty","ALMT+06ALMST+01,M3.5.0/00:00,M10.5.0/00:00"},
+                {"Asia/Amman","EET+02EEST+01,M3.5.4/00:00,M9.5.4/01:00"},
+                {"Asia/Anadyr","ANAT+12ANAST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Aqtau","AQTT+04AQTST+01,M3.5.0/00:00,M10.5.0/00:00"},
+                {"Asia/Aqtobe","AQTT+05AQTST+01,M3.5.0/00:00,M10.5.0/00:00"},
+                {"Asia/Ashgabat","TMT+05"},
+                {"Asia/Baghdad","AST+03ADT+01,M4.1.0/03:00,M10.1.0/04:00"},
+                {"Asia/Bahrain","AST+03"},
+                {"Asia/Baku","AZT+04AZST+01,M3.5.0/01:00,M10.5.0/01:00"},
+                {"Asia/Bangkok","ICT+07"},
+                {"Asia/Beirut","EET+02EEST+01,M3.5.0/00:00,M10.5.0/00:00"},
+                {"Asia/Bishkek","KGT+05KGST+01,M3.5.0/02:30,M10.5.0/02:30"},
+                {"Asia/Brunei","BNT+08"},
+                {"Asia/Calcutta","IST+05:30"},
+                {"Asia/Choibalsan","CHOT+09"},
+                {"Asia/Chongqing","CST+08"},
+                {"Asia/Colombo","LKT+06"},
+                {"Asia/Damascus","EET+02EEST+01,M4.1.0/00:00,M10.1.0/00:00"},
+                {"Asia/Dhaka","BDT+06"},
+                {"Asia/Dili","TPT+09"},
+                {"Asia/Dubai","GST+04"},
+                {"Asia/Dushanbe","TJT+05"},
+                {"Asia/Gaza","EET+02EEST+01,M4.3.5/00:00,M10.3.5/00:00"},
+                {"Asia/Harbin","CST+08"},
+                {"Asia/Hong_Kong","HKT+08"},
+                {"Asia/Hovd","HOVT+07"},
+                {"Asia/Irkutsk","IRKT+08IRKST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Istanbul","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Asia/Jakarta","WIT+07"},
+                {"Asia/Jayapura","EIT+09"},
+                {"Asia/Jerusalem","IST+02IDT+01,M4.1.0/01:00,M10.1.0/01:00"},
+                {"Asia/Kabul","AFT+04:30"},
+                {"Asia/Kamchatka","PETT+12PETST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Karachi","PKT+05"},
+                {"Asia/Kashgar","CST+08"},
+                {"Asia/Katmandu","NPT+05:45"},
+                {"Asia/Krasnoyarsk","KRAT+07KRAST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Kuala_Lumpur","MYT+08"},
+                {"Asia/Kuching","MYT+08"},
+                {"Asia/Kuwait","AST+03"},
+                {"Asia/Macao","CST+08"},
+                {"Asia/Macau","CST+08"},
+                {"Asia/Magadan","MAGT+11MAGST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Makassar","CIT+08"},
+                {"Asia/Manila","PHT+08"},
+                {"Asia/Muscat","GST+04"},
+                {"Asia/Nicosia","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Asia/Novosibirsk","NOVT+06NOVST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Omsk","OMST+06OMSST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Oral","WST+05"},
+                {"Asia/Phnom_Penh","ICT+07"},
+                {"Asia/Pontianak","WIT+07"},
+                {"Asia/Pyongyang","KST+09"},
+                {"Asia/Qatar","AST+03"},
+                {"Asia/Qyzylorda","KST+06"},
+                {"Asia/Rangoon","MMT+06:30"},
+                {"Asia/Riyadh","AST+03"},
+                {"Asia/Saigon","ICT+07"},
+                {"Asia/Sakhalin","SAKT+10SAKST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Samarkand","UZT+05"},
+                {"Asia/Seoul","KST+09"},
+                {"Asia/Shanghai","CST+08"},
+                {"Asia/Singapore","SGT+08"},
+                {"Asia/Taipei","CST+08"},
+                {"Asia/Tashkent","UZT+05"},
+                {"Asia/Tbilisi","GET+04GEST+01,M3.5.0/00:00,M10.5.0/00:00"},
+                {"Asia/Tehran","IRT+03:30"},
+                {"Asia/Thimphu","BTT+06"},
+                {"Asia/Tokyo","JST+09"},
+                {"Asia/Ujung_Pandang","CIT+08"},
+                {"Asia/Ulaanbaatar","ULAT+08"},
+                {"Asia/Urumqi","CST+08"},
+                {"Asia/Vientiane","ICT+07"},
+                {"Asia/Vladivostok","VLAT+10VLAST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Yakutsk","YAKT+09YAKST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Yekaterinburg","YEKT+05YEKST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Asia/Yerevan","AMT+04AMST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Atlantic/Azores","AZOT-01AZOST+01,M3.5.0/00:00,M10.5.0/01:00"},
+                {"Atlantic/Bermuda","AST-04ADT+01,M4.1.0/02:00,M10.5.0/02:00"},
+                {"Atlantic/Canary","WET+00WEST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Atlantic/Cape_Verde","CVT-01"},
+                {"Atlantic/Faeroe","WET+00WEST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Atlantic/Jan_Mayen","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Atlantic/Madeira","WET+00WEST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Atlantic/Reykjavik","GMT+00"},
+                {"Atlantic/South_Georgia","GST-02"},
+                {"Atlantic/St_Helena","GMT+00"},
+                {"Atlantic/Stanley","FKT-04FKST+01,M9.1.0/02:00,M4.3.0/02:00"},
+                {"Australia/Adelaide","CST+09:30CST+01,M10.1.0/02:00,M4.1.0/03:00"},
+                {"Australia/Brisbane","EST+10"},
+                {"Australia/Broken_Hill","CST+09:30CST+01,M10.1.0/02:00,M4.1.0/03:00"},
+                {"Australia/Darwin","CST+09:30"},
+                {"Australia/Eucla","CWST+08:45"},
+                {"Australia/Hobart","EST+10EST+01,M10.1.0/02:00,M4.1.0/03:00"},
+                {"Australia/Lindeman","EST+10"},
+                {"Australia/Lord_Howe","LHST+10:30LHST+00:30,M10.1.0/02:00,M4.1.0/02:30"},
+                {"Australia/Melbourne","EST+10EST+01,M10.1.0/02:00,M4.1.0/03:00"},
+                {"Australia/Perth","WST+08"},
+                {"Australia/Sydney","EST+10EST+01,M10.1.0/02:00,M4.1.0/03:00"},
+                {"Europe/Amsterdam","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Andorra","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Athens","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Belfast","GMT+00BST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Europe/Belgrade","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Berlin","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Bratislava","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Brussels","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Bucharest","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Budapest","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Chisinau","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Copenhagen","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Dublin","GMT+00IST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Europe/Gibraltar","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Helsinki","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Istanbul","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Kaliningrad","EET+02EEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Kiev","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Lisbon","WET+00WEST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Europe/Ljubljana","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/London","GMT+00BST+01,M3.5.0/01:00,M10.5.0/02:00"},
+                {"Europe/Luxembourg","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Madrid","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Malta","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Minsk","EET+02EEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Monaco","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Moscow","MSK+03MSD+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Nicosia","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Oslo","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Paris","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Prague","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Riga","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Rome","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Samara","SAMT+04SAMST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/San_Marino","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Sarajevo","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Simferopol","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Skopje","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Sofia","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Stockholm","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Tallinn","EET+02"},
+                {"Europe/Tirane","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Uzhgorod","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Vaduz","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Vatican","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Vienna","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Vilnius","EET+02"},
+                {"Europe/Warsaw","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Zagreb","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Europe/Zaporozhye","EET+02EEST+01,M3.5.0/03:00,M10.5.0/04:00"},
+                {"Europe/Zurich","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00"},
+                {"Indian/Antananarivo","EAT+03"},
+                {"Indian/Chagos","IOT+06"},
+                {"Indian/Christmas","CXT+07"},
+                {"Indian/Cocos","CCT+06:30"},
+                {"Indian/Comoro","EAT+03"},
+                {"Indian/Kerguelen","TFT+05"},
+                {"Indian/Mahe","SCT+04"},
+                {"Indian/Maldives","MVT+05"},
+                {"Indian/Mauritius","MUT+04"},
+                {"Indian/Mayotte","EAT+03"},
+                {"Indian/Reunion","RET+04"},
+                {"Pacific/Apia","WST-11"},
+                {"Pacific/Auckland","NZST+12NZDT+01,M10.1.0/02:00,M3.3.0/03:00"},
+                {"Pacific/Chatham","CHAST+12:45CHADT+01,M10.1.0/02:45,M3.3.0/03:45"},
+                {"Pacific/Easter","EAST-06EASST+01,M10.2.6/22:00,M3.2.6/22:00"},
+                {"Pacific/Efate","VUT+11"},
+                {"Pacific/Enderbury","PHOT+13"},
+                {"Pacific/Fakaofo","TKT-10"},
+                {"Pacific/Fiji","FJT+12"},
+                {"Pacific/Funafuti","TVT+12"},
+                {"Pacific/Galapagos","GALT-06"},
+                {"Pacific/Gambier","GAMT-09"},
+                {"Pacific/Guadalcanal","SBT+11"},
+                {"Pacific/Guam","ChST+10"},
+                {"Pacific/Honolulu","HST-10"},
+                {"Pacific/Johnston","HST-10"},
+                {"Pacific/Kiritimati","LINT+14"},
+                {"Pacific/Kosrae","KOST+11"},
+                {"Pacific/Kwajalein","MHT+12"},
+                {"Pacific/Majuro","MHT+12"},
+                {"Pacific/Marquesas","MART-09:-30"},
+                {"Pacific/Midway","SST-11"},
+                {"Pacific/Nauru","NRT+12"},
+                {"Pacific/Niue","NUT-11"},
+                {"Pacific/Norfolk","NFT+11:30"},
+                {"Pacific/Noumea","NCT+11"},
+                {"Pacific/Pago_Pago","SST-11"},
+                {"Pacific/Palau","PWT+09"},
+                {"Pacific/Pitcairn","PST-08"},
+                {"Pacific/Ponape","PONT+11"},
+                {"Pacific/Port_Moresby","PGT+10"},
+                {"Pacific/Rarotonga","CKT-10"},
+                {"Pacific/Saipan","ChST+10"},
+                {"Pacific/Tahiti","TAHT-10"},
+                {"Pacific/Tarawa","GILT+12"},
+                {"Pacific/Tongatapu","TOT+13"},
+                {"Pacific/Truk","TRUT+10"},
+                {"Pacific/Wake","WAKT+12"},
+                {"Pacific/Wallis","WFT+12"},
+                {"Pacific/Yap","YAPT+10"}
+            };
+            const size_t n_tzdef= sizeof(tzdef)/sizeof(tz_region_def);
+            void tz_info_database::load_from_iso_db() {
+
+                region_tz_map.clear(); name_tz_map.clear();
+                for(size_t i=0;i<n_tzdef;++i) {
+                    add_tz_info(tzdef[i].region,tzdef[i].posix_definition);
+                }
+            }
+        } // time_zone
+
+        calendar::calendar(string region_id) {
+            for(size_t i=0;i<time_zone::n_tzdef;++i) {
+                if(region_id==time_zone::tzdef[i].region) {
+                    tz_info=time_zone::create_from_posix_definition(time_zone::tzdef[i].posix_definition);
+                }
+            }
+            if(!tz_info)
+                throw runtime_error(string("time zone region id '")+region_id+ string("' not found, use .region_id_list() to get configured time zones"));
+        }
+
+        vector<string> calendar::region_id_list() {
+            vector<string> r;
+            for(size_t i=0;i<time_zone::n_tzdef;++i) r.push_back(time_zone::tzdef[i].region);
+            return r;
+        }
+
     } // core
 } // shyft

--- a/core/utctime_utilities.h
+++ b/core/utctime_utilities.h
@@ -20,7 +20,7 @@ namespace shyft {
 		 * context, and at the cost of compile time (also consider the python/api part).
          */
 
-		#ifdef WIN32
+		#ifdef _WIN32
 		typedef long long utctime;          /// time_t is typedef'd as a __time64_t, which is an __int64., happens to be equal to EnkiTime
 		typedef long long utctimespan;      /// utctimespan is typdedef'd as a utctime (thus __int64)
 
@@ -121,7 +121,7 @@ namespace shyft {
                  */
                 template<typename Tz>
                 tz_table(const Tz& tz ,int start_year=1905,size_t n_years=200):start_year(start_year) {
-                    for(size_t y=start_year;y<start_year+n_years;++y) {
+                    for(int y=start_year;y<start_year+n_years;++y) {
                         dst.emplace_back(tz.dst_start(y),tz.dst_end(y));
                         dt.push_back(tz.dst_offset(y));
                     }
@@ -255,7 +255,7 @@ namespace shyft {
 			static const utctimespan SECOND = 1L;
 
 			static const int UnixDay = 2440588;///< Calc::julian_day_number(ymd(1970,01,01));
-			static const utctime UnixSecond = 86400L * (utctime)UnixDay;///<Calc::julian_day_number(ymd(1970,01,01));
+			static const utctime UnixSecond = 86400LL * (utctime)UnixDay;///<Calc::julian_day_number(ymd(1970,01,01));
 
 			// Snapped from boost gregorian_calendar.ipp
 			static inline unsigned long day_number(const YMDhms& ymd) {

--- a/core/utctime_utilities.h
+++ b/core/utctime_utilities.h
@@ -2,6 +2,9 @@
 #include <string>
 #include <time.h>
 #include <cmath>
+#include <vector>
+#include <map>
+#include <memory>
 
 namespace shyft {
 	namespace core {
@@ -11,7 +14,10 @@ namespace shyft {
 		 * on the timeaxis, utc. Timeaxis zero is at 1970-01-01 00:00:00 (unix time).
 		 * resolution is 1 second, integer.
 		 * also define min max and no_utctime
-		 * The advantage with the definition well defined and commonly known in all C++ platforms
+		 *
+		 * The advantage with the definition is that it is well defined and commonly known in all platforms
+		 * Also considered: moving to std::chrono, would enable a strict time arithmetic regime, of little advantage in this
+		 * context, and at the cost of compile time (also consider the python/api part).
          */
 
 		#ifdef WIN32
@@ -23,17 +29,6 @@ namespace shyft {
 				typedef long utctimespan;   /// utctimespan is typdedef'd as a utctime (thus __int64)
 		#endif
 
-
-		namespace convert {
-			const double COleDateTime1970Offset = 25569.0;
-			static inline double to_COleDateTime(utctime t) {
-				return COleDateTime1970Offset + t/(86400.0);
-			}
-			static inline utctime to_utctime(double t)
-            {
-				return (utctime)floor((t - COleDateTime1970Offset)*86400.0 + 0.5);
-			}
-		}
         /** \brief deltahours
          * \param n number of hours
          * \return utctimespan representing number of hours specified
@@ -49,9 +44,9 @@ namespace shyft {
         /** \brief max_utctime represent the maximum utctime
          */
 		const		utctime max_utctime	= (utctime) (0x7FFFFFFFFFFFFFFFL);	/// max 64bit int
+
         /** \brief min_utctime represent the minimum utctime (equal to -max_utctime)
          */
-
 		const		utctime min_utctime	= - max_utctime;  /// min 64bit int
 
         /** \brief no_utctime represents 'NaN' time, null time, not valid time
@@ -63,7 +58,7 @@ namespace shyft {
          */
 		inline utctime utctime_now() {return (utctime)time(0); }
 
-
+        inline bool is_valid(utctime t) {return t != no_utctime;}
 
         /** \brief utcperiod is defined
          *  as period on the utctime space, like
@@ -76,6 +71,9 @@ namespace shyft {
 			utctimespan timespan() const {	return end - start; }
 			bool valid() const { return start != no_utctime && end != no_utctime && start <= end; }
 			bool operator==(const utcperiod &p) const { return start == p.start &&  end == p.end; }
+			bool operator!=(const utcperiod &p) const {return ! (*this==p);}
+			bool contains(utctime t) const {return is_valid(t)&&valid()?t>=start && t<end:false;}
+			bool overlaps(const utcperiod& p) const {return !( (p.start >= end) || (p.end <= start) )?true:false; }
 			utctime start;
 			utctime end;
 			std::string to_string() const;
@@ -83,7 +81,126 @@ namespace shyft {
             friend std::ostream& operator<<(std::ostream& os, const utcperiod& p);
 #endif
 		};
+		inline bool is_valid(const utcperiod &p) {return p.valid();}
 
+        namespace time_zone {
+            using namespace std;
+
+            /**\brief time_zone handling, basically just a wrapper that hides
+            * the fact we are using boost::date_time for getting/providing tz info
+            */
+            template<typename tz>
+            struct tz_info {
+                typedef tz tz_type_t;
+                string name() const {return "UTC";}
+                utctimespan base_offset() const {return utctimespan(0);}
+                utctimespan utc_offset(utctime t) const {return utctimespan(0);}
+                bool is_dst(utctime t) const {return false;}
+            };
+
+
+            /**\brief The tz_table is a table driven approach where each year in a specified range have
+             * a dst information containing start/end, and the applied dst offset.
+             * This approach allows to have historical correct dst-rules, at minor space/time overhead
+             * E.g. Norway, summertime rules are changed to EU defs. in 1996
+             * first time applied was 1916, then 1943-1945, then 1959-1965, then 1980-to 1996,
+             * where eu rules was introduced.
+             */
+            class tz_table {
+                int start_year;
+                string tz_name;
+                vector<utcperiod> dst;
+                vector<utctimespan> dt;
+
+              public:
+                /**\brief construct a tz_table using a information from provided Tz adapter
+                 *\tparam Tz a type that provids dst_start(year),dst_end(year), dst_offset(year)
+                 *\param tz const ref to provide tz information that will be used to construct a table driven interpretation
+                 *\param start_year default 1905 (limit of posix time is 1901) for which the dst table is constructed
+                 *\param n_years default 200 giving range from 1905 to 2105 with dst info.
+                 */
+                template<typename Tz>
+                tz_table(const Tz& tz ,int start_year=1905,size_t n_years=200):start_year(start_year) {
+                    for(size_t y=start_year;y<start_year+n_years;++y) {
+                        dst.emplace_back(tz.dst_start(y),tz.dst_end(y));
+                        dt.push_back(tz.dst_offset(y));
+                    }
+                    tz_name=tz.name();
+                }
+                /**\brief construct a simple dst infotable with no dst, just tz-offset
+                * suitable for non-dst time-zones and data-exchange.
+                * \param dt of type utctimespan, positive for tz east of GMT
+                */
+                tz_table(utctimespan dt):start_year(0) {
+                    char s[100];sprintf(s,"UTC%+02d",int(dt/deltahours(1)));
+                    tz_name=s;
+                }
+                inline bool is_dst() const {return dst.size()>0;}
+                string name() const {return tz_name;}
+                utctime dst_start(int year) const {return is_dst()?dst[year-start_year].start:no_utctime;}
+                utctime dst_end (int year) const {return is_dst()?dst[year-start_year].end:no_utctime;}
+                utctimespan dst_offset(utctime t) const ;
+            };
+
+            /**\brief a table driven tz_info, using the tz_table implementation */
+            template<>
+            struct tz_info<tz_table> {
+                utctimespan base_tz;
+                tz_table tz;
+                tz_info(utctimespan base_tz):base_tz(base_tz),tz(base_tz) {}
+                tz_info(utctimespan base_tz,const tz_table&tz):base_tz(base_tz),tz(tz) {}
+                string name() const {return tz.name();}
+                utctimespan base_offset() const {return base_tz;}
+                utctimespan utc_offset(utctime t) const {return base_tz + tz.dst_offset(t);}
+                bool is_dst(utctime t) const {return tz.dst_offset(t)!=utctimespan(0);}
+            };
+
+            typedef tz_info<tz_table> tz_info_t;///< tz_info type most general, supports all kinds of tz, at a minor extra cost.
+            typedef shared_ptr<tz_info_t> tz_info_t_;///< convinience, the shared ptr. version
+
+            /** \brief time zone database class that provides shared_ptr of predefined tz_info_t objects */
+            struct tz_info_database {
+
+                /** \brief load from compile time iso db as per boost 1.60 */
+                void load_from_iso_db();
+
+                /** \brief load from file that contains all descriptions, ref. boost::date_time for format */
+                void load_from_file(const string filename);
+
+                /** \brief add one entry, using a specified region_name like Europe/Copenhagen, and a posix description string, ref boost::date_time for spec */
+                void add_tz_info(string region_name,string posix_tz_string);
+
+                /** \brief returns a shared_ptr to tz_info_t given time-zone region name like Europe/Copenhagen */
+                shared_ptr<tz_info_t> tz_info_from_region(const string &region_name) const {
+                    auto f=region_tz_map.find(region_name);
+                    if( f!= region_tz_map.end()) return f->second;
+                    throw runtime_error(string("tz region '")+region_name + string("' not found"));
+                }
+
+                /** \brief returns a shared_ptr to tz_info_t given time-zone name like CET */
+                shared_ptr<tz_info_t> tz_info_from_name(const string &name) const {
+                    auto f=name_tz_map.find(name);
+                    if( f!= name_tz_map.end()) return f->second;
+                    throw runtime_error(string("tz name '")+name + string("' not found"));
+                }
+                vector<string> get_region_list() const {
+                    vector<string> r;r.reserve(region_tz_map.size());
+                    for(const auto& c:region_tz_map)
+                        r.push_back(c.first);
+                    return r;
+                }
+                vector<string> get_name_list() const {
+                    vector<string> r;r.reserve(region_tz_map.size());
+                    for(const auto& c:name_tz_map)
+                        r.push_back(c.first);
+                    return r;
+                }
+
+                map<string,shared_ptr<tz_info_t>> region_tz_map;///< map from Europe/Copenhagen to tz
+                map<string,shared_ptr<tz_info_t>> name_tz_map;///< map from CET to tz (same tz as Europe/Copenhagen)
+            };
+
+        }
         /** \brief YMDhms, simple structure that contains calendar coordinates.
          * Contains year,month,day,hour,minute, second,
          * for ease of constructing utctime.
@@ -91,6 +208,8 @@ namespace shyft {
          *
          */
 		struct YMDhms {
+            static const int YEAR_MAX= 9999;
+            static const int YEAR_MIN=-9999;
 			YMDhms():year(0), month(0), day(0), hour(0), minute(0), second(0) {}
 			YMDhms(int Y, int M=1, int D=1, int h=0, int m=0, int s=0) : year(Y), month(M), day(D), hour(h), minute(m), second(s)  {
                 if(!is_valid())
@@ -99,7 +218,7 @@ namespace shyft {
 
 			int year; int month; int day; int hour; int minute; int second;
 			///< just check that YMDhms are within reasonable ranges,\note it might still be an 'invalid' date!
-			bool is_valid_coordinates() const {return !(year<-9999 || year>9999 || month<1 || month>12 ||day<1 || day>31 ||hour<0 || hour>23 || minute<0 ||minute>59||second<0 ||second>59);}
+			bool is_valid_coordinates() const {return !(year<YEAR_MIN || year>YEAR_MAX || month<1 || month>12 ||day<1 || day>31 ||hour<0 || hour>23 || minute<0 ||minute>59||second<0 ||second>59);}
             ///< if a 'null' or valid_coordinates
 			bool is_valid() const { return is_null() || is_valid_coordinates(); }
 			bool is_null() const { return year == 0 && month == 0 && day == 0 && hour == 0 && minute == 0 && second == 0; }
@@ -107,10 +226,9 @@ namespace shyft {
                 return x.year == year && x.month == month && x.day == day && x.hour == hour
                        && x.minute == minute && x.second == second;
             }
-			static YMDhms max() {return YMDhms(9999,12,31,23,59,59);}
-			static YMDhms min() {return YMDhms(-9999,12,31,23,59,59);}
+			static YMDhms max() {return YMDhms(YEAR_MAX,12,31,23,59,59);}
+			static YMDhms min() {return YMDhms(YEAR_MIN,12,31,23,59,59);}
 		};
-
         /** \brief Calendar deals with the concept of human calendar.
          *
          * Please notice that although the calendar concept is complete,
@@ -126,25 +244,29 @@ namespace shyft {
          * -# Converting utctime to string and vice-versa
          */
 		struct calendar {
+			// these do have calendar sematics(could/should be separate typed/enum instad)
 			static const utctimespan YEAR=365*24*3600L;
 			static const utctimespan MONTH=30*24*3600L;
 			static const utctimespan WEEK = 7*24*3600L;
 			static const utctimespan DAY =  1*24*3600L;
+			// these are just timespan constants with no calendar semantics
 			static const utctimespan HOUR = 3600L;
 			static const utctimespan MINUTE = 60L;
 			static const utctimespan SECOND = 1L;
-			static const int UnixDay = 2440588;//Calc::julian_day_number(ymd(1970,01,01));
-			static const utctime UnixSecond = 86400L * (utctime)UnixDay;//Calc::julian_day_number(ymd(1970,01,01));
+
+			static const int UnixDay = 2440588;///< Calc::julian_day_number(ymd(1970,01,01));
+			static const utctime UnixSecond = 86400L * (utctime)UnixDay;///<Calc::julian_day_number(ymd(1970,01,01));
 
 			// Snapped from boost gregorian_calendar.ipp
-			static unsigned long day_number(YMDhms ymd) {
+			static inline unsigned long day_number(const YMDhms& ymd) {
 				unsigned short a = static_cast<unsigned short>((14 - ymd.month) / 12);
 				unsigned short y = static_cast<unsigned short>(ymd.year + 4800 - a);
 				unsigned short m = static_cast<unsigned short>(ymd.month + 12 * a - 3);
 				unsigned long  d = ymd.day + ((153 * m + 2) / 5) + 365 * y + (y / 4) - (y / 100) + (y / 400) - 32045;
 				return d;
 			}
-			static YMDhms from_day_number(unsigned long dayNumber) {
+
+			static inline YMDhms from_day_number(unsigned long dayNumber) {
 				int a = dayNumber + 32044;
 				int b = (4 * a + 3) / 146097;
 				int c = a - ((146097 * b) / 4);
@@ -154,8 +276,6 @@ namespace shyft {
 				unsigned short day = static_cast<unsigned short>(e - ((153 * m + 2) / 5) + 1);
 				unsigned short month = static_cast<unsigned short>(m + 3 - 12 * (m / 10));
 				int year = static_cast<unsigned short>(100 * b + d - 4800 + (m / 10));
-				//std::cout << year << "-" << month << "-" << day << "\n";
-
 				return YMDhms(year, month, day);
 			}
 			static int day_number(utctime t) {
@@ -163,133 +283,132 @@ namespace shyft {
 			}
 			static inline utctimespan seconds(int h, int m, int s) { return h*HOUR + m*MINUTE + s*SECOND; }
 
+			time_zone::tz_info_t_ tz_info;
+			/**\brief construct a timezone with standard offset, no dst, name= UTC+01 etc. */
+			calendar(utctimespan tz=0): tz_info(new time_zone::tz_info_t(tz)) {}
+			/**\brief construct a timezone from tz_info shared ptr provided from typically time_zone db */
+			calendar(time_zone::tz_info_t_ tz_info):tz_info(tz_info) {}
 
-			utctimespan tz_offset;
-			calendar(utctimespan tz=0): tz_offset(tz) {}
-			utctime time(YMDhms c) const {
-			    if(c.is_null())
-                    return no_utctime;
-                if(c==YMDhms::max())
-                    return max_utctime;
-                if(c==YMDhms::min())
-                    return min_utctime;
-				if (!c.is_valid_coordinates())
-					throw std::runtime_error("Calendar.time with invalid YMDhms coordinates attempted");
-				return ((int(day_number(c)) - UnixDay)*DAY) + seconds(c.hour, c.minute, c.second) - tz_offset;
+            /**\brief construct a timezone based on region id
+             * uses internal tz_info_database to lookup the name.
+             * \param region_id, like Europe/Oslo, \sa time_zone::tz_info_database
+             */
+            calendar(std::string region_id);
+            /**\brief get list of available time zone region */
+            static std::vector<std::string> region_id_list();
+
+			/**\brief construct utctime from calendar coordinates YMDhms
+			 *
+			 * If the YMDhms is invalid, runtime_error is thrown.
+			 * Currently just trivial checks is done.
+			 *
+			 * \param c YMDhms that has to be valid calendar coordinates.
+			 * \note special values of YMDhms, like max,min,null is mapped to corresponding utctime concepts.
+			 * \sa YMDhms
+			 * \return utctime
+			 */
+			utctime time(YMDhms c) const;
+
+            ///<short hand for calendar::time(YMDhms)
+            utctime time(int Y,int M=1,int D=1,int h=0,int m=0,int s=0) const {
+                return time(YMDhms(Y,M,D,h,m,s));
+            }
+            /**\brief returns *utc_year* of t \note for internal dst calculations only */
+			static inline int utc_year(utctime t) {
+                if(t == no_utctime  ) throw std::runtime_error("year of no_utctime");
+                if(t == max_utctime ) return YMDhms::YEAR_MAX;
+                if(t == min_utctime ) return YMDhms::YEAR_MIN;
+				return from_day_number(day_number(t)).year;
 			}
-			YMDhms  calendar_units(utctime t) const {
-				if (t == no_utctime) {
-					return YMDhms();
-				}
-				if (t == max_utctime) {
-					return YMDhms::max();
-				}
-				if (t == min_utctime) {
-					return YMDhms::min();
-				}
-				t += tz_offset;
-				auto jdn = day_number(t);
-				auto x = from_day_number(jdn);
-				YMDhms r;
-				r.year = x.year; r.month = x.month; r.day = x.day;
-				utctime tj = UnixSecond + t;
-				utctime td = DAY*(tj / DAY);
-				utctimespan dx = tj - td;// n seconds this day.
-				r.hour = int(dx / HOUR);
-				dx -= r.hour*HOUR;
-				r.minute = int(dx / MINUTE);
-				r.second = int(dx % MINUTE);
-				return r;
-			}
+            /**\brief return the calendar units of t taking timezone and dst into account
+             *
+             * Special utctime values, no_utctime max_utctime, min_utctime are mapped to corresponding
+             * YMDhms special values.
+             * \sa YMDhms
+             * \return calendar units YMDhms
+             */
+			YMDhms  calendar_units(utctime t) const ;
 
 			///< returns  0=sunday, 1= monday ... 6=sat.
-			int day_of_week(utctime t) const {
-				if (t == no_utctime || t == min_utctime || t == max_utctime)
-					return -1;
-				auto ymd = calendar_units(t);
-				unsigned short a = static_cast<unsigned short>((14 - ymd.month) / 12);
-				unsigned short y = static_cast<unsigned short>(ymd.year - a);
-				unsigned short m = static_cast<unsigned short>(ymd.month + 12 * a - 2);
-				int d = static_cast<int>((ymd.day + y + (y / 4) - (y / 100) + (y / 400) + (31 * m) / 12) % 7);
-				return d;
-			}
+			int day_of_week(utctime t) const ;
+
 			///< returns day_of year, 1..365..
-			size_t day_of_year(utctime t) const {
-				if (t == no_utctime || t == max_utctime || t == min_utctime) return -1;
-				auto x = calendar_units(t );
-				YMDhms y(x.year, 1, 1);
-				return 1 + day_number(x) - day_number(y);
-			}
-			///< returns the month of t, 1..12
-			int month(utctime t) const {
-				if (t == no_utctime || t == max_utctime || t == min_utctime) return -1;
-				return calendar_units(t ).month;
-			}
+			size_t day_of_year(utctime t) const ;
 
+			///< returns the month of t, 1..12, -1 of not valid time
+			int month(utctime t) const ;
+
+            ///< returns a readable iso standard string
 			std::string to_string(utctime t) const;
+
+			///< returns a readable period with time as for calendar::to_string
 			std::string to_string(utcperiod p) const;
-			//utctime fromString(std::string datetime) const;
+
 			// calendar arithmetic
-			utctime trim(utctime t, utctimespan deltaT) const {
-				if (t == no_utctime || t == min_utctime || t == max_utctime)
-					return t;
-				switch (deltaT) {
-				case YEAR: {
-					auto c = calendar_units(t);
-					c.month = c.day = 1; c.hour = c.minute = c.second = 0;
-					return time(c);
-				}break;
-				case MONTH: {
-					auto c = calendar_units(t);
-					c.day = 1; c.hour = c.minute = c.second = 0;
-					return time(c);
-				}break;
-				case DAY: {
-					auto c = calendar_units(t);
-					c.hour = c.minute = c.second = 0;
-					return time(c);
-				}break;
-				}
-				const utctime t0 = utctime(3LL * DAY) + utctime(WEEK * 52L * 200LL);// + 3 days to get to a monday, then add 100 years, the point is, align to a week start.
-				t += t0 + tz_offset;
-				return deltaT*(t / deltaT) - t0 - tz_offset;
+			/**\brief round down (floor) to nearest utctime with deltaT resolution.
+			 *
+             * If delta T is calendar::DAY,WEEK,MONTH,YEAR it do a time-zone semantically
+             * correct rounding.
+             * if delta T is any other number, e.g. minute/hour, the result is similar to
+             * integer truncation at the level of delta T.
+             * \param t utctime to be trimmed
+             * \param deltaT utctimespan specifying the resolution, use calendar::DAY,WEEK,MONTH,YEAR specify calendar specific resolutions
+             * \return a trimmed utctime
+             */
+			utctime trim(utctime t, utctimespan deltaT) const ;
+
+			/**\brief calendar semantic add
+			 *
+			 *  conceptually this is similar to t + deltaT*n
+			 *  but with deltaT equal to calendar::DAY,WEEK,MONTH,YEAR
+			 *  and/or with dst enabled time-zone the variation of length due to dst
+			 *  or month/year length is taken into account
+			 *  e.g. add one day, and calendar have dst, could give 23,24 or 25 hours due to dst.
+			 *  similar for week or any other time steps.
+			 *
+			 *  \sa calendar::diff_units
+			 *
+			 *  \note DST -if the calendar include dst, following rules applies:
+			 *   -# transition hour 1st hour after dst has changed
+			 *   -# if t and resulting t have different utc-offsets, the result is adjusted dst adjustment with the difference.
+			 *
+			 *
+			 * \param t utctime
+			 * \param delta T utctimespan, that can be any, but with calendar::DAY,WEEK,MONTH,YEAR calendar semantics applies
+			 * \param n numer of delta T to add, can be negative
+			 * \return new calculated utctime
+			 */
+			utctime add(utctime t, utctimespan deltaT, long n) const ;
+
+			/**\brief calculate the distance t1..t2 in specified units
+			 *
+			 * The function takes calendar semantics when deltaT is calendar::DAY,WEEK,MONTH,YEAR,
+			 * and in addition also dst.
+			 * e.g. the diff_units of calendar::DAY over summer->winter shift is 1, remainder is 0,
+			 * even if the number of hours during those days are 23 and 25 summer and winter transition respectively
+			 *
+			 * \sa calendar::add
+			 *
+			 * \return (t2-t1)/deltaT, and remainder, where deltaT could be calendar units DAY,WEEK,MONTH,YEAR
+			 */
+			utctimespan diff_units(utctime t1, utctime t2, utctimespan deltaT, utctimespan &remainder) const ;
+			///< diff_units discarding remainder, \sa diff_units
+			utctimespan diff_units(utctime t1, utctime t2, utctimespan deltaT) const {
+			    utctimespan ignore;
+			    return diff_units(t1,t2,deltaT,ignore);
 			}
-			utctime add(utctime t, utctimespan deltaT, long n) const {
-				switch (deltaT) {
-				case YEAR:
-				case MONTH:
-					throw std::runtime_error("Not yet implemented");
-
-				}
-				return t + deltaT*n;// assume no dst yet
-			};
-			/// returns (t2-t1)/deltaT, and remainder, where deltaT could be calendar units Day,Week,Month,Year.
-			utctimespan diff_units(utctime t1, utctime t2, utctimespan deltaT, utctimespan &remainder) const {
-				if (t1 == no_utctime || t2 == no_utctime) {
-					remainder = 0L;
-					return 0L;
-				}
-				switch (deltaT) {
-					case calendar::MONTH:{
-						throw std::runtime_error("calendar::diff MONTH not supported");
-					}break;
-					case calendar::YEAR: {
-						throw std::runtime_error("calendar::diff YEAR not supported");
-					}break;
-
-				}
-
-				utctimespan dt = t2 - t1;
-				utctimespan r = dt / deltaT;
-				remainder = (dt - r*deltaT);
-				return r;
-			};
 		};
 
-		//utctime utctimeFromYMDhms(YMDhms c);
-
-
-
+        namespace time_zone {
+            inline utctimespan tz_table::dst_offset(utctime t) const {
+                if(!is_dst()) return  utctimespan(0);
+                auto year=calendar::utc_year(t);
+                if(year-start_year >= (int) dst.size()) return utctimespan(0);
+                auto s=dst_start(year);
+                auto e=dst_end(year);
+                return (s<e? (t>=s&&t<e):(t<e || t>=s))?dt[year-start_year]:utctimespan(0);
+            }
+        }
 
 	}
 }

--- a/shyft/repository/yaml_state_repository.py
+++ b/shyft/repository/yaml_state_repository.py
@@ -127,8 +127,9 @@ class YamlStateRepository(StateRepository):
                                        "".format(self._filename_item_separator))
         version = 0
         state_id = ""
-        # ms does not tolerate : in filenames
-        utc_timestamp_str = api.Calendar().to_string(utc_timestamp).replace(":", ".")
+        # ms does not tolerate : in filenames, and make dash to dots.
+        dt = api.Calendar().calendar_units(utc_timestamp)
+        utc_timestamp_str = "{:04d}.{:02d}.{:02d}T{:02d}.{:02d}.{:02d}".format(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
         while True:
             version += 1
             state_id = "{}{}{}{}{}.yaml".format(region_model_id,

--- a/shyft/tests/api/test_calendar_and_time.py
+++ b/shyft/tests/api/test_calendar_and_time.py
@@ -18,6 +18,45 @@ class Calendar(unittest.TestCase):
         self.utc = None
         self.std = None
 
+    def test_time_zone_region_id_list(self):
+        self.assertGreater(len(api.Calendar.region_id_list()), 1)
+
+    def test_create_calendar_from_region_id(self):
+        osl = api.Calendar("Europe/Oslo")
+        self.assertIsNotNone(osl)
+        self.assertEquals(osl.tz_info.name(), "CET")
+        self.assertEquals(osl.tz_info.base_offset(), 3600)
+        t = osl.time(2015, 6, 1)
+        self.assertTrue(osl.tz_info.is_dst(t))
+        self.assertTrue(osl.tz_info.utc_offset(t), 7200)
+
+    def test_calendar_add_and_diff_units(self):
+        osl = api.Calendar("Europe/Oslo")
+        t0 = osl.time(2016, 6, 1, 12, 0, 0)
+        t1 = osl.add(t0, api.Calendar.DAY, 7)
+        t2 = osl.add(t1, api.Calendar.WEEK, -1)
+        self.assertEqual(t0, t2)
+        self.assertEqual(7, osl.diff_units(t0, t1, api.Calendar.DAY))
+        self.assertEqual(1, osl.diff_units(t0, t1, api.Calendar.WEEK))
+        self.assertEqual(0, osl.diff_units(t0, t1, api.Calendar.MONTH))
+        self.assertEqual(7*24, osl.diff_units(t0, t1, api.deltahours(1)))
+
+    def test_calendar_add_during_dst(self):
+        osl = api.Calendar("Europe/Oslo")
+        t0 = osl.time(2016, 3, 27)  # dst change during spring
+        t1 = osl.add(t0, api.Calendar.DAY,  1)
+        t2 = osl.add(t1, api.Calendar.DAY, -1)
+        self.assertEqual(t0, t2)
+        self.assertEqual("2016-03-28T00:00:00+02", osl.to_string(t1))
+        self.assertEqual(1, osl.diff_units(t0, t1, api.Calendar.DAY))
+        self.assertEqual(23, osl.diff_units(t0, t1, api.Calendar.HOUR))
+        t0 = osl.time(2016, 10, 30)
+        t1 = osl.add(t0, api.Calendar.WEEK,  1)
+        t2 = osl.add(t1, api.Calendar.WEEK, -1)
+        self.assertEqual(t0, t2)
+        self.assertEqual("2016-11-06T00:00:00+01", osl.to_string(t1))
+        self.assertEqual(168+1, osl.diff_units(t0, t1, api.Calendar.HOUR))
+
     def test_trim_day(self):
         t = api.utctime_now()
         td = self.std.trim(t, api.Calendar.DAY)
@@ -51,23 +90,40 @@ class Calendar(unittest.TestCase):
         c1 = api.YMDhms(2000, 1, 2, 3, 4, 5)
         t = self.std.time(c1)
         s = self.std.to_string(t)
-        self.assertEqual(s, "2000.01.02T03:04:05")
+        self.assertEqual(s, "2000-01-02T03:04:05+01")
 
     def test_UtcPeriod_to_string(self):
         c1 = api.YMDhms(2000, 1, 2, 3, 4, 5)
         t = self.utc.time(c1)
         p = api.UtcPeriod(t, t + api.deltahours(1))
         s = p.to_string()
-        self.assertEqual(s, "[2000.01.02T03:04:05,2000.01.02T04:04:05>")
-        s2 = self.utc.to_string(p)
-        self.assertEqual(s2, "[2000.01.02T03:04:05,2000.01.02T04:04:05>")
+        self.assertEqual(s, "[2000-01-02T03:04:05Z,2000-01-02T04:04:05Z>")
+        s2 = self.std.to_string(p)
+        self.assertEqual(s2, "[2000-01-02T04:04:05+01,2000-01-02T05:04:05+01>")
 
     def test_UtcPeriod_str(self):
         c1 = api.YMDhms(2000, 1, 2, 3, 4, 5)
         t = self.utc.time(c1)
         p = api.UtcPeriod(t, t + api.deltahours(1))
         s = str(p)
-        self.assertEqual(s, "[2000.01.02T03:04:05,2000.01.02T04:04:05>")
+        self.assertEqual(s, "[2000-01-02T03:04:05Z,2000-01-02T04:04:05Z>")
+
+    def test_UtcPeriod_methods(self):
+        p0 = api.UtcPeriod()
+        px = api.UtcPeriod(self.utc.time(2010), self.utc.time(2000))
+        py = api.UtcPeriod(self.utc.time(2010), self.utc.time(2010))
+        p1 = api.UtcPeriod(self.utc.time(2015), self.utc.time(2016))
+        p2 = api.UtcPeriod(self.utc.time(2016), self.utc.time(2017))
+        p3 = api.UtcPeriod(p1.start, p2.end)
+        self.assertFalse(p0.valid())
+        self.assertFalse(px.valid())
+        self.assertTrue(py.valid())
+        self.assertTrue(p1.contains(p1.start))
+        self.assertFalse(p1.contains(p1.end))
+        self.assertFalse(p1.overlaps(p2))
+        self.assertFalse(p2.overlaps(p1))
+        self.assertTrue(p3.overlaps(p1))
+        self.assertTrue(p3.overlaps(p2))
 
     def test_swig_python_time(self):
         """
@@ -80,7 +136,7 @@ class Calendar(unittest.TestCase):
         # way through swig layer to python it goes via int32 and then to int64, proper signhandling
         #
         t_str = self.utc.to_string(t)  # this one just to show it's still working as it should internally
-        self.assertEquals(t_str, "1969.12.31T23:00:00")
+        self.assertEquals(t_str, "1969-12-31T23:00:00Z")
         self.assertEquals(t, api.deltahours(-1))
 
 

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -12,7 +12,7 @@
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="inverse_distance_test test_temperature_gradient_model" />
+				<Option parameters="utctime_utilities_test test_calendar_to_string" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>
@@ -20,7 +20,7 @@
 					<Add directory="../bin/Debug" />
 				</Linker>
 				<ExtraCommands>
-					<Add after="cd ../bin/Debug &amp;&amp; ./test_shyft  inverse_distance_test" />
+					<Add after="cd ../bin/Debug &amp;&amp; ./test_shyft  utctime_utilities_test" />
 					<Mode after="always" />
 				</ExtraCommands>
 			</Target>

--- a/test/utctime_utilities_test.cpp
+++ b/test/utctime_utilities_test.cpp
@@ -19,22 +19,47 @@ void utctime_utilities_test::test_utctime() {
     YMDhms r=c.calendar_units(utctime(0L));
     TS_ASSERT_EQUALS(r,unixEra);
 }
+void utctime_utilities_test::test_utcperiod() {
+    calendar utc;
+    utctime t0=utc.time(2015,1,1);
+    utctime t1=utc.time(2015,2,1);
+    utctime t2=t1-deltahours(1);
+    utctime t3=t1+deltahours(1);
+    TS_ASSERT(utcperiod(t0,t1).valid());
+    TS_ASSERT(is_valid(utcperiod())==false);
+    TS_ASSERT(utcperiod(t1,t0).valid()==false);
+    TS_ASSERT_EQUALS(utcperiod(t1,t2),utcperiod(t1,t2));
+    TS_ASSERT(utcperiod(t1,t2)!=utcperiod(t0,t1));
+    TS_ASSERT(utcperiod(t0,t1).contains(t0));
+    TS_ASSERT(utcperiod(t0,t1).contains(t1)==false);
+    TS_ASSERT(utcperiod(t0,t1).contains(no_utctime)==false);
+    TS_ASSERT(utcperiod().contains(t0)==false);
+    TS_ASSERT(utcperiod(t0,t1).overlaps(utcperiod(t1,t3))==false);
+    TS_ASSERT(utcperiod(t1,t3).overlaps(utcperiod(t0,t1))==false);
+    TS_ASSERT(utcperiod(t0,t1).overlaps(utcperiod(t2,t3))==true);
+    TS_ASSERT(utcperiod(t2,t3).overlaps(utcperiod(t0,t1))==true);
 
+
+
+}
 void utctime_utilities_test::test_calendar_trim() {
     // simple trim test
     calendar cet(deltahours(1));
     utctime t=cet.time(YMDhms(2012,3,8,12,16,44));
     YMDhms t_y  (2012, 1, 1, 0, 0, 0);
     YMDhms t_m  (2012, 3, 1, 0, 0, 0);
+    YMDhms t_w  (2012, 3, 5, 0, 0, 0);
     YMDhms t_d  (2012, 3, 8, 0, 0, 0);
     YMDhms t_h  (2012, 3, 8,12, 0, 0);
     YMDhms t_15m(2012, 3, 8,12,15, 0);
     TS_ASSERT_EQUALS(cet.calendar_units( cet.trim(t,calendar::YEAR)),t_y);
     TS_ASSERT_EQUALS(cet.calendar_units( cet.trim(t,calendar::MONTH)),t_m);
+    TS_ASSERT_EQUALS(cet.calendar_units( cet.trim(t,calendar::WEEK)), t_w);
     TS_ASSERT_EQUALS(cet.calendar_units( cet.trim(t,calendar::DAY)),t_d);
     TS_ASSERT_EQUALS(cet.calendar_units( cet.trim(t,calendar::HOUR)),t_h);
     TS_ASSERT_EQUALS(cet.calendar_units( cet.trim(t,deltaminutes(15))),t_15m);
 }
+
 
 void utctime_utilities_test::test_calendar_timezone() {
     YMDhms unixEra(1970,01,01,00,00,00);
@@ -43,10 +68,15 @@ void utctime_utilities_test::test_calendar_timezone() {
 }
 
 void utctime_utilities_test::test_calendar_to_string() {
-    calendar cet(deltahours(1));
-    utctime t=cet.time(YMDhms(2012,3,8,12,16,44));
-    string t_s= cet.to_string(t);
-    TS_ASSERT_EQUALS(t_s,string("2012.03.08T12:16:44"));
+    calendar utc;
+    calendar osl(deltahours(1));
+    calendar cet("Europe/Oslo");
+    calendar xxx("America/St_Johns");// -03.30
+    utctime t=utc.time(YMDhms(2012,5,8,12,16,44));
+    TS_ASSERT_EQUALS(utc.to_string(t),string("2012-05-08T12:16:44Z"));
+    TS_ASSERT_EQUALS(cet.to_string(t),string("2012-05-08T14:16:44+02"));
+    TS_ASSERT_EQUALS(osl.to_string(t),string("2012-05-08T13:16:44+01"));
+    TS_ASSERT_EQUALS(xxx.to_string(t),string("2012-05-08T09:46:44-02:30"));
 }
 
 void utctime_utilities_test::test_calendar_day_of_year() {
@@ -82,7 +112,7 @@ void utctime_utilities_test::test_YMDhms_reasonable_calendar_coordinates() {
 void utctime_utilities_test::test_calendar_add_and_diff_units() {
 	calendar cet(deltahours(1));
 	int n_units = 3;
-	utctimespan dts[] = { calendar::HOUR, calendar::DAY, calendar::WEEK };// MONTH YEAR is not supported/needed (yet)
+	utctimespan dts[] = { calendar::HOUR, calendar::DAY, calendar::WEEK, calendar::MONTH,calendar::YEAR };
 	auto t1 = cet.time(YMDhms(2012, 1, 1));
 	for (auto dt : dts) {
 		auto t2 = cet.add(t1, dt, n_units);
@@ -97,5 +127,128 @@ void utctime_utilities_test::test_calendar_day_of_week() {
 	calendar cet(deltahours(1));
 	for (int i = 0; i < 7;++i)
 		TS_ASSERT_EQUALS(i, cet.day_of_week(cet.time(YMDhms(2015, 8, 9+i, 10, 11, 12))));
+
+}
+
+void utctime_utilities_test::test_tz_info_db() {
+    using namespace shyft::core;
+    using namespace shyft::core::time_zone;
+    tz_info_database tz_info_db;
+    TS_ASSERT_THROWS_ANYTHING(tz_info_db.tz_info_from_region("Europe/Oslo"));
+    // create from iso zone description:"Europe/Oslo","CET","CET","CEST","CEST","+01:00:00","+01:00:00","-1;0;3","+02:00:00","-1;0;10","+03:00:00"
+    tz_info_db.add_tz_info("Europe/Oslo","CET+01CEST+01,M3.5.0/02:00,M10.5.0/03:00");
+    auto eu_osl=tz_info_db.tz_info_from_region("Europe/Oslo");
+    TS_ASSERT_EQUALS(eu_osl->name(),string("CET"));
+    calendar utc;
+    TS_ASSERT_EQUALS(eu_osl->is_dst(utc.time(YMDhms(2016, 3,27, 0,59,59))),false);// second before..
+    TS_ASSERT_EQUALS(eu_osl->is_dst(utc.time(YMDhms(2016, 3,27, 1, 0, 0))),true); // exactly at shift into summer
+    TS_ASSERT_EQUALS(eu_osl->is_dst(utc.time(YMDhms(2016,10,30, 0,59,59))),true); // second before..
+    TS_ASSERT_EQUALS(eu_osl->is_dst(utc.time(YMDhms(2016,10,30, 1, 0, 0))),false);// exactly at shift into winter
+    tz_info_database tz_iso_db;// do some minor testing of the internal iso tz db.
+    tz_iso_db.load_from_iso_db();
+    auto eu_osl_iso=tz_iso_db.tz_info_from_region("Europe/Oslo");
+    TS_ASSERT_EQUALS(eu_osl_iso->name(),string("CET"));
+    TS_ASSERT_EQUALS(eu_osl_iso->is_dst(utc.time(YMDhms(2016, 3,27, 0,59,59))),false);// second before..
+    TS_ASSERT_EQUALS(eu_osl_iso->is_dst(utc.time(YMDhms(2016, 3,27, 1, 0, 0))),true); // exactly at shift into summer
+    TS_ASSERT_EQUALS(eu_osl_iso->is_dst(utc.time(YMDhms(2016,10,30, 0,59,59))),true); // second before..
+    TS_ASSERT_EQUALS(eu_osl_iso->is_dst(utc.time(YMDhms(2016,10,30, 1, 0, 0))),false);// exactly at shift into winter
+
+}
+void utctime_utilities_test::test_add_over_dst_transitions() {
+    using namespace shyft::core;
+    using namespace shyft::core::time_zone;
+    tz_info_database tz_info_db;
+    tz_info_db.load_from_iso_db();
+    /// case 1: 23hour day, winter to summer shift.
+    auto cet_info=tz_info_db.tz_info_from_region("Europe/Oslo");
+    calendar cet(cet_info);
+    calendar utc;
+    utctime t0=cet.time(YMDhms(2016, 3,27,0,0,0));
+    utctime t1=cet.add(t0,calendar::DAY,1);
+    utctime t2=cet.add(t1,calendar::DAY,-1);
+    TS_ASSERT_EQUALS(t1,cet.time(YMDhms(2016,3,28)));
+    utctimespan rem(0);
+    auto n_units=cet.diff_units(t0,t1,calendar::DAY,rem);
+    TS_ASSERT_EQUALS(1,n_units);//its a local day diffeerence!
+    TS_ASSERT_EQUALS(rem,utctimespan(0));// no remainder
+    TS_ASSERT_EQUALS(deltahours(23),(t1-t0));// the miracle, it's 23 hours.
+    TS_ASSERT_EQUALS(t0,t2);
+    /// case 2: 25 hour, summer->winter
+    t0 = cet.time(YMDhms(2016,10,30));
+    t1 = cet.add(t0,calendar::DAY,1);
+    t2 = cet.add(t1,calendar::DAY,-1);
+    n_units = cet.diff_units(t0,t1,calendar::DAY,rem);
+    TS_ASSERT_EQUALS(1,n_units);//its a local day diffeerence!
+    TS_ASSERT_EQUALS(rem,utctimespan(0));// no remainder
+    TS_ASSERT_EQUALS(deltahours(25),(t1-t0));// the miracle, it's 25 hours.
+    TS_ASSERT_EQUALS(t0,t2);
+
+}
+
+void utctime_utilities_test::test_calendar_trim_with_dst() {
+    using namespace shyft::core;
+    using namespace shyft::core::time_zone;
+    tz_info_database tz_info_db;
+    tz_info_db.load_from_iso_db();
+    /// case 1: 23hour day, winter to summer shift.
+    auto cet_info=tz_info_db.tz_info_from_region("Europe/Oslo");
+    calendar cet(cet_info);// simple trim test
+    utctime t=cet.time(YMDhms(2016,3,27, 0,0,0));// day of dst winter->summer
+    for(int h=0;h<23;++h) {
+        TS_ASSERT_EQUALS(cet.to_string(t),cet.to_string(cet.trim(t+deltahours(h),calendar::DAY)));// 23 hours should go down here.
+        TS_ASSERT_EQUALS(cet.time(YMDhms(2016,3,21)),cet.trim(t+deltahours(h),calendar::WEEK));// should all end on monday 21st.
+    }
+    TS_ASSERT_EQUALS(cet.time(YMDhms(2016,3,28)),cet.trim(t+deltahours(23),calendar::DAY));
+    TS_ASSERT_EQUALS(cet.time(YMDhms(2016,3,28)),cet.trim(t+deltahours(23),calendar::WEEK));
+    /// case 2: 25 hour day, summer to winter
+    t=cet.time(YMDhms(2016,10,30, 0,0,0));// day of dst summer->winter
+    for(int h=0;h<25;++h) {
+        TS_ASSERT_EQUALS(cet.to_string(t),cet.to_string(cet.trim(t+deltahours(h),calendar::DAY)));// 25 hours should go down here.
+        TS_ASSERT_EQUALS(cet.time(YMDhms(2016,10,24)),cet.trim(t+deltahours(h),calendar::WEEK));// should all end on monday 21st.
+    }
+    TS_ASSERT_EQUALS(cet.time(YMDhms(2016,10,31)),cet.trim(t+deltahours(25),calendar::DAY));
+    TS_ASSERT_EQUALS(cet.time(YMDhms(2016,10,31)),cet.trim(t+deltahours(25),calendar::WEEK));
+
+
+}
+void utctime_utilities_test::test_add_months() {
+    using namespace shyft::core;
+    using namespace shyft::core::time_zone;
+    tz_info_database tz_info_db;
+    tz_info_db.load_from_iso_db();
+    for(auto& rtz:tz_info_db.region_tz_map) {
+        auto cet_info=tz_info_db.tz_info_from_region(rtz.first);
+        //cout<<"testing :"<<rtz.first<<endl;
+        calendar cet(cet_info);
+        calendar cal;
+        /// case 1: trival just add increasing number of months, and insist on other time-parameters are constant.
+        for(int month=1;month<13;++month) {
+            for(int day=1;day<29;day+=3) {
+                YMDhms dt0(2015,month,day,15,45,35);
+                utctime t0=cet.time(dt0);
+                for(int m=0;m<12*5;m+=7) {
+                    auto t1=cet.add(t0,calendar::MONTH, m);
+                    utctimespan remainder;
+                    auto n_m=cet.diff_units(t0,t1,calendar::MONTH,remainder);
+                    TS_ASSERT_EQUALS(remainder,utctimespan(0));// should match exactly
+                    TS_ASSERT_EQUALS(n_m,m);
+                    n_m= cet.diff_units(t1,t0,calendar::MONTH,remainder);
+                    TS_ASSERT_EQUALS(remainder,utctimespan(0));// should match exactly
+                    TS_ASSERT_EQUALS(n_m,-m);
+                    auto t2=cet.add(t1,calendar::MONTH,-m);
+                    auto dt1=cet.calendar_units(t1);
+                    if( t0 != t2 ) {
+                        // cout << "case "<< cet.to_string(t0)<<" vs "<<cet.to_string(t2)<<" error at m="<<m<<"d="<<day<<" diff is "<<t0-t2<<endl;
+                        TS_ASSERT_EQUALS(t0,t2);
+                        return;
+                    }
+                    TS_ASSERT_EQUALS(t0,t2);
+                    dt1.month=dt0.month;//just put back this one to ease comparison, all other should be equal
+                    dt1.year=dt0.year;
+                    TS_ASSERT_EQUALS(cet.to_string(cet.time(dt1)),cet.to_string(cet.time(dt0)));
+                }
+            }
+        }
+    }
 
 }

--- a/test/utctime_utilities_test.h
+++ b/test/utctime_utilities_test.h
@@ -4,6 +4,7 @@
 class utctime_utilities_test: public CxxTest::TestSuite {
     public:
     void test_utctime();
+    void test_utcperiod();
     void test_calendar_timezone();
     void test_calendar_to_string();
     void test_calendar_day_of_year();
@@ -12,6 +13,10 @@ class utctime_utilities_test: public CxxTest::TestSuite {
 	void test_calendar_trim();
 	void test_calendar_add_and_diff_units();
 	void test_YMDhms_reasonable_calendar_coordinates();
+	void test_add_over_dst_transitions();
+	void test_tz_info_db();
+	void test_calendar_trim_with_dst();
+	void test_add_months();
 };
 
 


### PR DESCRIPTION
The utctime and calendar library now supports timezone and DST.

The changes are backward compatible, and **the only difference from previous version** is that the to_string() methods now returns ISO8601 formatted strings. The formatting can be further extended utilizing python built-in libraries later.

e.g: Previous utc : 2015.02.03T12:30:00 now gives tz indicator  2015-02-03T12:30:00Z

This includes _calendar semantics_ for the .add(), .diff_units() and .trim() methods.

Briefly this means that adding a calendar day to a time, could mean adding 23,24 or 25 hours if the calendar observes dst. For details on the python side, ref. to test in test_calendar_and_time.py.

One example to illustrate it:
`

       def test_calendar_add_during_dst(self):
        osl = api.Calendar("Europe/Oslo")
        t0 = osl.time(2016, 3, 27)  # dst change during spring
        t1 = osl.add(t0, api.Calendar.DAY,  1)
        t2 = osl.add(t1, api.Calendar.DAY, -1)
        self.assertEqual(t0, t2)
        self.assertEqual("2016-03-28T00:00:00+02", osl.to_string(t1))
        self.assertEqual(1, osl.diff_units(t0, t1, api.Calendar.DAY))
        self.assertEqual(23, osl.diff_units(t0, t1, api.Calendar.HOUR))
        t0 = osl.time(2016, 10, 30)
        t1 = osl.add(t0, api.Calendar.WEEK,  1)
        t2 = osl.add(t1, api.Calendar.WEEK, -1)
        self.assertEqual(t0, t2)
        self.assertEqual("2016-11-06T00:00:00+01", osl.to_string(t1))
        self.assertEqual(168+1, osl.diff_units(t0, t1, api.Calendar.HOUR))
`



The .to_string() method also uses tz_info to provide an ISO 8601 standard formatting of time.

Internally, the time-zone information is provided by boost::date_time.

You can now create calendar with all standard rules like this

`
osl= api.Calendar('Europe/Oslo')
`

A complete list of built-in region_id (a complete list covering the globe) is available by 

`time_zone_region_id_list=api.Calendar.region_id_list()
`
The calendar now have a .tz_info member that have

- name() --> gives the short name of the time-zone (CET etc)
- base_offset() --> gives the standard utctimespan offset for the tz
- utc_offset(utctime t) --> gives the utc_offset for the specified t (depending on dst)
- is_dst(utctime t) --> true if dst is active at specified utctime t
