### PR TITLE
actual evapotranspiration fix so that is independent of timestep

### DIFF
--- a/api/boostpython/api_actual_evapotranspiration.cpp
+++ b/api/boostpython/api_actual_evapotranspiration.cpp
@@ -16,7 +16,7 @@ namespace expose {
             .def_readwrite("ae",&response::ae)
             ;
         def("ActualEvapotranspirationCalculate_step",calculate_step,args("water_level","potential_evapotranspiration","scale_factor","snow_fraction","dt"),
-             " actual_evapotranspiration calculates actual evapotranspiration for a timestep dt[s]\n"
+             " actual_evapotranspiration calculates actual evapotranspiration, returning same unit as input pot.evap\n"
              " based on supplied parameters\n"
              "\n"
              " * param water_level[mm]\n"

--- a/core/actual_evapotranspiration.h
+++ b/core/actual_evapotranspiration.h
@@ -52,9 +52,7 @@ namespace shyft {
 				const double scale_factor,
 				const double snow_fraction,
 				const utctime dt) {
-				const double dh = double(dt)/calendar::HOUR;
-				const double scale = scale_factor*dh/3.0;
-				return potential_evapotranspiration*(1.0 - exp(-water_level/scale))*(1.0 - snow_fraction)/dh;
+				return potential_evapotranspiration*(1.0 - exp(-water_level*3.0/ scale_factor))*(1.0 - snow_fraction);
 			}
 		};
 	};

--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -284,7 +284,7 @@ namespace shyft {
                 //
 
                 // PriestleyTaylor (scale by timespan since it delivers results in mm/s)
-                double pot_evap = pt.potential_evapotranspiration(temp, rad, rel_hum)*period.timespan();
+                double pot_evap = pt.potential_evapotranspiration(temp, rad, rel_hum)*period.timespan()/calendar::HOUR; // mm/h 
                 response.pt.pot_evapotranspiration=pot_evap;
 
                 // Gamma Snow

--- a/core/pt_hs_k.h
+++ b/core/pt_hs_k.h
@@ -186,7 +186,7 @@ namespace shyft {
                 //
 
                 // PriestleyTaylor (scale by timespan since it delivers results in mm/s)
-                response.pt.pot_evapotranspiration = pt.potential_evapotranspiration(temp, rad, rel_hum)*period.timespan();
+                response.pt.pot_evapotranspiration = pt.potential_evapotranspiration(temp, rad, rel_hum)*period.timespan()/calendar::HOUR;// mm/h
 
                 // HBVSnow
                 hbv_snow.step(state.snow, response.snow, period.start, period.end, parameter.hs, prec, temp);

--- a/core/pt_ss_k.h
+++ b/core/pt_ss_k.h
@@ -198,7 +198,7 @@ namespace shyft {
                 //
 
                 // PriestleyTaylor (scale by timespan since it delivers results in mm/s)
-                double pot_evap = pt.potential_evapotranspiration(temp, rad, rel_hum)*period.timespan();
+                double pot_evap = pt.potential_evapotranspiration(temp, rad, rel_hum)*period.timespan()/calendar::HOUR;
                 response.pt.pot_evapotranspiration = pot_evap;
 
                 // Snow

--- a/test/actual_evapotranspiration_test.cpp
+++ b/test/actual_evapotranspiration_test.cpp
@@ -13,13 +13,15 @@ void actual_evapotranspiration_test::test_water() {
     const double sca = 0.0;
     const double pot_evap = 5.0; // [mm/h]
     const double scale_factor = 1.0;
-    const utctime dt = deltahours(1);
+    const utctime dt = deltahours(3);
     double act_evap;
 	act_evap = calculate_step(0.0, pot_evap, scale_factor, sca, dt);
     TS_ASSERT_DELTA(act_evap, 0.0, shyfttest::EPS);
 
 	act_evap = calculate_step(1.0e8, pot_evap, scale_factor, sca, dt);
     TS_ASSERT_DELTA(act_evap, pot_evap, shyfttest::EPS);
+
+	TS_ASSERT_DELTA((1-exp(-3*1.0/1.0)), calculate_step(1.0, 1.0, 1.0, 0.0, dt), shyfttest::EPS)
 }
 
 void actual_evapotranspiration_test::test_snow() {


### PR DESCRIPTION
This fix resolves issue reported when running SHyFT at timestep different from hour, like 3hour.

1. The actual evapotranspiration is now calculated as
    input_potential_evap * ( 1- exp(-3.0* kirchner.state.q/ae_scale_factor))* (1-snow_covered_area)

   So given snow_covered_area=0.0, and kirchner.state.q = scale_factor, the ae is 0.95* pe

2. The unit in the response time-series is mm/h for potential and actual evapotranspiration.


 