### PR TITLE
Gis server switch

### DIFF
--- a/shyft/orchestration/configuration/yaml_constructors.py
+++ b/shyft/orchestration/configuration/yaml_constructors.py
@@ -41,6 +41,8 @@ def region_model_repo_constructor(cls,region_config, model_config, region_model_
         from six import iteritems # This replaces dictionary.iteritems() on Python 2 and dictionary.items() on Python 3
 
         repo_params = region_config.repository()['params']
+        server_name = repo_params.get('server_name')
+        server_name_preprod = repo_params.get('server_name_preprod')
         use_cache = repo_params.get('use_cache', False)
         cache_folder = repo_params.get('cache_folder', None)
         cache_file_type = repo_params.get('cache_file_type', None)
@@ -57,7 +59,8 @@ def region_model_repo_constructor(cls,region_config, model_config, region_model_
                                   "if 'use_cache' or 'get_bbox_from_catchment_boundary' is enabled".format(dx, dy))
         if get_bbox_from_catchment_boundary:
             grid_specification = get_grid_spec_from_catch_poly(c_ids, repo_params['catchment_regulated_type'],
-                                                               repo_params['service_id_field_name'], epsg_id, dx, pad)
+                                                               repo_params['service_id_field_name'], epsg_id, dx, pad,
+                                                               server_name=server_name, server_name_preprod=server_name_preprod)
         else:
             grid_specification = GridSpecification(epsg_id, d['lower_left_x'], d['lower_left_y'],
                                                    dx, dy, d['nx'], d['ny'])
@@ -106,11 +109,14 @@ def region_model_repo_constructor(cls,region_config, model_config, region_model_
             RegionModelConfig(region_model_id, region_model_type, region_parameter, grid_specification,
                               repo_params['catchment_regulated_type'], repo_params['service_id_field_name'],
                               region_config.catchments(), catchment_parameters=catchment_parameters,
-                              server_name=repo_params.get('server_name', None),
-                              server_name_preprod=repo_params.get('server_name_preprod', None)),
+                              ),
         ]
         rm_cfg_dict = {x.name: x for x in cfg_list}
         # return GisRegionModelRepository(rm_cfg_dict)
+        if server_name is not None:
+            cls.server_name = repo_params.get('server_name')
+        if server_name_preprod is not None:
+            cls.server_name_preprod = repo_params.get('server_name_preprod')
         return cls(rm_cfg_dict, use_cache=use_cache, cache_folder=cache_folder, cache_file_type=cache_file_type)
     else:
         return cls(region_config, model_config)

--- a/shyft/orchestration/configuration/yaml_constructors.py
+++ b/shyft/orchestration/configuration/yaml_constructors.py
@@ -19,7 +19,8 @@ def geo_ts_repo_constructor(cls, params): # ,region_config):
         #epsg = region_config.domain()["EPSG"]
         epsg = params['epsg']
         met_stations = [MetStationConfig(**s) for s in params['stations_met']]
-        gis_location_repository=GisLocationService() # this provides the gis locations for my stations
+        gis_location_repository=GisLocationService(server_name=params.get('server_name', None),
+                              server_name_preprod=params.get('server_name_preprod', None)) # this provides the gis locations for my stations
         smg_ts_repository = SmGTsRepository(PROD,FC_PROD) # this provide the read function for my time-series
         # return GeoTsRepository(epsg_id=epsg, geo_location_repository=gis_location_repository,
         #                        ts_repository=smg_ts_repository, met_station_list=met_stations,
@@ -104,7 +105,9 @@ def region_model_repo_constructor(cls,region_config, model_config, region_model_
         cfg_list=[
             RegionModelConfig(region_model_id, region_model_type, region_parameter, grid_specification,
                               repo_params['catchment_regulated_type'], repo_params['service_id_field_name'],
-                              region_config.catchments(), catchment_parameters=catchment_parameters),
+                              region_config.catchments(), catchment_parameters=catchment_parameters,
+                              server_name=repo_params.get('server_name', None),
+                              server_name_preprod=repo_params.get('server_name_preprod', None)),
         ]
         rm_cfg_dict = {x.name: x for x in cfg_list}
         # return GisRegionModelRepository(rm_cfg_dict)

--- a/shyft/repository/service/gis_location_service.py
+++ b/shyft/repository/service/gis_location_service.py
@@ -21,6 +21,16 @@ class GisLocationService(GeoLocationRepository):
         self.server_port=server_port
         self.service_index=service_index
 
