### PR TITLE
Enable caching of GIS geo_cell_data for SHyFT models

### DIFF
--- a/api/api.h
+++ b/api/api.h
@@ -581,34 +581,37 @@ namespace shyft {
      *
 	 */
 	struct geo_cell_data_io {
+        static size_t size() {return 11;}// number of doubles to store a gcd
+        static void push_to_vector(vector<double>&v,const geo_cell_data& gcd ){
+            v.push_back(gcd.mid_point().x);
+            v.push_back(gcd.mid_point().y);
+            v.push_back(gcd.mid_point().z);
+            v.push_back(gcd.area());
+            v.push_back(int(gcd.catchment_id()));
+            v.push_back(gcd.radiation_slope_factor());
+            v.push_back(gcd.land_type_fractions_info().glacier());
+            v.push_back(gcd.land_type_fractions_info().lake());
+            v.push_back(gcd.land_type_fractions_info().reservoir());
+            v.push_back(gcd.land_type_fractions_info().forest());
+            v.push_back(gcd.land_type_fractions_info().unspecified());// not really needed, since it can be computed from 1- theothers
+        }
+        static vector<double> to_vector(const geo_cell_data& gcd) {
+            vector<double> v;v.reserve(11);
+            push_to_vector(v,gcd);
+            return std::move(v);
+        }
+        static geo_cell_data from_raw_vector(const double *v) {
+            land_type_fractions ltf; ltf.set_fractions(v[6],v[7],v[8],v[9]);
+            //                               x    y    z    a    cid       rsl
+            return geo_cell_data(geo_point(v[0],v[1],v[2]),v[3],int(v[4]),v[5],ltf);
+        }
+        static geo_cell_data from_vector(const vector<double>&v) {
+            if(v.size()!= size())
+                throw invalid_argument("geo_cell_data_io::from_vector: size of vector must be equal to geo_cell_data_io::size()");
+            return from_raw_vector(v.data());
 
-        static string to_string(const geo_cell_data& gcd) {
-            char s[500];// 500 should be able to keep text of 12 double with 12 digits precicion
-            sprintf(s,"gcd(gpt(%.12lf,%.12lf,%.12lf),%.12lf,%d,%.12lf,ltf(%.12lf,%.12lf,%.12lf,%.12lf,%.12lf));",
-                    gcd.mid_point().x,gcd.mid_point().y,gcd.mid_point().z,
-                    gcd.area(),int(gcd.catchment_id()),gcd.radiation_slope_factor(),
-                    gcd.land_type_fractions_info().glacier(),
-                    gcd.land_type_fractions_info().lake(),
-                    gcd.land_type_fractions_info().reservoir(),
-                    gcd.land_type_fractions_info().forest(),
-                    gcd.land_type_fractions_info().unspecified());
-            return s;
         }
 
-        static geo_cell_data from_string(const char *s) {
-            double x,y,z;
-            double a;
-            int cid;
-            double rsf;
-            double g,l,r,f,u;
-            if( s==nullptr || sscanf(s,"gcd(gpt(%lf,%lf,%lf),%lf,%d,%lf,ltf(%lf,%lf,%lf,%lf,%lf));",
-                   &x,&y,&z,&a,&cid,&rsf,&g,&l,&r,&f,&u
-                   )!= 11)
-                throw invalid_argument("geo_cell_data string not well formatted");
-            land_type_fractions ltf;
-            ltf.set_fractions(g,l,r,f);
-            return geo_cell_data(geo_point(x,y,z),a,cid,rsf,ltf);
-        }
 
     };
   } // Namespace api

--- a/api/boostpython/api_actual_evapotranspiration.cpp
+++ b/api/boostpython/api_actual_evapotranspiration.cpp
@@ -16,14 +16,14 @@ namespace expose {
             .def_readwrite("ae",&response::ae)
             ;
         def("ActualEvapotranspirationCalculate_step",calculate_step,args("water_level","potential_evapotranspiration","scale_factor","snow_fraction","dt"),
-             " actual_evapotranspiration calculates actual evapotranspiration for a timestep dt\n"
+             " actual_evapotranspiration calculates actual evapotranspiration for a timestep dt[s]\n"
              " based on supplied parameters\n"
              "\n"
-             " * param water_level\n"
-             " * param potential_evapotranspiration\n"
-             " * param scale_factor typically 1.5\n"
+             " * param water_level[mm]\n"
+             " * param potential_evapotranspiration[mm/x]\n"
+             " * param scale_factor typically 1.5[mm]\n"
              " * param snow_fraction 0..1\n"
-             " * return calculated actual evapotranspiration\n"
+             " * return calculated actual evapotranspiration[mm/x]\n"
              "\n"
             );
     }

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -78,7 +78,7 @@ namespace expose {
             DEF_STD_TS_STUFF()
             // expose time_axis sih: would liek to use property, but no return value policy, so we use get_ + fixup in init.py
             .def("get_time_axis",&shyft::api::apoint_ts::time_axis,"returns the time-axis",return_internal_reference<>())
-            .add_property("values",&shyft::api::apoint_ts::values,"return the values (possibly calculated on the fly")
+            .add_property("values",&shyft::api::apoint_ts::values,"return the values (possibly calculated on the fly)")
             // operators
             .def(self * self)
             .def(double() * self )

--- a/shyft/.idea/misc.xml
+++ b/shyft/.idea/misc.xml
@@ -10,7 +10,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.4.3 (C:\Anaconda\python.exe)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.4.3 (/opt/anaconda/bin/python3.4)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="1" />
   </component>

--- a/shyft/.idea/shyft.iml
+++ b/shyft/.idea/shyft.iml
@@ -10,7 +10,7 @@
       <excludeFolder url="file://$MODULE_DIR$/../core/obj" />
       <excludeFolder url="file://$MODULE_DIR$/../test/obj" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.4.3 (C:\Anaconda\python.exe)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.4.3 (/opt/anaconda/bin/python3.4)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/shyft/api/__init__.py
+++ b/shyft/api/__init__.py
@@ -81,6 +81,8 @@ Timeseries.time_axis = property(lambda self: self.get_time_axis(), doc="returns 
 Timeseries.__len__ = lambda self: self.size()
 Timeseries.time_shift = lambda self,delta_t: time_shift(self,delta_t)
 
+TsFixed.values = property(lambda self:self.v,doc="returns the point values, .v of the timeseries")
+TsPoint.values = property(lambda self:self.v,doc="returns the point values, .v of the timeseries")
 
 def ta_iter(x):
     x.counter = 0

--- a/shyft/repository/service/gis_region_model_repository.py
+++ b/shyft/repository/service/gis_region_model_repository.py
@@ -13,6 +13,8 @@ import os
 from ..interfaces import RegionModelRepository
 from ..interfaces import BoundingRegion
 from shyft import api
+from shyft import shyftdata_dir
+import pickle
 
 
 class GisDataFetchError(Exception):
@@ -503,25 +505,171 @@ class RegionModelConfig(object):
     def epsg_id(self):
         return self.grid_specification.epsg_id
 
+class CellDataCache(object):
+    def __init__(self, folder):
+        #self.file_type = file_type
+        self.folder = folder
+        self.reader = {'pickle': self._load_from_pkl,
+                       #'netcdf': self._load_from_nc,
+                       #'numpy': self._load_from_npy
+                        }
+        self.saver = {'pickle': self._dump_to_pkl,
+                       #'netcdf': self._load_from_nc,
+                       #'numpy': self._load_from_npy
+                      }
+        self.file_ext = {'pickle': 'pkl',
+                         #'netcdf': 'nc',
+                         #'numpy': 'npy'
+                         }
+
+    def _make_filename(self, file_type, service_id_field_name, grid_specification):
+        gs = grid_specification
+        file_name = 'EPSG_{}_ID_{}_dX_{}_dY_{}.{}'.format(gs.epsg(), service_id_field_name, int(gs.dx), int(gs.dy),
+                                                     self.file_ext[file_type])
+        return os.path.join(self.folder, file_name)
+
+    def is_file_available(self, file_type, service_id_field_name, grid_specification):
+        file_path = self._make_filename(file_type, service_id_field_name, grid_specification)
+        #file_path = os.path.join(self.folder, file_name)
+        return os.path.isfile(file_path),file_path
+
+    def remove_cache(self,file_type,service_id_field_name, grid_specification):
+        file_exists, file_path = self.is_file_available(file_type, service_id_field_name, grid_specification)
+        if file_exists:
+            print('Deleting file {}'.format(file_path))
+            os.remove(file_path)
+        else:
+            print('No cashe file to remove!')
+
+    def get_cell_data(self, file_type, service_id_field_name, grid_specification, id_list):
+        #file_path = 'All_regions_as_dict_poly_wkb.pkl'
+        file_path = self._make_filename(file_type, service_id_field_name, grid_specification)
+        #file_path = os.path.join(self.folder, file_name)
+        return self.reader[file_type](file_path, id_list)
+
+    def save_cell_data(self, file_type, service_id_field_name, grid_specification, cell_data):
+        file_path = self._make_filename(file_type, service_id_field_name, grid_specification)
+        file_status = self.is_file_available(file_type, service_id_field_name, grid_specification)[0]
+        #file_path = os.path.join(self.folder, file_name)
+        self.saver[file_type](file_path, cell_data, file_status)
+
+    def _load_from_pkl(self, file_path, cids):
+        print('Loading from cache_file {}...'.format(file_path))
+        with open(file_path, 'rb') as pkl_file:
+            cell_info = pickle.load(pkl_file)
+        geo_data = cell_info['geo_data']
+        polygons = np.array(cell_info['polygons'])
+        cids_ = np.sort(cids)
+        cid_map = cids_
+        cids_in_cache = geo_data[:, 4].astype(int)
+        if np.in1d(cids,cids_in_cache).sum()!= len(cids_): # Disable fetching if not all cids are found
+            geo_data_ext = polygons_ext = cid_map = []
+        else:
+            idx = np.in1d(cids_in_cache, cids).nonzero()[0]
+            geo_data_ext = geo_data[idx]
+            polygons_ext = polygons[idx]
+            geo_data_ext[:, 4] = np.searchsorted(cids_, geo_data_ext[:, 4])
+        return {'cid_map': cid_map, 'geo_data': geo_data_ext, 'polygons': polygons_ext}
+
+    def _dump_to_pkl(self, file_path, cell_data, is_existing_file):
+        print('Saving to cache_file {}...'.format(file_path))
+        new_geo_data = cell_data['geo_data']
+        cid_map = cell_data['cid_map']
+        new_geo_data[:, 4] = cid_map[new_geo_data[:, 4].astype(int)]
+        cell_info = {'geo_data': cell_data['geo_data'], 'polygons': cell_data['polygons'].tolist()}
+        if is_existing_file:
+            with open(file_path, 'rb') as pkl_file_in:
+                old = pickle.load(pkl_file_in)
+            #new_geo_data = cell_data['geo_data']
+            #cid_map = cell_data['cid_map']
+            #new_geo_data[:, 4] = cid_map[new_geo_data[:, 4].astype(int)]
+            old['polygons'] = np.array(old['polygons'])
+            old_geo_data = old['geo_data']
+            old_cid = old_geo_data[:, 4].astype(int)
+            idx_keep = np.invert(np.in1d(old_cid, cid_map)).nonzero()[0]
+            if len(idx_keep) > 0:
+                cell_info = {'geo_data': np.vstack((old_geo_data[idx_keep], new_geo_data)),
+                             'polygons': np.concatenate((old['polygons'][idx_keep], cell_data['polygons']))
+                             }
+        with open(file_path, 'wb') as pkl_file_out:
+            pickle.dump(cell_info, pkl_file_out, -1)
+
+
+
 
 class GisRegionModelRepository(RegionModelRepository):
     """
     Statkraft GIS service based version of repository for RegionModel objects.
     """
+    cell_data_cache = CellDataCache(shyftdata_dir)
+    cache_file_type = 'pickle'
 
-    def __init__(self, region_id_config):
+    def __init__(self, region_id_config, use_cache=True, cache_folder=None, cache_file_type=None):
         """
         Parameters
         ----------
         region_id_config: dictionary(region_id:RegionModelConfig)
         """
         self._region_id_config = region_id_config
+        self.use_cache = use_cache
 
     def _get_cell_data_info(self, region_id, catchments):
         # alternative parse out from region_id, like
         # neanidelv.regulated.plant_field, or neanidelv.unregulated.catchment ?
         return self._region_id_config[
             region_id]  # return tuple (regulated|unregulated,'POWER_PLANT_ID'|CATCH_ID', 'FELTNR',[id1, id2])
+
+    @classmethod
+    def get_cell_data_from_gis(cls, catchment_regulated_type, service_id_field_name, grid_specification, id_list):
+        print('Fetching gis_data from online GIS database...')
+        cell_info_service = CellDataFetcher(catchment_regulated_type, service_id_field_name,
+                                            grid_specification, id_list)
+
+        result = cell_info_service.fetch()  # clumsy result, we can adjust this.. (I tried to adjust it below)
+        cell_data = result['cell_data']  # this is the part we need here
+        radiation_slope_factor = 0.9  # todo: get it from service layer
+        extra_geo_attribute = 0.0 # todo: should we just remove this
+        print('Making cell_data from gis_data...')
+        cids = np.sort(list(cell_data.keys()))
+        geo_data = np.vstack([[c['cell'].centroid.x, c['cell'].centroid.y, c['elevation'], c['cell'].area, idx,
+                               radiation_slope_factor,c.get('glacier', 0.0), c.get('lake', 0.0),c.get('reservoir', 0.0),
+                               c.get('forest', 0.0), extra_geo_attribute] for c in cell_data[cid]]
+                             for idx, cid in enumerate(cids))
+        polys = np.concatenate(tuple([c['cell'] for c in cell_data[cid]] for cid in cids))
+        return {'cid_map': cids, 'geo_data': geo_data, 'polygons': polys}
+
+    @classmethod
+    def get_cell_data_from_cache(cls, service_id_field_name, grid_specification, id_list):
+        if cls.cell_data_cache.is_file_available(cls.cache_file_type, service_id_field_name, grid_specification)[0]:
+            cell_info = cls.cell_data_cache.get_cell_data(cls.cache_file_type, service_id_field_name,
+                                                          grid_specification, id_list)
+            if len(cell_info['cid_map'])!=0:
+                return cell_info
+            else:
+                print('MESSAGE: not all catchment IDs requested were found in cache!')
+                return None
+        else:
+            print('MESSAGE: no cache file found!')
+            return None
+
+    @classmethod
+    def update_cache(cls, catchment_regulated_type, service_id_field_name, grid_specification, id_list):
+        cell_info = cls.get_cell_data_from_gis(catchment_regulated_type, service_id_field_name, grid_specification, id_list)
+        cls.cell_data_cache.save_cell_data(cls.cache_file_type, service_id_field_name, grid_specification, cell_info)
+
+    @classmethod
+    def remove_cache(cls, service_id_field_name, grid_specification):
+        cls.cell_data_cache.remove_cache(cls.cache_file_type,service_id_field_name, grid_specification)
+
+    @classmethod
+    def save_cell_data_to_cache(cls, service_id_field_name, grid_specification, cell_info):
+        cls.cell_data_cache.save_cell_data(cls.cache_file_type, service_id_field_name, grid_specification, cell_info)
+
+    @classmethod
+    def build_cell_vector(cls, region_model_type, cell_geo_data):
+        print('Building cell_vector from cell_data...')
+        return region_model_type.cell_t.vector_t.create_from_geo_cell_data_vector(np.ravel(cell_geo_data))
+
 
     def get_region_model(self, region_id, catchments=None):
         """
@@ -552,48 +700,39 @@ class GisRegionModelRepository(RegionModelRepository):
         """
 
         rm = self._get_cell_data_info(region_id, catchments)  # fetch region model info needed to fetch efficiently
-        cell_info_service = CellDataFetcher(rm.catchment_regulated_type, rm.service_id_field_name,
-                                            rm.grid_specification, rm.id_list)
-        result = cell_info_service.fetch()  # clumsy result, we can adjust this..
-        cell_info = result['cell_data']  # this is the part we need here
-        cell_vector = rm.region_model_type.cell_t.vector_t()
-        radiation_slope_factor = 0.9  # todo: get it from service layer 
-        catchment_id_map = []  # needed to build up the external c-id to shyft core internal 0-based c-ids
-        for c_id, c_info_list in cell_info.items():
-            if not c_id == 0:  # only cells with c_id different from 0
-                if not c_id in catchment_id_map:
-                    catchment_id_map.append(c_id)
-                    c_id_0 = len(catchment_id_map) - 1
-                else:
-                    c_id_0 = catchment_id_map.index(c_id)
-                for c_info in c_info_list:
-                    shape = c_info['cell']  # todo fetcher should return geopoint,area, ltf..
-                    z = c_info['elevation']
-                    geopoint = api.GeoPoint(shape.centroid.x, shape.centroid.y, z)
-                    area = shape.area
-                    ltf = api.LandTypeFractions()
-                    ltf.set_fractions(c_info.get('glacier', 0.0), c_info.get('lake', 0.0),
-                                      c_info.get('reservoir', 0.0), c_info.get('forest', 0.0))
-                    cell = rm.region_model_type.cell_t()
-                    cell.geo = api.GeoCellData(geopoint, area, c_id_0, radiation_slope_factor, ltf)
-                    cell_vector.append(cell)
+        if self.use_cache:
+            cell_info = self.get_cell_data_from_cache(rm.service_id_field_name, rm.grid_specification, rm.id_list)
+            if cell_info is None:
+                print('MESSAGE: Reverting to online GIS database and updating cache!')
+                cell_info = self.get_cell_data_from_gis(rm.catchment_regulated_type, rm.service_id_field_name,
+                                                        rm.grid_specification, rm.id_list)
+                self.save_cell_data_to_cache(rm.service_id_field_name, rm.grid_specification, cell_info)
+        else:
+            cell_info = self.get_cell_data_from_gis(rm.catchment_regulated_type, rm.service_id_field_name,
+                                                    rm.grid_specification, rm.id_list)
+        catchment_id_map, cell_geo_data, polygons = [cell_info[k] for k in['cid_map', 'geo_data', 'polygons']]
+        cell_vector = self.build_cell_vector(rm.region_model_type, cell_geo_data)
+
         catchment_parameter_map = rm.region_model_type.parameter_t.map_t()
         for cid, param in rm.catchment_parameters.items():
             if cid in catchment_id_map:
                 catchment_parameter_map[catchment_id_map.index(cid)] = param
-        # todo add catchment level parameters to map
         region_model = rm.region_model_type(cell_vector, rm.region_parameters, catchment_parameter_map)
         region_model.bounding_region = rm.grid_specification  # mandatory for orchestration
         region_model.catchment_id_map = catchment_id_map  # needed to map from externa c_id to 0-based c_id used internally in
-        region_model.gis_info = result  # opt:needed for internal statkraft use/presentation
+        #region_model.gis_info = result  # opt:needed for internal statkraft use/presentation
+        region_model.gis_info = polygons # opt:needed for internal statkraft use/presentation
 
         def do_clone(x):
             clone = x.__class__(x)
             clone.bounding_region = x.bounding_region
             clone.catchment_id_map = catchment_id_map
-            clone.gis_info = result
+            clone.gis_info = polygons
             return clone
 
         region_model.clone = do_clone
 
         return region_model
+
+
+

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -214,7 +214,7 @@ class RegionModel(unittest.TestCase):
         cell_vector = model.get_cells()
         geo_cell_data_string = cell_vector.geo_cell_data_string(cell_vector)  # This gives a string, ultra fast, containing the serialized form of all geo-cell data
         self.assertTrue(len(geo_cell_data_string) > 10 * 10)
-        cell_vector2 = cell_vector.create_from_geo_cell_data_string(geo_cell_data_string) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
+        cell_vector2 = pt_gs_k.PTGSKCellAllVector.create_from_geo_cell_data_string(geo_cell_data_string) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
         self.assertEqual(len(cell_vector), len(cell_vector2))  #  just verify equal size, and then geometry, the remaining tests are covered by C++ testing
         for i in range(len(cell_vector)):
             self.assertAlmostEqual(cell_vector[i].geo.mid_point().z, cell_vector2[i].mid_point().z)

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -31,6 +31,7 @@ class RegionModel(unittest.TestCase):
             cell = model_t.cell_t()
             cell.geo = geo_cell_data
             cells.append(cell)
+
         return model_t(cells, region_parameter)
 
     @staticmethod
@@ -76,14 +77,14 @@ class RegionModel(unittest.TestCase):
         re.temperature.append(self._create_constant_geo_ts(api.TemperatureSource, mid_point, time_axis.total_period(), 10.0))
         re.wind_speed.append(self._create_constant_geo_ts(api.WindSpeedSource, mid_point, time_axis.total_period(), 2.0))
         re.rel_hum.append(self._create_constant_geo_ts(api.RelHumSource, mid_point, time_axis.total_period(), 0.7))
-        re.radiation = api.RadiationSourceVector() # just for testing BW compat
+        re.radiation = api.RadiationSourceVector()  # just for testing BW compat
         re.radiation.append(self._create_constant_geo_ts(api.RadiationSource, mid_point, time_axis.total_period(), 300.0))
         return re
 
     def test_create_region_environment(self):
         cal = api.Calendar()
-        time_axis = api.Timeaxis(cal.time(api.YMDhms(2015, 1, 1, 0, 0, 0)),api.deltahours(1), 240)
-        re = self.create_dummy_region_environment(time_axis,api.GeoPoint(1000,1000,100))
+        time_axis = api.Timeaxis(cal.time(api.YMDhms(2015, 1, 1, 0, 0, 0)), api.deltahours(1), 240)
+        re = self.create_dummy_region_environment(time_axis, api.GeoPoint(1000, 1000, 100))
         self.assertIsNotNone(re)
         self.assertEqual(len(re.radiation), 1)
         self.assertAlmostEqual(re.radiation[0].ts.value(0), 300.0)
@@ -98,7 +99,7 @@ class RegionModel(unittest.TestCase):
         num_cells = 20
         model_type = pt_hs_k.PTHSKModel
         model = self.build_model(model_type, pt_hs_k.PTHSKParameter, num_cells)
-        self.assertEqual(model.size(),num_cells)
+        self.assertEqual(model.size(), num_cells)
 
     def test_model_initialize_and_run(self):
         num_cells = 20
@@ -112,8 +113,8 @@ class RegionModel(unittest.TestCase):
         self.assertEqual(region_parameter.gs.snow_cv_forest_factor, 0.1)
         self.assertEqual(region_parameter.gs.snow_cv_altitude_factor, 0.0001)
 
-        self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 0.0), region_parameter.gs.snow_cv+0.1)
-        self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 1000.0), region_parameter.gs.snow_cv+0.1+0.1)
+        self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 0.0), region_parameter.gs.snow_cv + 0.1)
+        self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 1000.0), region_parameter.gs.snow_cv + 0.1 + 0.1)
         cal = api.Calendar()
         time_axis = api.Timeaxis(cal.time(api.YMDhms(2015, 1, 1, 0, 0, 0)),
                                  api.deltahours(1), 240)
