### PR TITLE
Catchment Identifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - ln -s $HOME/miniconda/include/python3.5m $HOME/miniconda/include/python3.5
 
   # Install dependencies (including fix for boost python build that do not recognize the m -letter variant)
-  - conda create -n shyft_env  pyyaml numpy libgfortran netcdf4 gdal matplotlib requests nose coverage pip shapely pyproj 
+  - conda create -n shyft_env  -c osgeo pyyaml numpy libgfortran netcdf4 gdal matplotlib requests nose coverage pip shapely pyproj 
   - source activate shyft_env
   - ln -s $HOME/miniconda/envs/shyft_env/include/python3.5m $HOME/miniconda/envs/shyft_env/include/python3.5
   - python -V

--- a/core/geo_cell_data.h
+++ b/core/geo_cell_data.h
@@ -6,8 +6,8 @@ namespace shyft {
         /** \brief LandTypeFractions are used to describe 'type of land'
          *   like glacier, lake, reservoir and forest.
          *
-         *   It is designed as a part of GeoCellData (could be nested, but 
-         *   we take python/swig into consideration). It's of course 
+         *   It is designed as a part of GeoCellData (could be nested, but
+         *   we take python/swig into consideration). It's of course
          *   questionable, since we could have individual models for each type
          *   of land, - but current approach is to use a cell-area, and then
          *   describe fractional properties.
@@ -18,12 +18,12 @@ namespace shyft {
 
             /** \brief LandTypeFraction constructor
              *
-             *  Construct the land type fractions based on the sizes of the 
-             *  different land types. Each size should be greater or equal to 
+             *  Construct the land type fractions based on the sizes of the
+             *  different land types. Each size should be greater or equal to
              *  zero.
              */
-            land_type_fractions(double glacier_size, double lake_size, 
-                               double reservoir_size, double forest_size, 
+            land_type_fractions(double glacier_size, double lake_size,
+                               double reservoir_size, double forest_size,
                                double unspecified_size) {
                 // TODO: Is this needed?
                 glacier_size = std::max(0.0, glacier_size);
@@ -39,7 +39,7 @@ namespace shyft {
                     reservoir_ = reservoir_size/sum;
                     forest_ = forest_size/sum;
                 }
-                else 
+                else
                     glacier_ = lake_ = reservoir_ = forest_ = 0.0;
             }
             double glacier() const { return glacier_; }
@@ -55,7 +55,7 @@ namespace shyft {
                     lake /= sum;
                     reservoir /= sum;
                     forest /= sum;
-                } else if (sum > 1.0  || 
+                } else if (sum > 1.0  ||
                           (glacier < 0.0 || lake < 0.0 || reservoir < 0.0 || forest < 0.0))
                    throw std::invalid_argument("LandTypeFractions:: must be >=0.0 and sum <= 1.0");
                 glacier_ = glacier; lake_ = lake; reservoir_ = reservoir; forest_ = forest;
@@ -82,7 +82,7 @@ namespace shyft {
 		 */
 		struct geo_cell_data {
 		    static const int default_area_m2=1000000;
-			geo_cell_data() :area_m2(default_area_m2),catchment_id_(-1),radiation_slope_factor_(default_radiation_slope_factor){}
+			geo_cell_data() :catchment_ix(0),area_m2(default_area_m2),catchment_id_(-1),radiation_slope_factor_(default_radiation_slope_factor){}
 
 			geo_cell_data(geo_point mid_point,double area=default_area_m2,
                 int catchment_id = -1, double radiation_slope_factor=default_radiation_slope_factor,const land_type_fractions& land_type_fractions=land_type_fractions()):
@@ -95,6 +95,7 @@ namespace shyft {
 			const land_type_fractions& land_type_fractions_info() const { return fractions; }
 			void set_land_type_fractions(const land_type_fractions& ltf) { fractions = ltf; }
 			double area() const { return area_m2; }
+			size_t catchment_ix; // internally generated zero-based catchment index, used to correlate to calc-filter, ref. region_model
 		  private:
 
 			geo_point mid_point_; // midpoint

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -517,7 +517,7 @@ namespace shyft{
                     model.catchment_discharges(catchment_d);
                 pts_t discharge_sum(model.time_axis,0.0,shyft::timeseries::POINT_AVERAGE_VALUE);
                 for(auto i : t.catchment_indexes)
-                    discharge_sum.add(catchment_d[i]);
+                    discharge_sum.add(catchment_d[model.cix_from_cid(i)]);// important! the catchment_d(ischarge) is in internal index order
                 return discharge_sum;
             }
 

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -176,7 +176,6 @@ namespace shyft{
 			typedef PS target_time_series_t;
 			target_specification()
               : scale_factor(1.0), calc_mode(NASH_SUTCLIFFE), catchment_property(DISCHARGE), s_r(1.0), s_a(1.0), s_b(1.0) {}
-#ifndef SWIG
 			target_specification(const target_specification& c)
               : ts(c.ts), catchment_indexes(c.catchment_indexes), scale_factor(c.scale_factor),
                 calc_mode(c.calc_mode),catchment_property(c.catchment_property), s_r(c.s_r), s_a(c.s_a), s_b(c.s_b) {}
@@ -207,11 +206,10 @@ namespace shyft{
 			bool operator==(const target_specification& x) const {
 			    return catchment_indexes == x.catchment_indexes && catchment_property==x.catchment_property;
 			}
-#endif
             /** \brief Constructs a target specification element for calibration, specifying all neede parameters
              *
              * \param ts; the target time-series that contain the target/observed discharge values
-             * \param cids;  a vector of the catchment ids (zero-based) in the model that together should add up to the target time-series
+             * \param cids;  a vector of the catchment ids in the model that together should add up to the target time-series
              * \param scale_factor; the weight that this target_specification should have relative to the possible other target_specs.
              */
 			target_specification(const target_time_series_t& ts, vector<int> cids, double scale_factor,
@@ -220,7 +218,7 @@ namespace shyft{
               : ts(ts), catchment_indexes(cids), scale_factor(scale_factor),
                 calc_mode(calc_mode), catchment_property(catchment_property_), s_r(s_r), s_a(s_a), s_b(s_b) {}
 			target_time_series_t ts; ///< The target ts, - any type that is time-series compatible
-			std::vector<int> catchment_indexes; ///< the catchment_indexes (zero based) that denotes the catchments in the model that together should match the target ts
+			std::vector<int> catchment_indexes; ///< the catchment_indexes that denotes the catchments in the model that together should match the target ts
 			double scale_factor; ///<< the scale factor to be used when considering multiple target_specifications.
 			target_spec_calc_type calc_mode;///< *NASH_SUTCLIFFE, KLING_GUPTA
 			catchment_property_type catchment_property;///<  *DISCHARGE,SNOW_COVERED_AREA, SNOW_WATER_EQUIVALENT
@@ -230,7 +228,6 @@ namespace shyft{
 		};
 
 
-        #ifndef SWIG
         ///< template helper classes to be used in enable_if_t in the optimizer for snow swe/sca:
         template< bool B, class T = void >
         using enable_if_tx = typename enable_if<B,T>::type;
@@ -281,7 +278,6 @@ namespace shyft{
                 }
             };
 
-        #endif // SWIG
 
 		/** \brief The optimizer for parameters in a \ref shyft::core::region_model
 		 * provides needed functionality to orchestrate a search for the optimal parameters so that the goal function
@@ -317,7 +313,6 @@ namespace shyft{
             typedef typename M::cell_t cell_t;
             typedef typename cell_t::response_collector_t response_collector_t;
           private:
-#ifndef SWIG
 		public:
             PA& parameter_accessor; ///<  a *reference* to the model parameters in the target  model, all cells share this!
             region_model_t& model; ///< a reference to the region model that we optimize
@@ -352,7 +347,6 @@ namespace shyft{
 				return r;
 			}
 
-#endif
 		public:
 			/**\brief construct an opt model for ptgsk, use p_min=p_max to disable optimization for a parameter
 			* \param model reference to the model to be optimized, the model should be initialized, i.e. the interpolation step done.
@@ -477,7 +471,6 @@ namespace shyft{
 				p_expanded = full_vector_of_parameters;// ensure all parameters are  according to full_vector..
 				return run(reduce_p_vector(full_vector_of_parameters));// then run with parameters as if from optimize
 			}
-#ifndef SWIG
             friend class calibration_test;// to enable testing of individual methods
 			/** called by bobyqua: */
             double operator() (const column_vector& p_s) { return run(from_scaled(p_s)); }
@@ -537,13 +530,13 @@ namespace shyft{
             vector<area_ts> extract_area_ts_property( property_ts_function && tsf) const {
                 vector<area_ts> r(n_catchments,area_ts(0.0,pts_t(model.time_axis,0.0,shyft::timeseries::POINT_AVERAGE_VALUE)));
                 for(const auto& c: *model.get_cells()) {
-                    if (model.is_calculated(c.geo.catchment_id())){
-                        r[c.geo.catchment_id()].ts.add_scale(tsf(c),c.geo.area());//the only ref. to snow_sca
-                        r[c.geo.catchment_id()].area += c.geo.area(); //using entire cell geo area for now.
+                    if (model.is_calculated_by_catchment_ix(c.geo.catchment_ix)){
+                        r[c.geo.catchment_ix].ts.add_scale(tsf(c),c.geo.area());//the only ref. to snow_sca
+                        r[c.geo.catchment_ix].area += c.geo.area(); //using entire cell geo area for now.
                     }
                 }
                 for(size_t i=0;i<n_catchments;++i)
-                    if(model.is_calculated(i))
+                    if(model.is_calculated_by_catchment_ix(i))
                         r[i].ts.scale_by(1/r[i].area);
                 return r;
             }
@@ -552,7 +545,8 @@ namespace shyft{
             pts_t compute_weighted_area_ts_average(const target_specification_t& t, const vector<area_ts>& ats) const {
                 pts_t ts_sum(model.time_axis,0.0,shyft::timeseries::POINT_AVERAGE_VALUE);
                 double a_sum=0.0;
-                for(auto i:t.catchment_indexes) {
+                for(auto cid:t.catchment_indexes) {
+                    auto i=model.cix_from_cid(cid); // need to get the catchment zero-based index here
                     ts_sum.add_scale(ats[i].ts,ats[i].area);
                     a_sum += ats[i].area;
                 }
@@ -652,7 +646,6 @@ namespace shyft{
 				}
 				return goal_function_value;
 			}
-#endif
         };
 
 

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -215,9 +215,26 @@ namespace shyft {
             //     we can extract cell-level into into the catchments
 
             parameter_t_ region_parameter;///< applies to all cells, except those with catchment override
-            std::map<int, parameter_t_> catchment_parameters;///<  for each catchment parameter is possible
+            std::map<int, parameter_t_> catchment_parameters;///<  for each catchment (with cid) parameter is possible
 
             std::vector<bool> catchment_filter;///<if active (alias .size()>0), only calc if catchment_filter[catchment_id] is true.
+            std::vector<int> cix_to_cid;///< maps internal zero-based catchment index ix to externally supplied catchment id.
+            std::map<int,int> cid_to_cix;///< map external catchment id to internal index
+
+            void update_ix_to_id_mapping() {
+                // iterate over cell-vector
+                // map<id,ix>
+                // if new id, push it, map-it
+                cid_to_cix.clear();
+                cix_to_cid.clear();
+                for(auto&c:*cells) {
+                    if(cid_to_cix.find(c.geo.catchment_id())==cid_to_cix.end()) {
+                        cid_to_cix[c.geo.catchment_id()]=cix_to_cid.size();
+                        c.geo.catchment_ix=cix_to_cid.size();// assign catchment ix to cell.
+                        cix_to_cid.push_back(c.geo.catchment_id());// keep map
+                    }
+                }
+            }
 
             size_t n_catchments;///< optimized//extracted as max(cell.geo.catchment_id())+1 in run interpolate
 
@@ -229,6 +246,8 @@ namespace shyft {
                 n_catchments = c.n_catchments;
                 catchment_parameters.clear();
                 // Then, clone from c
+                cix_to_cid=c.cix_to_cid;
+                cid_to_cix=c.cid_to_cix;
                 cells = cell_vec_t_(new cell_vec_t(*(c.cells)));
                 set_region_parameter(*(c.region_parameter));
                 for(const auto& pair:c.catchment_parameters)
@@ -246,32 +265,29 @@ namespace shyft {
              : cells(cells) {
                 set_region_parameter(region_param);// ensure we have a correct model
                 ncore = thread::hardware_concurrency()*4;
+                update_ix_to_id_mapping();
             }
             region_model(std::shared_ptr<std::vector<C> >& cells,
                          const parameter_t &region_param,
                          const std::map<int, parameter_t>& catchment_parameters)
              : cells(cells) {
                 set_region_parameter(region_param);
+                update_ix_to_id_mapping();
                 for(const auto & pair:catchment_parameters)
                      set_catchment_parameter(pair.first, pair.second);
                 ncore = thread::hardware_concurrency()*4;
             }
             region_model(const region_model& model) { clone(model); }
-			#ifndef SWIG
 			region_model& operator=(const region_model& c) {
                 if (&c != this)
                     clone(c);
                 return *this;
             }
-			#endif
             timeaxis_t time_axis; ///<The time_axis as set from run_interpolation, determines the axis for run()..
             size_t ncore = 0; ///<< defaults to 4x hardware concurrency, controls number of threads used for cell processing
             /** \brief compute and return number of catchments inspecting call cells.geo.catchment_id() */
             size_t number_of_catchments() const {
-                size_t max_catchment_id=0;
-                for(const auto&c:*cells)
-                    if(c.geo.catchment_id()>max_catchment_id) max_catchment_id=c.geo.catchment_id();
-                return max_catchment_id+1;
+                return cix_to_cid.size();
             }
             /** \brief run_interpolation interpolates region_environment temp,precip,rad.. point sources
             * to a value representative for the cell.mid_point().
@@ -292,7 +308,6 @@ namespace shyft {
             */
             template < class RE, class IP>
             void run_interpolation(const IP& interpolation_parameter, const timeaxis_t& time_axis, const RE& env) {
-                #ifndef SWIG
                 for(auto&c:*cells){
                     c.init_env_ts(time_axis);
                 }
@@ -401,7 +416,6 @@ namespace shyft {
                 idw_radiation.get();
                 idw_wind_speed.get();
                 idw_rel_hum.get();
-                #endif
             }
 
             /** \brief run_cells calculations over specified time_axis
@@ -512,10 +526,14 @@ namespace shyft {
              */
             void set_catchment_calculation_filter(const std::vector<int>& catchment_id_list) {
                 if (catchment_id_list.size()) {
-                    int mx = 0;
-                    for (auto i : catchment_id_list) mx = i > mx ? i : mx;
-                    catchment_filter = vector<bool>(mx + 1, false);
-                    for (auto i : catchment_id_list) catchment_filter[i] = true;
+                    if(catchment_id_list.size()> cix_to_cid.size())
+                        throw std::runtime_error("set_catchment_calculation_filter: supplied list > available catchments");
+                    for(auto cid:catchment_id_list) {
+                        if(cid_to_cix.find(cid)==cid_to_cix.end())
+                            throw std::runtime_error("set_catchment_calculation_filter: no cells have supplied cid");
+                    }
+                    catchment_filter = vector<bool>(cix_to_cid.size(), false);
+                    for (auto i : catchment_id_list) catchment_filter[cid_to_cix[i]] = true;
                 } else {
                     catchment_filter.clear();
                 }
@@ -525,8 +543,18 @@ namespace shyft {
              * \param cid  catchment id
              * \returns true if catchment id is calculated during runs
              */
-            bool is_calculated(size_t cid) const { return catchment_filter.size() == 0 || (catchment_filter[cid]); }
+            bool is_calculated(size_t cid) const {
+                return is_calculated_by_catchment_ix(cix_from_cid(cid));
+            }
 
+            bool is_calculated_by_catchment_ix(size_t cix) const {return catchment_filter.size() == 0 || (catchment_filter[cix]);}
+
+            size_t cix_from_cid(size_t cid) const {
+                auto cix=cid_to_cix.find(cid);
+                if(cix == cid_to_cix.end())
+                    throw runtime_error("region_model: no match for cid in map lookup");
+                return cix->second;
+            }
             /** \brief collects current state from all the cells
             * \note that catchment filter can influence which states are calculated/updated.
             *\param end_states a reference to the vector<state_t> that are filled with cell state, in order of appearance.
@@ -580,7 +608,6 @@ namespace shyft {
              * \note the ts type should have proper move/copy etc. semantics
              *
              */
-            #ifndef SWIG
             template <class TSV>
             void catchment_discharges( TSV& cr) const {
                 typedef typename TSV::value_type ts_t;
@@ -590,13 +617,11 @@ namespace shyft {
                     cr.emplace_back(ts_t(time_axis, 0.0));
                 }
                 for(const auto& c: *cells) {
-                    if (is_calculated(c.geo.catchment_id()))
-                        cr[c.geo.catchment_id()].add(c.rc.avg_discharge);
+                    if ( is_calculated_by_catchment_ix(c.geo.catchment_ix))
+                        cr[c.geo.catchment_ix].add(c.rc.avg_discharge);
                 }
             }
-            #endif
         protected:
-            #ifndef SWIG
             /** \brief parallell_run using a mid-point split + async to engange multicore execution
              *
              * \param time_axis forwarded to the cell.run(time_axis)
@@ -605,7 +630,7 @@ namespace shyft {
              */
             void single_run(const timeaxis_t& time_axis, cell_iterator beg, cell_iterator endc) {
                 for(auto& cell:boost::make_iterator_range(beg,endc)) {
-                     if (catchment_filter.size() == 0 || (cell.geo.catchment_id() < catchment_filter.size() && catchment_filter[cell.geo.catchment_id()]))
+                     if (is_calculated_by_catchment_ix(cell.geo.catchment_ix))
                         cell.run(time_axis);
                 }
             }
@@ -641,12 +666,7 @@ namespace shyft {
                     f.get();
                 return;
             }
-            #endif
         };
-
-
-
-
 
     } // core
 } // shyft

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -228,11 +228,14 @@ namespace shyft {
                 cid_to_cix.clear();
                 cix_to_cid.clear();
                 for(auto&c:*cells) {
-                    if(cid_to_cix.find(c.geo.catchment_id())==cid_to_cix.end()) {
+					auto found = cid_to_cix.find(c.geo.catchment_id());
+                    if(found==cid_to_cix.end()) {
                         cid_to_cix[c.geo.catchment_id()]=cix_to_cid.size();
                         c.geo.catchment_ix=cix_to_cid.size();// assign catchment ix to cell.
                         cix_to_cid.push_back(c.geo.catchment_id());// keep map
-                    }
+					} else {
+						c.geo.catchment_ix = found->second;// assign corresponding ix.
+					}
                 }
             }
 
@@ -606,7 +609,7 @@ namespace shyft {
              *  -# .ct(timeaxis_t, double) fills a series with 0.0 for all time_axis elements
              *  -# .add( const some_ts & ts)
              * \note the ts type should have proper move/copy etc. semantics
-             *
+             * \treturns filled in cr, dimensioned to number of catchments, where the i'th entry correspond to cid using cix_to_cid(i)
              */
             template <class TSV>
             void catchment_discharges( TSV& cr) const {


### PR DESCRIPTION
This PR internalize the previousely 0-based catchment-identifers (cids), so that the user can use cids that relates to external identities.

Internally SHyFT are still using internal 0-based cids for performance reasons.

There are no changes externally, except for the relaxed requirement to cids that now can be any integer.
 
Another PR related to simplifying the python parts (cid-map to internal-id map) will be submitted later.