+    def _get_response(self, url, **kwargs):
+        response = requests.get(url, **kwargs)
+        if response.status_code != 200:
+            raise StationDataError("Could not get data from GIS service!")
+        data = response.json()
+        if "features" not in data:
+            raise StationDataError(
+                "GeoJson data missing mandatory field, please check your gis service or your query.")
+        return data
+
     def build_query(self,base_fetcher,station_ids,epsg_id):
         q = base_fetcher.get_query()
         if station_ids is None:
@@ -45,22 +55,26 @@ class GisLocationService(GeoLocationRepository):
         """
         base_fetcher= BaseGisDataFetcher(epsg_id=epsg_id,geometry=None, server_name=self.server_name, server_port=self.server_port, service_index=self.service_index)
         q = self.build_query(base_fetcher,location_id_list,epsg_id)
-        response = requests.get(base_fetcher.url, params=q)
+        # response = requests.get(base_fetcher.url, params=q)
         locations = {}
         station_info={}
-        if response.status_code == 200:
-            for feature in response.json()['features']:
-                index = feature["attributes"]["OBJECTID"]
-                x = feature["geometry"]["x"]
-                y = feature["geometry"]["y"]
-                z = feature["attributes"]["MOH"]
-                name = unicodedata.normalize('NFKC', feature["attributes"]["ST_NAVN"])
-                name = str(str(name).encode("ascii", errors="replace"))
+        try:
+            data = self._get_response(base_fetcher.url, params=q)
+        except:
+            data = self._get_response(base_fetcher.url.replace(self.server_name, base_fetcher.server_name_preprod), params=q)
+        # if response.status_code == 200:
+        for feature in data['features']:
+            index = feature["attributes"]["OBJECTID"]
+            x = feature["geometry"]["x"]
+            y = feature["geometry"]["y"]
+            z = feature["attributes"]["MOH"]
+            name = unicodedata.normalize('NFKC', feature["attributes"]["ST_NAVN"])
+            name = str(str(name).encode("ascii", errors="replace"))
 
-                locations[index] = (x,y,z)
-                station_info[index]= {"owner": feature["attributes"]["EIER"],"name": name}
-        else:
-            raise StationDataError("Could not get data from GIS service!")
+            locations[index] = (x,y,z)
+            station_info[index]= {"owner": feature["attributes"]["EIER"],"name": name}
+        # else:
+        #     raise StationDataError("Could not get data from GIS service!")
         return locations,station_info
 
 

--- a/shyft/repository/service/gis_location_service.py
+++ b/shyft/repository/service/gis_location_service.py
@@ -15,10 +15,14 @@ class GisLocationService(GeoLocationRepository):
 
     """
 
-    def __init__(self, server_name="oslwvagi001p", server_name_preprod = "oslwvagi001q", server_port="6080", service_index=5 ):
+    def __init__(self, server_name=None, server_name_preprod = None, server_port="6080", service_index=5 ):
         super(GeoLocationRepository, self).__init__()
-        self.server_name=server_name
-        self.server_name_preprod=server_name_preprod
+        self.server_name="oslwvagi001p"
+        self.server_name_preprod="oslwvagi001q"
+        if server_name is not None:
+            self.server_name = server_name
+        if server_name_preprod is not None:
+            self.server_name_preprod = server_name_preprod
         self.server_port=server_port
         self.service_index=service_index
 

--- a/shyft/repository/service/gis_location_service.py
+++ b/shyft/repository/service/gis_location_service.py
@@ -67,7 +67,10 @@ class GisLocationService(GeoLocationRepository):
         station_info={}
         try:
             data = self._get_response(base_fetcher.url, params=q)
-        except:
+        except Exception as e:
+            print('Error in fetching GIS data: {}'.format('Station locations'))
+            print('Error description: {}'.format(str(e)))
+            print('Switching from PROD server {} to PREPROD server {}'.format(self.server_name, self.server_name_preprod))
             data = self._get_response(base_fetcher.url.replace(base_fetcher.server_name, base_fetcher.server_name_preprod), params=q)
         # if response.status_code == 200:
         for feature in data['features']:

--- a/shyft/repository/service/gis_location_service.py
+++ b/shyft/repository/service/gis_location_service.py
@@ -15,9 +15,10 @@ class GisLocationService(GeoLocationRepository):
 
     """
 
-    def __init__(self, server_name="oslwvagi001p", server_port="6080", service_index=5 ):
+    def __init__(self, server_name="oslwvagi001p", server_name_preprod = "oslwvagi001q", server_port="6080", service_index=5 ):
         super(GeoLocationRepository, self).__init__()
         self.server_name=server_name
+        self.server_name_preprod=server_name_preprod
         self.server_port=server_port
         self.service_index=service_index
 
@@ -53,7 +54,9 @@ class GisLocationService(GeoLocationRepository):
         tuple(location-dict(station:position),info-dict(station:info-dict))
 
         """
