### PR TITLE
Calibration parameter names for pt_xx_k is now xx.parameter name

### DIFF
--- a/api/boostpython/pt_hs_k.cpp
+++ b/api/boostpython/pt_hs_k.cpp
@@ -34,7 +34,7 @@ namespace expose {
                 .def(init<const parameter&>(args("p"),"clone a parameter"))
                 .def_readwrite("pt",&parameter::pt,"priestley_taylor parameter")
 				.def_readwrite("ae", &parameter::ae, "actual evapotranspiration parameter")
-                .def_readwrite("snow",&parameter::snow,"hbv-snow parameter")
+                .def_readwrite("snow",&parameter::hs,"hbv-snow parameter")
                 .def_readwrite("kirchner",&parameter::kirchner,"kirchner parameter")
                 .def_readwrite("p_corr",&parameter::p_corr,"precipitation correction parameter")
                 .def("size",&parameter::size,"returns total number of calibration parameters")

--- a/api/boostpython/pt_ss_k.cpp
+++ b/api/boostpython/pt_ss_k.cpp
@@ -37,7 +37,7 @@ namespace expose {
                 .def(init<const parameter&>(args("p"),"clone a parameter"))
                 .def_readwrite("pt",&parameter::pt,"priestley_taylor parameter")
 				.def_readwrite("ae", &parameter::ae, "actual evapotranspiration parameter")
-                .def_readwrite("snow",&parameter::snow,"skaugen-snow parameter")
+                .def_readwrite("snow",&parameter::ss,"skaugen-snow parameter")
                 .def_readwrite("kirchner",&parameter::kirchner,"kirchner parameter")
                 .def_readwrite("p_corr",&parameter::p_corr,"precipitation correction parameter")
                 .def("size",&parameter::size,"returns total number of calibration parameters")

--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -109,12 +109,27 @@ namespace shyft {
             ///< calibration and python support, get the i'th parameter name
             string get_name(size_t i) const {
                 static const char *names[] = {
-                    "c1","c2","c3","ae_scale_factor",
-                    "TX","wind_scale","max_water","wind_const",
-                    "fast_albedo_decay_rate","slow_albedo_decay_rate",
-                    "surface_magnitude", "max_albedo", "min_albedo", "snowfall_reset_depth", "snow_cv",
-                    "glacier_albedo", "p_corr_scale_factor","snow_cv_forest_factor","snow_cv_altitude_factor",
-					"pt_albedo","pt_alpha"
+                    "kirchner.c1",
+                    "kirchner.c2",
+                    "kirchner.c3",
+                    "ae.ae_scale_factor",
+                    "gs.tx",
+                    "gs.wind_scale",
+                    "gs.max_water",
+                    "gs.wind_const",
+                    "gs.fast_albedo_decay_rate",
+                    "gs.slow_albedo_decay_rate",
+                    "gs.surface_magnitude",
+                    "gs.max_albedo",
+                    "gs.min_albedo",
+                    "gs.snowfall_reset_depth",
+                    "gs.snow_cv",
+                    "gs.glacier_albedo",
+                    "p_corr.scale_factor",
+                    "gs.snow_cv_forest_factor",
+                    "gs.snow_cv_altitude_factor",
+                    "pt.albedo",
+                    "pt.alpha"
                 };
                 if (i >= size())
                     throw runtime_error("PTGSK Parameter Accessor:.get_name(i) Out of range.");

--- a/core/pt_ss_k.h
+++ b/core/pt_ss_k.h
@@ -18,7 +18,7 @@ namespace shyft {
             typedef kirchner::parameter kirchner_parameter_t;
             typedef precipitation_correction::parameter precipitation_correction_parameter_t;
             pt_parameter_t pt;
-            snow_parameter_t snow;
+            snow_parameter_t ss;
             ae_parameter_t ae;
             kirchner_parameter_t  kirchner;
             precipitation_correction_parameter_t p_corr;
@@ -28,14 +28,14 @@ namespace shyft {
                       ae_parameter_t ae,
                       kirchner_parameter_t kirchner,
                       precipitation_correction_parameter_t p_corr)
-             : pt(pt), snow(snow), ae(ae), kirchner(kirchner), p_corr(p_corr) { /* Do nothing */ }
+             : pt(pt), ss(snow), ae(ae), kirchner(kirchner), p_corr(p_corr) { /* Do nothing */ }
 
-			parameter(const parameter &c) : pt(c.pt), snow(c.snow), ae(c.ae), kirchner(c.kirchner), p_corr(c.p_corr) {}
+			parameter(const parameter &c) : pt(c.pt), ss(c.ss), ae(c.ae), kirchner(c.kirchner), p_corr(c.p_corr) {}
 			parameter(){}
 			parameter& operator=(const parameter &c) {
                 if(&c != this) {
                     pt = c.pt;
-                    snow = c.snow;
+                    ss = c.ss;
                     ae = c.ae;
                     kirchner = c.kirchner;
                     p_corr = c.p_corr;
@@ -53,14 +53,14 @@ namespace shyft {
                 kirchner.c2 = p[i++];
                 kirchner.c3 = p[i++];
                 ae.ae_scale_factor = p[i++];
-                snow.alpha_0 = p[i++];
-                snow.d_range = p[i++];
-                snow.unit_size = p[i++];
-                snow.max_water_fraction = p[i++];
-                snow.tx = p[i++];
-                snow.cx = p[i++];
-                snow.ts = p[i++];
-                snow.cfr = p[i++];
+                ss.alpha_0 = p[i++];
+                ss.d_range = p[i++];
+                ss.unit_size = p[i++];
+                ss.max_water_fraction = p[i++];
+                ss.tx = p[i++];
+                ss.cx = p[i++];
+                ss.ts = p[i++];
+                ss.cfr = p[i++];
                 p_corr.scale_factor = p[i++];
 				pt.albedo = p[i++];
 				pt.alpha = p[i++];
@@ -73,14 +73,14 @@ namespace shyft {
                     case  1:return kirchner.c2;
                     case  2:return kirchner.c3;
                     case  3:return ae.ae_scale_factor;
-                    case  4:return snow.alpha_0;
-                    case  5:return snow.d_range;
-                    case  6:return snow.unit_size;
-                    case  7:return snow.max_water_fraction;
-                    case  8:return snow.tx;
-                    case  9:return snow.cx;
-                    case 10:return snow.ts;
-                    case 11:return snow.cfr;
+                    case  4:return ss.alpha_0;
+                    case  5:return ss.d_range;
+                    case  6:return ss.unit_size;
+                    case  7:return ss.max_water_fraction;
+                    case  8:return ss.tx;
+                    case  9:return ss.cx;
+                    case 10:return ss.ts;
+                    case 11:return ss.cfr;
                     case 12:return p_corr.scale_factor;
 					case 13:return pt.albedo;
 					case 14:return pt.alpha;
@@ -94,10 +94,21 @@ namespace shyft {
             ///< calibration and python support, get the i'th parameter name
             string get_name(size_t i) const {
                 static const char *names[] = {
-                    "c1", "c2", "c3", "ae_scale_factor",
-                    "alpha_0", "d_range", "unit_size", "max_water_fraction",
-                    "tx", "cx", "ts", "cfr", "p_corr_scale_factor",
-					"pt_albedo","pt_alpha"
+                    "kirchner.c1",
+                    "kirchner.c2",
+                    "kirchner.c3",
+                    "ae.ae_scale_factor",
+                    "snow.alpha_0",
+                    "snow.d_range",
+                    "snow.unit_size",
+                    "snow.max_water_fraction",
+                    "snow.tx",
+                    "snow.cx",
+                    "snow.ts",
+                    "snow.cfr",
+                    "p_corr.scale_factor",
+                    "pt.albedo",
+                    "pt.alpha"
 				};
                 if (i >= size())
                     throw runtime_error("pt_ss_k parameter accessor:.get_name(i) Out of range.");
@@ -191,7 +202,7 @@ namespace shyft {
                 response.pt.pot_evapotranspiration = pot_evap;
 
                 // Snow
-                skaugen_snow.step(period.timespan(), parameter.snow, temp, prec, rad, wind_speed, snow_state, response.snow);
+                skaugen_snow.step(period.timespan(), parameter.ss, temp, prec, rad, wind_speed, snow_state, response.snow);
 
                 // TODO: Snow transport
                 // At my pos xx mm of snow moves in direction d.


### PR DESCRIPTION
The parameter names for pt_xx_k (xx= gs, hs, ss) is now gs,hs,ss respectively for the snow routines.

The parameter.get_name(i) is now equal to the class attribute syntax, e.g. 
pt_hs_k.parameter.hs.tx is now "hs.tx"

