### PR TITLE
extended dls support to cover resolution >1h < 1 day

### DIFF
--- a/core/time_axis.h
+++ b/core/time_axis.h
@@ -127,7 +127,7 @@ namespace shyft {
             }
 
             utcperiod period( size_t i ) const {
-                if( i < n ) return dt < dt_h ? utcperiod( t + i * dt, t + ( i + 1 ) * dt ) : utcperiod( cal->add( t, dt, long( i) ), cal->add( t, dt, long(i + 1) ) );
+                if( i < n ) return dt <= dt_h ? utcperiod( t + i * dt, t + ( i + 1 ) * dt ) : utcperiod( cal->add( t, dt, long( i) ), cal->add( t, dt, long(i + 1) ) );
                 throw out_of_range( "calendar_dt.period(i)" );
             }
 
@@ -254,7 +254,7 @@ namespace shyft {
             point_dt p;
             //---------------
             generic_dt(): gt( FIXED ) {}
-            // provide convinence constructors, to directly create the wanted time-axis, regardless underlying rep.
+            // provide convinience constructors, to directly create the wanted time-axis, regardless underlying rep.
             generic_dt( utctime t0,utctimespan dt,size_t n):gt(FIXED),f(t0,dt,n) {}
             generic_dt( const shared_ptr<const calendar>& cal, utctime t, utctimespan dt, size_t n ) : gt(CALENDAR),c(cal,t,dt,n) {}
             generic_dt( const vector<utctime>& t, utctime t_end ):gt(POINT),p(t,t_end) {}

--- a/core/utctime_utilities.cpp
+++ b/core/utctime_utilities.cpp
@@ -212,7 +212,14 @@ namespace shyft {
                     }
                 } break;
                 default: {
-                    remainder = t2 - (t1+n_units*deltaT);
+					if (deltaT > HOUR) {// a bit tricky, tz might jeopardize interval size by 1h (again assuming dst=1h)
+						auto utc_diff_1 = tz_info->utc_offset(t1);//assuming dst=1h!
+						auto utc_diff_2 = tz_info->utc_offset(t2);//assuming dst=1h!
+						n_units = (t2 - t1 - (utc_diff_1 - utc_diff_2)) / deltaT;
+						remainder = t2 - add(t1, deltaT, n_units);
+					} else { // simple case, hour< 15 min etc.
+						remainder = t2 - (t1 + n_units*deltaT);
+					}
                 } break;
             }
             return n_units*sgn;

--- a/core/utctime_utilities.h
+++ b/core/utctime_utilities.h
@@ -255,6 +255,7 @@ namespace shyft {
 			static const utctimespan MONTH=30*24*3600L;
 			static const utctimespan WEEK = 7*24*3600L;
 			static const utctimespan DAY =  1*24*3600L;
+			static const utctimespan HOUR_3 = 3 * 3600L;
 			// these are just timespan constants with no calendar semantics
 			static const utctimespan HOUR = 3600L;
 			static const utctimespan MINUTE = 60L;

--- a/shyft/tests/api/test_calendar_and_time.py
+++ b/shyft/tests/api/test_calendar_and_time.py
@@ -57,6 +57,15 @@ class Calendar(unittest.TestCase):
         self.assertEqual("2016-11-06T00:00:00+01", osl.to_string(t1))
         self.assertEqual(168+1, osl.diff_units(t0, t1, api.Calendar.HOUR))
 
+    def test_calendar_add_3h_during_dst(self):
+        osl = api.Calendar("Europe/Oslo")
+        t0 = osl.time(2016, 3, 27)  # dst change during spring
+        t1 = osl.add(t0, api.Calendar.DAY,  1)
+        dt3h=api.deltahours(3)
+        d3h= osl.diff_units(t0,t1,dt3h)
+        self.assertEqual(8, d3h)
+
+
     def test_trim_day(self):
         t = api.utctime_now()
         td = self.std.trim(t, api.Calendar.DAY)

--- a/test/utctime_utilities_test.cpp
+++ b/test/utctime_utilities_test.cpp
@@ -181,7 +181,7 @@ void utctime_utilities_test::test_add_over_dst_transitions() {
     TS_ASSERT_EQUALS(t1_2,t0+deltahours(1));
     TS_ASSERT_EQUALS(YMDhms(2016,3,27,1),cet.calendar_units(t1_2));
     TS_ASSERT_EQUALS(t1_3,t0+deltahours(2));
-
+	TS_ASSERT_EQUALS(1,cet.diff_units(t0,t1_3,deltahours(3)))
     /// case 2: 25 hour, summer->winter
     t0 = cet.time(YMDhms(2016,10,30));
     t1 = cet.add(t0,calendar::DAY,1);


### PR DESCRIPTION
Extended calendar/time-axis functionality and handling of dst to cover 
timestep > 1h < 1 day.

Previously, dls support only for  >= day timesteps.