-        base_fetcher= BaseGisDataFetcher(epsg_id=epsg_id,geometry=None, server_name=self.server_name, server_port=self.server_port, service_index=self.service_index)
+        base_fetcher= BaseGisDataFetcher(epsg_id=epsg_id,geometry=None, server_name=self.server_name,
+                                         server_name_preprod=self.server_name_preprod,
+                                         server_port=self.server_port, service_index=self.service_index)
         q = self.build_query(base_fetcher,location_id_list,epsg_id)
         # response = requests.get(base_fetcher.url, params=q)
         locations = {}
@@ -61,7 +64,7 @@ class GisLocationService(GeoLocationRepository):
         try:
             data = self._get_response(base_fetcher.url, params=q)
         except:
-            data = self._get_response(base_fetcher.url.replace(self.server_name, base_fetcher.server_name_preprod), params=q)
+            data = self._get_response(base_fetcher.url.replace(base_fetcher.server_name, base_fetcher.server_name_preprod), params=q)
         # if response.status_code == 200:
         for feature in data['features']:
             index = feature["attributes"]["OBJECTID"]

--- a/shyft/repository/service/gis_region_model_repository.py
+++ b/shyft/repository/service/gis_region_model_repository.py
@@ -452,7 +452,7 @@ class DTMFetcher(object):
         self.server_name = server_name  # PROD
         self.server_name_preprod = server_name_preprod  # PREPROD
         self.server_port = "6080"
-        self.url_template = "http://{}:{}/arcgis/rest/services/Enki/Norway_DTM_1000m/ImageServer/exportImage"  # PROD
+        self.url_template = "http://{}:{}/arcgis/rest/services/SHyFT/Norway_DTM_1000m/ImageServer/exportImage"  # PROD
 
         self.query = dict(
             bboxSR=self.grid_specification.epsg(),

--- a/shyft/repository/service/gis_region_model_repository.py
+++ b/shyft/repository/service/gis_region_model_repository.py
@@ -239,7 +239,7 @@ class LandTypeFetcher(BaseGisDataFetcher):
         # if response.status_code != 200:
         #     raise GisDataFetchError("Could not fetch land type data from gis server.")
         # data = response.json()
-        data = self.get_response("Land type",params=q)
+        data = self.get_response(name,params=q)
         polygons = []
         if 'error' in data.keys():
             raise GisDataFetchError("Failed in GIS service:" + data['error']['message'])

--- a/shyft/repository/service/gis_region_model_repository.py
+++ b/shyft/repository/service/gis_region_model_repository.py
@@ -116,10 +116,7 @@ class BaseGisDataFetcher(object):
         self.service_index = service_index
         self.geometry = geometry
         self.epsg_id = epsg_id
-        if server_name.endswith('p'):
-            self.url_template = "http://{}:{}/arcgis/rest/services/SHyFT/SHyFT/MapServer/{}/query"
-        else:
-            self.url_template = "http://{}:{}/arcgis/rest/services/SHyFT/SHyFT/MapServer/{}/query"
+        self.url_template = "http://{}:{}/arcgis/rest/services/SHyFT/SHyFT/MapServer/{}/query"
         self.adj_proxy_setting(self.server_name)
 
         self.query = dict(text="",

--- a/shyft/tests/test_gis_region_model_repository.py
+++ b/shyft/tests/test_gis_region_model_repository.py
@@ -144,7 +144,7 @@ try:
             return api.pt_gs_k.PTGSKParameter(pt_params, gs_params, ae_params, k_params, p_params)
 
         def test_region_model_nea_nidelv(self):
-            nea_nidelv_grid_spec = GridSpecification(epsg_id=32633, x0=270000.0, y0=7035000.0, dx=1000, dy=1000, nx=105, ny=75)
+            nea_nidelv_grid_spec = GridSpecification(epsg_id=32633, x0=266000.0, y0=6960000.0, dx=1000, dy=1000, nx=109, ny=80)
             catch_ids = [1228, 1308, 1394, 1443, 1726, 1867, 1996, 2041, 2129, 2195, 2198, 2277, 2402, 2446, 2465, 2545,
                          2640, 2718, 3002, 3536, 3630]  #  , 1000010, 1000011]
             ptgsk_params = self.std_ptgsk_parameters


### PR DESCRIPTION
This PR inculdes the following:

- Automatic switching of gis service server from PROD to PREPROD

- Usage of server names as parameters to GIS related classes and handling of this in yaml based configuration and orchestration

- Fix to a test for gis_region_model_repo caused by mismatch between bounding-box and catchment location 