### PR TITLE
Changes to CatchmentFetcher in Statkraft's gis_region_model_repo

### DIFF
--- a/shyft/repository/service/gis_region_model_repository.py
+++ b/shyft/repository/service/gis_region_model_repository.py
@@ -253,11 +253,15 @@ class ReservoirFetcher(BaseGisDataFetcher):
 class CatchmentFetcher(BaseGisDataFetcher):
     def __init__(self, catchment_type, identifier, epsg_id):
         if catchment_type == 'regulated':
-            service_index = 7 # 6
-            # self.identifier = 'POWER_PLANT_ID'
+            if identifier == 'SUBCATCH_ID':
+                service_index = 4
+            elif identifier in ['CATCH_ID', 'POWER_PLANT_ID']:
+                service_index = 7
+            else:
+                raise GisDataFetchError(
+                    "Unknown identifier {} - use one of ['SUBCATCH_ID','CATCH_ID','POWER_PLANT_ID']".format(identifier))
         elif catchment_type == 'unregulated':
-            service_index = 8 # 7
-            # self.identifier = 'FELTNR'
+            service_index = 8
         else:
             raise GisDataFetchError(
                 "Undefined catchment type {} - use either regulated or unregulated".format(catchment_type))

--- a/shyft/tests/demo_statkraft_stuff.py
+++ b/shyft/tests/demo_statkraft_stuff.py
@@ -82,20 +82,24 @@ class GisRegionModelDemo(object):
         ax.set_ylim(geometry[1], geometry[3])
         plt.show()
 
-    def nea_nidelv(self):
+    def nea_nidelv(self, identifier):
         x0 = 270000.0
         y0 = 6960000.0
         dx = 1000
         dy = 1000
         nx = 105
         ny = 75
-        # test fetching for regulated catchments using CATCH_ID
-        id_list = [1228, 1308, 1394, 1443, 1726, 1867, 1996, 2041, 2129, 2195, 2198, 2277, 2402, 2446, 2465, 2545, 2640, 2718, 3002, 3536, 3630, 100010, 100011]
         # Finnkoisjøen, Hersjøen, Lødølja, Nesjøen, Nidarvoll, Sakristian, Selbu II, Sellisjøen, Stuggusjøen, Sylsjøen II, Sørungen, Trondheim-Voll
         #s_list = [121, 217, 360, 421, 423, 489, 503, 506, 574, 598, 610, 632] # Old OBJECTID
         # Finnkoisjøen, Hersjøen, Lødølja, Nesjøen, Sakristian, Selbu II, Sellisjøen, Stuggusjøen, Sylsjøen II, Sørungen, Trondheim-Voll
         s_list = [666, 3, 68, 605, 479, 454, 489, 460, 402, 538, 555] # Updated OBJECTID
-        self.plot_region_model('regulated', 'CATCH_ID', x0, y0, dx, dy, nx, ny, id_list, s_list, 32633)
+        if identifier == 'CATCH_ID':
+            # test fetching for regulated catchments using CATCH_ID
+            id_list = [1228, 1308, 1330, 1394, 1443, 1726, 1867, 1966, 1996, 2041, 2129, 2195, 2198, 2277, 2402, 2446, 2465, 2545, 2640, 2728, 2718, 3002, 3178, 3536, 3630, 100010, 100011]
+        if identifier == 'SUBCATCH_ID':
+            # test fetching for regulated catchments using SUBCATCH_ID
+            id_list = [188, 196, 180, 191, 187, 190, 172, 177, 174, 185, 175, 176, 183, 179, 197, 171, 181, 182, 184, 186, 189, 192, 194, 195, 752, 173, 195, 193]
+        self.plot_region_model('regulated', identifier, x0, y0, dx, dy, nx, ny, id_list, s_list, 32633)
 
     def vinjevatn(self):
         x0 = 73000.0
@@ -137,5 +141,5 @@ if __name__ == '__main__':
     demo = GisRegionModelDemo()
     # demo.tistel_32()
     # demo.tistel_arome()
-    demo.nea_nidelv()
+    demo.nea_nidelv('CATCH_ID')
     # demo.vinjevatn()


### PR DESCRIPTION
Changes to CatchmentFetcher in Statkraft's gis_region_model_repo to enable using SUBCATCH_ID as subcatchment identifier.