### PR TITLE
calibration: add priestley taylor parameter 

### DIFF
--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -47,7 +47,7 @@ namespace shyft {
             kirchner_parameter_t  kirchner;
             precipitation_correction_parameter_t p_corr;
             ///<calibration support, needs vector interface to params, size is the total count
-            size_t size() const { return 19; }
+            size_t size() const { return 21; }
             ///<calibration support, need to set values from ordered vector
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -72,6 +72,8 @@ namespace shyft {
                 p_corr.scale_factor = p[i++];
                 gs.snow_cv_forest_factor=p[i++];
                 gs.snow_cv_altitude_factor=p[i++];
+				pt.albedo = p[i++];
+				pt.alpha = p[i++];
             }
 
             ///< calibration support, get the value of i'th parameter
@@ -96,6 +98,8 @@ namespace shyft {
                     case 16:return p_corr.scale_factor;
                     case 17:return gs.snow_cv_forest_factor;
                     case 18:return gs.snow_cv_altitude_factor;
+					case 19:return pt.albedo;
+					case 20:return pt.alpha;
                 default:
                     throw runtime_error("PTGSK Parameter Accessor:.get(i) Out of range.");
                 }
@@ -109,7 +113,8 @@ namespace shyft {
                     "TX","wind_scale","max_water","wind_const",
                     "fast_albedo_decay_rate","slow_albedo_decay_rate",
                     "surface_magnitude", "max_albedo", "min_albedo", "snowfall_reset_depth", "snow_cv",
-                    "glacier_albedo", "p_corr_scale_factor","snow_cv_forest_factor","snow_cv_altitude_factor"
+                    "glacier_albedo", "p_corr_scale_factor","snow_cv_forest_factor","snow_cv_altitude_factor",
+					"pt_albedo","pt_alpha"
                 };
                 if (i >= size())
                     throw runtime_error("PTGSK Parameter Accessor:.get_name(i) Out of range.");

--- a/core/pt_hs_k.h
+++ b/core/pt_hs_k.h
@@ -32,7 +32,6 @@ namespace shyft {
              : pt(pt), snow(snow), ae(ae), kirchner(kirchner), p_corr(p_corr) { /* Do nothing */ }
              			parameter(const parameter &c) : pt(c.pt), snow(c.snow), ae(c.ae), kirchner(c.kirchner), p_corr(c.p_corr) {}
 			parameter(){}
-			#ifndef SWIG
 			parameter& operator=(const parameter &c) {
                 if(&c != this) {
                     pt = c.pt;
@@ -43,9 +42,8 @@ namespace shyft {
                 }
                 return *this;
 			}
-			#endif
             ///< Calibration support, size is the total number of calibration parameters
-            size_t size() const { return 10; }
+            size_t size() const { return 12; }
 
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -61,6 +59,8 @@ namespace shyft {
                 snow.ts = p[i++];
                 snow.cfr = p[i++];
                 p_corr.scale_factor = p[i++];
+				pt.albedo = p[i++];
+				pt.alpha = p[i++];
             }
             //
             ///< calibration support, get the value of i'th parameter
@@ -76,6 +76,8 @@ namespace shyft {
                     case  7:return snow.ts;
                     case  8:return snow.cfr;
                     case  9:return p_corr.scale_factor;
+					case 10:return pt.albedo;
+					case 11:return pt.alpha;
                 default:
                     throw runtime_error("pt_hs_k parameter accessor:.get(i) Out of range.");
                 }
@@ -87,7 +89,9 @@ namespace shyft {
                 static const char *names[] = {
                     "c1", "c2", "c3", "ae_scale_factor",
                     "lw",
-                    "tx", "cx", "ts", "cfr", "p_corr_scale_factor"};
+                    "tx", "cx", "ts", "cfr", "p_corr_scale_factor",
+					"pt_albedo","pt_alpha"
+				};
                 if (i >= size())
                     throw runtime_error("pt_hs_k parameter accessor:.get_name(i) Out of range.");
                 return names[i];
@@ -124,7 +128,7 @@ namespace shyft {
         };
 
 
-#ifndef SWIG
+
         template<template <typename, typename> class A, class R, class T_TS, class P_TS, class WS_TS, class RH_TS, class RAD_TS, class T,
         class S, class GEOCELLDATA, class P, class SC, class RC >
         void run(const GEOCELLDATA& geo_cell_data,
@@ -205,7 +209,6 @@ namespace shyft {
             }
             response_collector.set_end_response(response);
         }
-#endif
     }
   } // core
 } // shyft

--- a/core/pt_ss_k.h
+++ b/core/pt_ss_k.h
@@ -32,7 +32,6 @@ namespace shyft {
 
 			parameter(const parameter &c) : pt(c.pt), snow(c.snow), ae(c.ae), kirchner(c.kirchner), p_corr(c.p_corr) {}
 			parameter(){}
-			#ifndef SWIG
 			parameter& operator=(const parameter &c) {
                 if(&c != this) {
                     pt = c.pt;
@@ -43,9 +42,8 @@ namespace shyft {
                 }
                 return *this;
 			}
-			#endif
             ///< Calibration support, size is the total number of calibration parameters
-            size_t size() const { return 13; }
+            size_t size() const { return 15; }
 
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -64,6 +62,8 @@ namespace shyft {
                 snow.ts = p[i++];
                 snow.cfr = p[i++];
                 p_corr.scale_factor = p[i++];
+				pt.albedo = p[i++];
+				pt.alpha = p[i++];
             }
             //
             ///< calibration support, get the value of i'th parameter
@@ -82,6 +82,9 @@ namespace shyft {
                     case 10:return snow.ts;
                     case 11:return snow.cfr;
                     case 12:return p_corr.scale_factor;
+					case 13:return pt.albedo;
+					case 14:return pt.alpha;
+
                 default:
                     throw runtime_error("pt_ss_k parameter accessor:.get(i) Out of range.");
                 }
@@ -93,7 +96,9 @@ namespace shyft {
                 static const char *names[] = {
                     "c1", "c2", "c3", "ae_scale_factor",
                     "alpha_0", "d_range", "unit_size", "max_water_fraction",
-                    "tx", "cx", "ts", "cfr", "p_corr_scale_factor"};
+                    "tx", "cx", "ts", "cfr", "p_corr_scale_factor",
+					"pt_albedo","pt_alpha"
+				};
                 if (i >= size())
                     throw runtime_error("pt_ss_k parameter accessor:.get_name(i) Out of range.");
                 return names[i];
@@ -129,7 +134,7 @@ namespace shyft {
             double total_discharge;
         };
 
-#ifndef SWIG
+
         template<template <typename, typename> class A, class R, class T_TS, class P_TS,
                  class WS_TS, class RH_TS, class RAD_TS, class T, class S, class GCD,
                  class P, class SC, class RC>
@@ -217,7 +222,6 @@ namespace shyft {
             }
             response_collector.set_end_response(response);
         }
-#endif
     } // pt_hs_k
   } // core
 } // shyft


### PR DESCRIPTION
This enable the alpha and albedo factor of priestley taylor to be calibrated.
pt_xx_k stacks now allow 2 more parameters for calibration.
