### PR TITLE
IDW precipitation.scale_factor cleaned up and documented

### DIFF
--- a/api/boostpython/api_interpolation.cpp
+++ b/api/boostpython/api_interpolation.cpp
@@ -56,11 +56,12 @@ namespace expose {
 
         typedef shyft::core::inverse_distance::precipitation_parameter IDWPrecipitationParameter;
         class_<IDWPrecipitationParameter,bases<IDWParameter>>("IDWPrecipitationParameter",
-                    "For precipitation,the scaling model needs the increase in precipitation for each 100 meters.\n"
+                    "For precipitation,the scaling model needs the scale_factor.\n"
+                    "adjusted_precipitation = precipitation* (scale_factor)^(z-distance-in-meters/100.0)\n"
                     "Ref to IDWParameter for the other parameters\n"
             )
-            .def(init<double,optional<int,double>>(args("increase_pct_m", "max_members","max_distance"),"create IDW from supplied parameters"))
-            .def_readwrite("scale_factor",&IDWPrecipitationParameter::scale_factor,"mm/m,  default=1.02, mm/m, corresponding to 2 mm increase pr. 100 m height")
+            .def(init<double,optional<int,double>>(args("scale_factor", "max_members","max_distance"),"create IDW from supplied parameters"))
+            .def_readwrite("scale_factor",&IDWPrecipitationParameter::scale_factor," ref. formula for adjusted_precipitation,  default=1.02")
         ;
     }
     static void interpolation_parameter() {

--- a/core/inverse_distance.h
+++ b/core/inverse_distance.h
@@ -52,12 +52,14 @@ namespace shyft {
 
 	        /*\brief For precipitation,the scaling model needs the increase in precipitation for each 100 meters.
 			 * \sa temperature_model
+			 * precipitation_adjusted = (scale_factor)^(z-distance-in-meters/100.0)
+			 *
 	        */
 	        struct precipitation_parameter: public parameter {
 	            double scale_factor;
-	            precipitation_parameter(double increase_pct_m=2, size_t max_members=20, double max_distance=200000.0)
-	              : parameter(max_members, max_distance), scale_factor(1+increase_pct_m/100) {}
-	            double precipitation_scale_factor() const { return scale_factor; } // mm/m,  0.5 mm increase pr. 100 m height
+	            precipitation_parameter(double scale_factor=1.02, size_t max_members=20, double max_distance=200000.0)
+	              : parameter(max_members, max_distance), scale_factor(scale_factor) {}
+	            double precipitation_scale_factor() const { return scale_factor; }
 	        };
 
 

--- a/shyft/.idea/misc.xml
+++ b/shyft/.idea/misc.xml
@@ -10,5 +10,8 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.4.3 (C:\Anaconda\python.exe)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.4.3 (/opt/anaconda/bin/python3.4)" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="1" />
+  </component>
 </project>

--- a/shyft/.idea/shyft.iml
+++ b/shyft/.idea/shyft.iml
@@ -10,7 +10,7 @@
       <excludeFolder url="file://$MODULE_DIR$/../core/obj" />
       <excludeFolder url="file://$MODULE_DIR$/../test/obj" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.4.3 (C:\Anaconda\python.exe)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.4.3 (/opt/anaconda/bin/python3.4)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -130,7 +130,7 @@ class RegionModel(unittest.TestCase):
         model_interpolation_parameter.temperature_idw.distance_measure_factor = 1.0
         # This enables IDW with default temperature gradient.
         model_interpolation_parameter.use_idw_for_temperature = True
-
+        self.assertAlmostEqual(model_interpolation_parameter.precipitation.scale_factor,1.02)  # just verify this one is as before change to scale_factor
         model.run_interpolation(
                 model_interpolation_parameter, time_axis,
                 self.create_dummy_region_environment(time_axis,


### PR DESCRIPTION
As Yisak poinited out, the constructor and attribute of the IDW precipitation parameters did not match.
This is now fixed, and documentation added accordingly.
The constructor now takes scale_factor, -as is the property of the parameter also.

The formula is
adj.precipitation := precipitation * (scale_factor) ^ ( delta_z_in_meters/100.0)

Added test to verify the default is scale_factor = 1.02.