@@ -130,11 +131,11 @@ class RegionModel(unittest.TestCase):
         model_interpolation_parameter.temperature_idw.distance_measure_factor = 1.0
         # This enables IDW with default temperature gradient.
         model_interpolation_parameter.use_idw_for_temperature = True
-        self.assertAlmostEqual(model_interpolation_parameter.precipitation.scale_factor,1.02)  # just verify this one is as before change to scale_factor
+        self.assertAlmostEqual(model_interpolation_parameter.precipitation.scale_factor, 1.02)  # just verify this one is as before change to scale_factor
         model.run_interpolation(
-                model_interpolation_parameter, time_axis,
-                self.create_dummy_region_environment(time_axis,
-                                                     model.get_cells()[int(num_cells / 2)].geo.mid_point()))
+            model_interpolation_parameter, time_axis,
+            self.create_dummy_region_environment(time_axis,
+                                                 model.get_cells()[int(num_cells / 2)].geo.mid_point()))
         s0 = pt_gs_k.PTGSKStateVector()
         for i in range(num_cells):
             si = pt_gs_k.PTGSKState()
@@ -158,10 +159,10 @@ class RegionModel(unittest.TestCase):
         # lwc surface_heat alpha melt_mean melt iso_pot_energy temp_sw
         avg_gs_albedo = model.gamma_snow_state.albedo(cids)
         self.assertIsNotNone(avg_gs_albedo)
