### PR TITLE
Extend parameter list

### DIFF
--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -47,7 +47,7 @@ namespace shyft {
             kirchner_parameter_t  kirchner;
             precipitation_correction_parameter_t p_corr;
             ///<calibration support, needs vector interface to params, size is the total count
-            size_t size() const { return 21; }
+            size_t size() const { return 24; }
             ///<calibration support, need to set values from ordered vector
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -74,6 +74,9 @@ namespace shyft {
                 gs.snow_cv_altitude_factor=p[i++];
 				pt.albedo = p[i++];
 				pt.alpha = p[i++];
+				gs.initial_bare_ground_fraction = p[i++];
+				gs.winter_end_day_of_year = size_t(p[i++]);
+				gs.calculate_iso_pot_energy = p[i++] != 0.0 ? true : false;
             }
 
             ///< calibration support, get the value of i'th parameter
@@ -100,6 +103,10 @@ namespace shyft {
                     case 18:return gs.snow_cv_altitude_factor;
 					case 19:return pt.albedo;
 					case 20:return pt.alpha;
+					case 21:return gs.initial_bare_ground_fraction;
+					case 22:return gs.winter_end_day_of_year;
+					case 23:return gs.calculate_iso_pot_energy ? 1.0 : 0.0;
+
                 default:
                     throw runtime_error("PTGSK Parameter Accessor:.get(i) Out of range.");
                 }
@@ -129,7 +136,10 @@ namespace shyft {
                     "gs.snow_cv_forest_factor",
                     "gs.snow_cv_altitude_factor",
                     "pt.albedo",
-                    "pt.alpha"
+                    "pt.alpha",
+					"gs.initial_bare_ground_fraction",
+					"gs.winter_end_day_of_year",
+					"gs.calculate_iso_pot_energy"
                 };
                 if (i >= size())
                     throw runtime_error("PTGSK Parameter Accessor:.get_name(i) Out of range.");

--- a/shyft/tests/api/test_calibration_types.py
+++ b/shyft/tests/api/test_calibration_types.py
@@ -84,7 +84,22 @@ class ShyftApi(unittest.TestCase):
         "gs.winter_end_day_of_year",
         "gs.calculate_iso_pot_energy"
         ]
-        self.verify_parameter_for_calibration(pt_gs_k.PTGSKParameter(), ptgsk_size,valid_names)
+        p=pt_gs_k.PTGSKParameter()
+        self.verify_parameter_for_calibration(p, ptgsk_size,valid_names)
+        #special verification of bool parameter
+        p.gs.calculate_iso_pot_energy = True
+        self.assertTrue(p.gs.calculate_iso_pot_energy)
+        self.assertAlmostEqual(p.get(23),1.0,0.00001)
+        p.gs.calculate_iso_pot_energy = False
+        self.assertFalse(p.gs.calculate_iso_pot_energy)
+        self.assertAlmostEqual(p.get(23), 0.0, 0.00001)
+        pv = api.DoubleVector.from_numpy([p.get(i) for i in range(p.size())])
+        pv[23]=1.0
+        p.set(  pv)
+        self.assertTrue(p.gs.calculate_iso_pot_energy)
+        pv[23]=0.0;
+        p.set(pv)
+        self.assertFalse(p.gs.calculate_iso_pot_energy)
 
     def test_pt_ss_k_param(self):
         ptssk_size = 15

--- a/shyft/tests/api/test_calibration_types.py
+++ b/shyft/tests/api/test_calibration_types.py
@@ -57,7 +57,7 @@ class ShyftApi(unittest.TestCase):
 
 
     def test_pt_gs_k_param(self):
-        ptgsk_size = 21
+        ptgsk_size = 24
         valid_names = [
         "kirchner.c1",
         "kirchner.c2",
@@ -79,7 +79,10 @@ class ShyftApi(unittest.TestCase):
         "gs.snow_cv_forest_factor",
         "gs.snow_cv_altitude_factor",
         "pt.albedo",
-        "pt.alpha"
+        "pt.alpha",
+        "gs.initial_bare_ground_fraction",
+        "gs.winter_end_day_of_year",
+        "gs.calculate_iso_pot_energy"
         ]
         self.verify_parameter_for_calibration(pt_gs_k.PTGSKParameter(), ptgsk_size,valid_names)
 


### PR DESCRIPTION
# Background

pt_gs_k was lacking 3 parameters, for the get(i) get_name(i) and set(v) related to gamma snow.
To ease orchestration and repositories, these are now available for getting/setting etc. so that the parameter yaml files can have the complete parameter configuration that have an impact on the calculated result.

The extra parameters are:
        "gs.initial_bare_ground_fraction":double
        "gs.winter_end_day_of_year" : int, default 100
        "gs.calculate_iso_pot_energy": bool (0.0 or 1.0)

The api does automatic conversion from internal types to external number/float representation, so that setting parameters by vector do give the expected result.

Notice that we do not do any range-check/sanity check when setting parameters. This is entirely up to the repository/user to perform at the perimeter (when reading file, when accepting input from the user).