-        self.assertEqual(avg_temperature.size(), time_axis.size(),"expect results equal to time-axis size")
+        self.assertEqual(avg_temperature.size(), time_axis.size(), "expect results equal to time-axis size")
         copy_region_model = model.__class__(model)
         self.assertIsNotNone(copy_region_model)
-        copy_region_model.run_cells() #just to verify we can copy and run the new model
+        copy_region_model.run_cells()  # just to verify we can copy and run the new model
 
     def test_model_state_io(self):
         num_cells = 2
@@ -200,6 +201,25 @@ class RegionModel(unittest.TestCase):
             state_vector = sio.vector_from_string(statestr)
 
             self.assertRaises(RuntimeError, model.set_states, state_vector)
+
+    def test_geo_cell_data_serializer(self):
+        """
+        This test the bulding block for the geo-cell caching mechanism that can be
+        implemented in GeoCell repository to cache complex information from the GIS system.
+        The test illustrates how to convert existing cell-vector geo info into a peristable string,
+        and then how to re-create the cell-vector,(of any given type actually) based on the geo-cell data.
+
+        """
+        model = self.build_model(pt_gs_k.PTGSKModel, pt_gs_k.PTGSKParameter, 10)
+        cell_vector = model.get_cells()
+        geo_cell_data_string = cell_vector.geo_cell_data_string(cell_vector)  # This gives a string, ultra fast, containing the serialized form of all geo-cell data
+        self.assertTrue(len(geo_cell_data_string) > 10 * 10)
+        cell_vector2 = cell_vector.create_from_geo_cell_data_string(geo_cell_data_string) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
+        self.assertEqual(len(cell_vector), len(cell_vector2))  #  just verify equal size, and then geometry, the remaining tests are covered by C++ testing
+        for i in range(len(cell_vector)):
+            self.assertAlmostEqual(cell_vector[i].geo.mid_point().z, cell_vector2[i].mid_point().z)
+            self.assertAlmostEqual(cell_vector[i].geo.mid_point().x, cell_vector2[i].mid_point().x)
+            self.assertAlmostEqual(cell_vector[i].geo.mid_point().y, cell_vector2[i].mid_point().y)
 
 
 if __name__ == "__main__":

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -206,14 +206,21 @@ class RegionModel(unittest.TestCase):
         """
         This test the bulding block for the geo-cell caching mechanism that can be
         implemented in GeoCell repository to cache complex information from the GIS system.
-        The test illustrates how to convert existing cell-vector geo info into a peristable string,
-        and then how to re-create the cell-vector,(of any given type actually) based on the geo-cell data.
+        The test illustrates how to convert existing cell-vector geo info into a DoubleVector,
+        that can be converted .to_nump(),
+        and then how to re-create the cell-vector,(of any given type actually) based on
+        the geo-cell data DoubleVector (that can be created from .from_numpy(..)
+
+        Notice that the from_numpy(np array) could have limited functionality when it comes
+        to strides etc, so if problem flatten out the np.array before passing it.
 
         """
-        model = self.build_model(pt_gs_k.PTGSKModel, pt_gs_k.PTGSKParameter, 3)
+        n_cells = 3
+        n_values_pr_gcd = 11  # number of values in a geo_cell_data stride
+        model = self.build_model(pt_gs_k.PTGSKModel, pt_gs_k.PTGSKParameter, n_cells)
         cell_vector = model.get_cells()
         geo_cell_data_vector = cell_vector.geo_cell_data_vector(cell_vector)  # This gives a string, ultra fast, containing the serialized form of all geo-cell data
-        self.assertEqual(len(geo_cell_data_vector) , 11 * 3)
+        self.assertEqual(len(geo_cell_data_vector) , n_values_pr_gcd * n_cells)
         cell_vector2 = pt_gs_k.PTGSKCellAllVector.create_from_geo_cell_data_vector(geo_cell_data_vector) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
         self.assertEqual(len(cell_vector), len(cell_vector2))  #  just verify equal size, and then geometry, the remaining tests are covered by C++ testing
         for i in range(len(cell_vector)):

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -210,11 +210,11 @@ class RegionModel(unittest.TestCase):
         and then how to re-create the cell-vector,(of any given type actually) based on the geo-cell data.
 
         """
-        model = self.build_model(pt_gs_k.PTGSKModel, pt_gs_k.PTGSKParameter, 10)
+        model = self.build_model(pt_gs_k.PTGSKModel, pt_gs_k.PTGSKParameter, 3)
         cell_vector = model.get_cells()
-        geo_cell_data_string = cell_vector.geo_cell_data_string(cell_vector)  # This gives a string, ultra fast, containing the serialized form of all geo-cell data
-        self.assertTrue(len(geo_cell_data_string) > 10 * 10)
-        cell_vector2 = pt_gs_k.PTGSKCellAllVector.create_from_geo_cell_data_string(geo_cell_data_string) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
+        geo_cell_data_vector = cell_vector.geo_cell_data_vector(cell_vector)  # This gives a string, ultra fast, containing the serialized form of all geo-cell data
+        self.assertEqual(len(geo_cell_data_vector) , 11 * 3)
+        cell_vector2 = pt_gs_k.PTGSKCellAllVector.create_from_geo_cell_data_vector(geo_cell_data_vector) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
         self.assertEqual(len(cell_vector), len(cell_vector2))  #  just verify equal size, and then geometry, the remaining tests are covered by C++ testing
         for i in range(len(cell_vector)):
             self.assertAlmostEqual(cell_vector[i].geo.mid_point().z, cell_vector2[i].mid_point().z)

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -62,9 +62,9 @@ class TimeSeries(unittest.TestCase):
         tsfixed = api.TsFixed(self.ta, v)
         self.assertEqual(tsfixed.size(), self.ta.size())
         self.assertAlmostEqual(tsfixed.get(0).v, v[0])
-        vv = tsfixed.v.to_numpy()
+        vv = tsfixed.values.to_numpy() #introduced .values for compatibility
         assert_array_almost_equal(dv, vv)
-        tsfixed.v[0] = 10.0
+        tsfixed.values[0] = 10.0
         dv[0] = 10.0
         assert_array_almost_equal(dv, tsfixed.v.to_numpy())
         # self.assertAlmostEqual(v,vv)
@@ -84,6 +84,7 @@ class TimeSeries(unittest.TestCase):
         tspoint = api.TsPoint(ta, v)
         self.assertEqual(tspoint.size(), ta.size())
         self.assertAlmostEqual(tspoint.get(0).v, v[0])
+        self.assertAlmostEqual(tspoint.values[0], v[0]) # just to verfy compat .values works
         self.assertEqual(tspoint.get(0).t, ta(0).start)
 
     def test_ts_factory(self):

--- a/shyft/tests/test_geo_data_serialization.py
+++ b/shyft/tests/test_geo_data_serialization.py
@@ -4,97 +4,109 @@ from shyft.api import pt_gs_k
 from shyft.repository.service.gis_region_model_repository import \
     (GridSpecification, get_grid_spec_from_catch_poly, RegionModelConfig, GisRegionModelRepository)
 
+try:
+    
+    from statkraft.ssa.environment import SMG_PREPROD as PREPROD
 
-class SerializationTestCase(unittest.TestCase):
+    def import_check():
+        return PREPROD  # just to silence the module unused
 
-    def test_serialize_and_deserialize(self):
-        rm_type = pt_gs_k.PTGSKModel
-        reg_param = rm_type.parameter_t()
-        epsg_id = 32633
-        catchment_type = 'regulated'
-        identifier = 'SUBCATCH_ID'
-        dxy = 1000.
-        pad = 5
-        # LTM5-Tya
-        id_list = [172, 174, 177, 185, 187, 190]
-        grid_specification = get_grid_spec_from_catch_poly(id_list, catchment_type, identifier, epsg_id, dxy, pad)
-        # LTM5-Nea
-        id_list_1 = [180, 188, 191, 196]
-        grid_specification_1 = get_grid_spec_from_catch_poly(id_list_1, catchment_type, identifier, epsg_id, dxy, pad)
+    class SerializationTestCase(unittest.TestCase):
 
-        cfg_list = [
-            RegionModelConfig('Tya', rm_type, reg_param, grid_specification, catchment_type, identifier, id_list),
-            RegionModelConfig('Nea', rm_type, reg_param, grid_specification_1, catchment_type, identifier, id_list_1),
-        ]
-        rm_cfg_dict = {x.name: x for x in cfg_list}
-        rm_repo = GisRegionModelRepository(rm_cfg_dict, use_cache=True)
+        def test_serialize_and_deserialize(self):
+            rm_type = pt_gs_k.PTGSKModel
+            reg_param = rm_type.parameter_t()
+            epsg_id = 32633
+            catchment_type = 'regulated'
+            identifier = 'SUBCATCH_ID'
+            dxy = 1000.
+            pad = 5
+            # LTM5-Tya
+            id_list = [172, 174, 177, 185, 187, 190]
+            grid_specification = get_grid_spec_from_catch_poly(id_list, catchment_type, identifier, epsg_id, dxy, pad)
+            # LTM5-Nea
+            id_list_1 = [180, 188, 191, 196]
+            grid_specification_1 = get_grid_spec_from_catch_poly(id_list_1, catchment_type, identifier, epsg_id, dxy, pad)
 
-        # Start by removing existing cache file
-        GisRegionModelRepository.remove_cache(identifier, grid_specification)
-        # Update cache with Nea cell_data
-        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification_1, id_list_1)
-        # Construct a region_model for Tya - this process should automatically append Tya cell_data to cache
-        rm = rm_repo.get_region_model('Tya')
-        cells_from_rm = rm.get_cells()
-        # Get Tya cell_data from the region_model
-        cell_data_from_region_model = cells_from_rm.geo_cell_data_vector(cells_from_rm).to_numpy().reshape(-1, 11)
-        # Get Tya cell_data from auto generated cache
-        cell_data_from_auto_cache = GisRegionModelRepository.get_cell_data_from_cache(
-            identifier, grid_specification, id_list)
-        # Remove the cache file
-        GisRegionModelRepository.remove_cache(identifier, grid_specification)
-        # Update cache with Tya cell_data
-        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification, id_list)
-        # Update cache with Nea cell_data
-        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification_1, id_list_1)
-        # Get Tya cell_data from updated cache
-        cell_data_from_updated_cache = GisRegionModelRepository.get_cell_data_from_cache(
-            identifier, grid_specification, id_list)
-        # Get Nea cell_data from updated cache
-        cell_data_from_updated_cache_1 = GisRegionModelRepository.get_cell_data_from_cache(
-            identifier, grid_specification_1, id_list_1)
-        # Remove the cache file
-        GisRegionModelRepository.remove_cache(identifier, grid_specification)
-        # Get Nea cell_data from GIS
-        cell_data_from_gis_1 = GisRegionModelRepository.get_cell_data_from_gis(
-            catchment_type, identifier, grid_specification_1, id_list_1)
-        # Get Tya cell_data from GIS
-        cell_data_from_gis = GisRegionModelRepository.get_cell_data_from_gis(
-            catchment_type, identifier, grid_specification, id_list)
-        # Update cache with Tya cell_data
-        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification, id_list)
-        # Construct a region_model for Nea - this process should automatically append Nea cell_data to cache')
-        rm_1 = rm_repo.get_region_model('Nea')
-        cells_from_rm_1 = rm_1.get_cells()
-        # Get Nea cell_data from the region_model
-        cell_data_from_region_model_1 = cells_from_rm_1.geo_cell_data_vector(cells_from_rm_1).to_numpy().reshape(-1, 11)
-        # Get Nea cell_data from auto generated cache
-        cell_data_from_auto_cache_1 = GisRegionModelRepository.get_cell_data_from_cache(
-            identifier, grid_specification_1, id_list_1)
-        # Remove the cache file
-        GisRegionModelRepository.remove_cache(identifier, grid_specification)
+            cfg_list = [
+                RegionModelConfig('Tya', rm_type, reg_param, grid_specification, catchment_type, identifier, id_list),
+                RegionModelConfig('Nea', rm_type, reg_param, grid_specification_1, catchment_type, identifier, id_list_1),
+            ]
+            rm_cfg_dict = {x.name: x for x in cfg_list}
+            rm_repo = GisRegionModelRepository(rm_cfg_dict, use_cache=True)
 
-        # Comparing results...
-        # Arrays to compare
-        # Tya
-        # cell_data_from_region_model, cell_data_from_auto_cache, cell_data_from_updated_cache, cell_data_from_gis
-        atol = 1e-08
-        self.assertTrue(np.allclose(cell_data_from_region_model, cell_data_from_gis['geo_data'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_auto_cache['geo_data'], cell_data_from_gis['geo_data'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_updated_cache['geo_data'], cell_data_from_gis['geo_data'], atol=atol))
+            # Start by removing existing cache file
+            GisRegionModelRepository.remove_cache(identifier, grid_specification)
+            # Update cache with Nea cell_data
+            GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification_1, id_list_1)
+            # Construct a region_model for Tya - this process should automatically append Tya cell_data to cache
+            rm = rm_repo.get_region_model('Tya')
+            cells_from_rm = rm.get_cells()
+            # Get Tya cell_data from the region_model
+            cell_data_from_region_model = cells_from_rm.geo_cell_data_vector(cells_from_rm).to_numpy().reshape(-1, 11)
+            # Get Tya cell_data from auto generated cache
+            cell_data_from_auto_cache = GisRegionModelRepository.get_cell_data_from_cache(
+                identifier, grid_specification, id_list)
+            # Remove the cache file
+            GisRegionModelRepository.remove_cache(identifier, grid_specification)
+            # Update cache with Tya cell_data
+            GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification, id_list)
+            # Update cache with Nea cell_data
+            GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification_1, id_list_1)
+            # Get Tya cell_data from updated cache
+            cell_data_from_updated_cache = GisRegionModelRepository.get_cell_data_from_cache(
+                identifier, grid_specification, id_list)
+            # Get Nea cell_data from updated cache
+            cell_data_from_updated_cache_1 = GisRegionModelRepository.get_cell_data_from_cache(
+                identifier, grid_specification_1, id_list_1)
+            # Remove the cache file
+            GisRegionModelRepository.remove_cache(identifier, grid_specification)
+            # Get Nea cell_data from GIS
+            cell_data_from_gis_1 = GisRegionModelRepository.get_cell_data_from_gis(
+                catchment_type, identifier, grid_specification_1, id_list_1)
+            # Get Tya cell_data from GIS
+            cell_data_from_gis = GisRegionModelRepository.get_cell_data_from_gis(
+                catchment_type, identifier, grid_specification, id_list)
+            # Update cache with Tya cell_data
+            GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification, id_list)
+            # Construct a region_model for Nea - this process should automatically append Nea cell_data to cache')
+            rm_1 = rm_repo.get_region_model('Nea')
+            cells_from_rm_1 = rm_1.get_cells()
+            # Get Nea cell_data from the region_model
+            cell_data_from_region_model_1 = cells_from_rm_1.geo_cell_data_vector(cells_from_rm_1).to_numpy().reshape(-1, 11)
+            # Get Nea cell_data from auto generated cache
+            cell_data_from_auto_cache_1 = GisRegionModelRepository.get_cell_data_from_cache(
+                identifier, grid_specification_1, id_list_1)
+            # Remove the cache file
+            GisRegionModelRepository.remove_cache(identifier, grid_specification)
 
-        self.assertTrue(np.allclose(rm.catchment_id_map, cell_data_from_gis['cid_map'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_auto_cache['cid_map'], cell_data_from_gis['cid_map'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_updated_cache['cid_map'], cell_data_from_gis['cid_map'], atol=atol))
-        # Nea
-        # cell_data_from_region_model_1, cell_data_from_auto_cache_1, cell_data_from_updated_cache_1, cell_data_from_gis_1
-        self.assertTrue(np.allclose(cell_data_from_region_model_1, cell_data_from_gis_1['geo_data'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_auto_cache_1['geo_data'], cell_data_from_gis_1['geo_data'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_updated_cache_1['geo_data'], cell_data_from_gis_1['geo_data'], atol=atol))
+            # Comparing results...
+            # Arrays to compare
+            # Tya
+            # cell_data_from_region_model, cell_data_from_auto_cache, cell_data_from_updated_cache, cell_data_from_gis
+            atol = 1e-08
+            self.assertTrue(np.allclose(cell_data_from_region_model, cell_data_from_gis['geo_data'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_auto_cache['geo_data'], cell_data_from_gis['geo_data'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_updated_cache['geo_data'], cell_data_from_gis['geo_data'], atol=atol))
 
-        self.assertTrue(np.allclose(rm_1.catchment_id_map, cell_data_from_gis_1['cid_map'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_auto_cache_1['cid_map'], cell_data_from_gis_1['cid_map'], atol=atol))
-        self.assertTrue(np.allclose(cell_data_from_updated_cache_1['cid_map'], cell_data_from_gis_1['cid_map'], atol=atol))
+            self.assertTrue(np.allclose(rm.catchment_id_map, cell_data_from_gis['cid_map'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_auto_cache['cid_map'], cell_data_from_gis['cid_map'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_updated_cache['cid_map'], cell_data_from_gis['cid_map'], atol=atol))
+            # Nea
+            # cell_data_from_region_model_1, cell_data_from_auto_cache_1, cell_data_from_updated_cache_1, cell_data_from_gis_1
+            self.assertTrue(np.allclose(cell_data_from_region_model_1, cell_data_from_gis_1['geo_data'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_auto_cache_1['geo_data'], cell_data_from_gis_1['geo_data'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_updated_cache_1['geo_data'], cell_data_from_gis_1['geo_data'], atol=atol))
+
+            self.assertTrue(np.allclose(rm_1.catchment_id_map, cell_data_from_gis_1['cid_map'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_auto_cache_1['cid_map'], cell_data_from_gis_1['cid_map'], atol=atol))
+            self.assertTrue(np.allclose(cell_data_from_updated_cache_1['cid_map'], cell_data_from_gis_1['cid_map'], atol=atol))
+
+except ImportError as ie:
+    if 'statkraft' in str(ie):
+        print("(Test require statkraft.script environment to run: {})".format(ie))
+    else:
+        print("ImportError: {}".format(ie))
 
 if __name__ == '__main__':
     unittest.main()

--- a/shyft/tests/test_geo_data_serialization.py
+++ b/shyft/tests/test_geo_data_serialization.py
@@ -1,0 +1,100 @@
+import unittest
+import numpy as np
+from shyft.api import pt_gs_k
+from shyft.repository.service.gis_region_model_repository import \
+    (GridSpecification, get_grid_spec_from_catch_poly, RegionModelConfig, GisRegionModelRepository)
+
+
+class SerializationTestCase(unittest.TestCase):
+
+    def test_serialize_and_deserialize(self):
+        rm_type = pt_gs_k.PTGSKModel
+        reg_param = rm_type.parameter_t()
+        epsg_id = 32633
+        catchment_type = 'regulated'
+        identifier = 'SUBCATCH_ID'
+        dxy = 1000.
+        pad = 5
+        # LTM5-Tya
+        id_list = [172, 174, 177, 185, 187, 190]
+        grid_specification = get_grid_spec_from_catch_poly(id_list, catchment_type, identifier, epsg_id, dxy, pad)
+        # LTM5-Nea
+        id_list_1 = [180, 188, 191, 196]
+        grid_specification_1 = get_grid_spec_from_catch_poly(id_list_1, catchment_type, identifier, epsg_id, dxy, pad)
+
+        cfg_list = [
+            RegionModelConfig('Tya', rm_type, reg_param, grid_specification, catchment_type, identifier, id_list),
+            RegionModelConfig('Nea', rm_type, reg_param, grid_specification_1, catchment_type, identifier, id_list_1),
+        ]
+        rm_cfg_dict = {x.name: x for x in cfg_list}
+        rm_repo = GisRegionModelRepository(rm_cfg_dict, use_cache=True)
+
+        # Start by removing existing cache file
+        GisRegionModelRepository.remove_cache(identifier, grid_specification)
+        # Update cache with Nea cell_data
+        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification_1, id_list_1)
+        # Construct a region_model for Tya - this process should automatically append Tya cell_data to cache
+        rm = rm_repo.get_region_model('Tya')
+        cells_from_rm = rm.get_cells()
+        # Get Tya cell_data from the region_model
+        cell_data_from_region_model = cells_from_rm.geo_cell_data_vector(cells_from_rm).to_numpy().reshape(-1, 11)
+        # Get Tya cell_data from auto generated cache
+        cell_data_from_auto_cache = GisRegionModelRepository.get_cell_data_from_cache(
+            identifier, grid_specification, id_list)
+        # Remove the cache file
+        GisRegionModelRepository.remove_cache(identifier, grid_specification)
+        # Update cache with Tya cell_data
+        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification, id_list)
+        # Update cache with Nea cell_data
+        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification_1, id_list_1)
+        # Get Tya cell_data from updated cache
+        cell_data_from_updated_cache = GisRegionModelRepository.get_cell_data_from_cache(
+            identifier, grid_specification, id_list)
+        # Get Nea cell_data from updated cache
+        cell_data_from_updated_cache_1 = GisRegionModelRepository.get_cell_data_from_cache(
+            identifier, grid_specification_1, id_list_1)
+        # Remove the cache file
+        GisRegionModelRepository.remove_cache(identifier, grid_specification)
+        # Get Nea cell_data from GIS
+        cell_data_from_gis_1 = GisRegionModelRepository.get_cell_data_from_gis(
+            catchment_type, identifier, grid_specification_1, id_list_1)
+        # Get Tya cell_data from GIS
+        cell_data_from_gis = GisRegionModelRepository.get_cell_data_from_gis(
+            catchment_type, identifier, grid_specification, id_list)
+        # Update cache with Tya cell_data
+        GisRegionModelRepository.update_cache(catchment_type, identifier, grid_specification, id_list)
+        # Construct a region_model for Nea - this process should automatically append Nea cell_data to cache')
+        rm_1 = rm_repo.get_region_model('Nea')
+        cells_from_rm_1 = rm_1.get_cells()
+        # Get Nea cell_data from the region_model
+        cell_data_from_region_model_1 = cells_from_rm_1.geo_cell_data_vector(cells_from_rm_1).to_numpy().reshape(-1, 11)
+        # Get Nea cell_data from auto generated cache
+        cell_data_from_auto_cache_1 = GisRegionModelRepository.get_cell_data_from_cache(
+            identifier, grid_specification_1, id_list_1)
+        # Remove the cache file
+        GisRegionModelRepository.remove_cache(identifier, grid_specification)
+
+        # Comparing results...
+        # Arrays to compare
+        # Tya
+        # cell_data_from_region_model, cell_data_from_auto_cache, cell_data_from_updated_cache, cell_data_from_gis
+        atol = 1e-08
+        self.assertTrue(np.allclose(cell_data_from_region_model, cell_data_from_gis['geo_data'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_auto_cache['geo_data'], cell_data_from_gis['geo_data'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_updated_cache['geo_data'], cell_data_from_gis['geo_data'], atol=atol))
+
+        self.assertTrue(np.allclose(rm.catchment_id_map, cell_data_from_gis['cid_map'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_auto_cache['cid_map'], cell_data_from_gis['cid_map'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_updated_cache['cid_map'], cell_data_from_gis['cid_map'], atol=atol))
+        # Nea
+        # cell_data_from_region_model_1, cell_data_from_auto_cache_1, cell_data_from_updated_cache_1, cell_data_from_gis_1
+        self.assertTrue(np.allclose(cell_data_from_region_model_1, cell_data_from_gis_1['geo_data'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_auto_cache_1['geo_data'], cell_data_from_gis_1['geo_data'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_updated_cache_1['geo_data'], cell_data_from_gis_1['geo_data'], atol=atol))
+
+        self.assertTrue(np.allclose(rm_1.catchment_id_map, cell_data_from_gis_1['cid_map'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_auto_cache_1['cid_map'], cell_data_from_gis_1['cid_map'], atol=atol))
+        self.assertTrue(np.allclose(cell_data_from_updated_cache_1['cid_map'], cell_data_from_gis_1['cid_map'], atol=atol))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -117,9 +117,9 @@ void api_test::test_pthsk_state_io() {
 void api_test::test_geo_cell_data_io() {
     geo_cell_data gcd(geo_point(1,2,3),4,5,0.6,land_type_fractions(2,4,6,8,10));
 
-    string gcd_s=geo_cell_data_io::to_string(gcd);
+    auto gcd_s=geo_cell_data_io::to_vector(gcd);
     TS_ASSERT(gcd_s.size()>0);
-    geo_cell_data gcd2= geo_cell_data_io::from_string(gcd_s.data());
+    geo_cell_data gcd2= geo_cell_data_io::from_vector(gcd_s);
     double eps=1e-12;
     TS_ASSERT_DELTA(gcd2.area(),gcd.area(),eps);
     TS_ASSERT_EQUALS(gcd2.mid_point(),gcd.mid_point());

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -18,42 +18,7 @@ using namespace shyft::timeseries;
 
 using namespace shyft::api;
 
-#if 0
-bool operator==(const pt_gs_k_state_t& a, const pt_gs_k_state_t& b) {
-	const double tol = 1e-9;
-	return fabs(a.gs.albedo - b.gs.albedo) < tol
-		&& fabs(a.gs.alpha - b.gs.alpha) < tol
-		&& fabs(a.gs.sdc_melt_mean - b.gs.sdc_melt_mean) < tol
-		&& fabs(a.gs.acc_melt - b.gs.acc_melt) < tol
-		&& fabs(a.gs.iso_pot_energy - b.gs.iso_pot_energy) < tol
-		&& fabs(a.gs.temp_swe - b.gs.temp_swe) < tol
-		&& fabs(a.kirchner.q - b.kirchner.q) < tol
-		&& fabs(a.gs.lwc - b.gs.lwc) < tol
-		&& fabs(a.gs.surface_heat - b.gs.surface_heat) < tol;
 
-}
-
-bool operator==(const pt_ss_k_state_t& a, const pt_ss_k_state_t& b) {
-	const double tol = 1e-9;
-	return fabs(a.snow.nu - b.snow.nu) < tol
-		&& fabs(a.snow.alpha - b.snow.alpha) < tol
-		&& fabs(a.snow.sca - b.snow.sca) < tol
-		&& fabs(a.snow.swe - b.snow.swe) < tol
-		&& fabs(a.snow.free_water - b.snow.free_water) < tol
-		&& fabs(a.snow.residual - b.snow.residual) < tol
-		&& fabs(a.kirchner.q - b.kirchner.q) < tol
-		&& (a.snow.num_units == b.snow.num_units);
-
-}
-bool operator==(const pt_hs_k_state_t& a, const pt_hs_k_state_t& b) {
-	const double tol = 1e-9;
-	return
-		   fabs(a.snow.sca - b.snow.sca) < tol
-		&& fabs(a.snow.swe - b.snow.swe) < tol
-		&& fabs(a.kirchner.q - b.kirchner.q) < tol;
-
-}
-#endif
 void api_test::test_ptgsk_state_io() {
 	using namespace shyft::api;
 	pt_gs_k_state_t s;
@@ -147,4 +112,22 @@ void api_test::test_pthsk_state_io() {
 		TS_ASSERT_EQUALS(rsv[i], sv[i]);
 	}
 
+}
+
+void api_test::test_geo_cell_data_io() {
+    geo_cell_data gcd(geo_point(1,2,3),4,5,0.6,land_type_fractions(2,4,6,8,10));
+
+    string gcd_s=geo_cell_data_io::to_string(gcd);
+    TS_ASSERT(gcd_s.size()>0);
+    geo_cell_data gcd2= geo_cell_data_io::from_string(gcd_s.data());
+    double eps=1e-12;
+    TS_ASSERT_DELTA(gcd2.area(),gcd.area(),eps);
+    TS_ASSERT_EQUALS(gcd2.mid_point(),gcd.mid_point());
+    TS_ASSERT_EQUALS(gcd2.catchment_id(),gcd.catchment_id());
+    TS_ASSERT_DELTA(gcd2.radiation_slope_factor(),gcd.radiation_slope_factor(),eps);
+    TS_ASSERT_DELTA(gcd2.land_type_fractions_info().glacier(),gcd.land_type_fractions_info().glacier(),eps);
+    TS_ASSERT_DELTA(gcd2.land_type_fractions_info().lake(),gcd.land_type_fractions_info().lake(),eps);
+    TS_ASSERT_DELTA(gcd2.land_type_fractions_info().reservoir(),gcd.land_type_fractions_info().reservoir(),eps);
+    TS_ASSERT_DELTA(gcd2.land_type_fractions_info().forest(),gcd.land_type_fractions_info().forest(),eps);
+    TS_ASSERT_DELTA(gcd2.land_type_fractions_info().unspecified(),gcd.land_type_fractions_info().unspecified(),eps);
 }

--- a/test/api_test.h
+++ b/test/api_test.h
@@ -10,5 +10,6 @@ class api_test : public CxxTest::TestSuite {
     void test_ptgsk_state_io(void);
 	void test_ptssk_state_io(void);
 	void test_pthsk_state_io(void);
+	void test_geo_cell_data_io(void);
 
 };

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -38,7 +38,7 @@
 					<Add directory="../bin/Release" />
 				</Linker>
 				<ExtraCommands>
-					<Add after="cd ../bin/Release &amp;&amp; ./test_shyft  timeseries_test" />
+					<Add after="cd ../bin/Release &amp;&amp; ./test_shyft  api_test test_geo_cell_data_io" />
 					<Mode after="always" />
 				</ExtraCommands>
 			</Target>


### PR DESCRIPTION
**Background**
Fetching and computing accurate  geo-cell data from the GIS system takes resources and time compared to running SHyFT models. For larger models, with a high degree of accuracy, 
this involves millions of polygons describing forrest, lakes, reservoirs and glaciers.
Added togehter, this takes in the order of several seconds (20-200).

GIS-system data is rather constant for a model, so we add caching-support to this level so that models can be retrieved in split-seconds.

The additional code goes in two parts (c++ and python)

 1. the cell-vector at core/api level  provides methods for serializing to/from suitable format for persistence
 2. the affected repository uses the mechanism above plus some few lines to 
     check for existence of the cached data before retrieving from the GIS service.
    The feature defaults to active, with possibility to override (for refresh cache).



