### PR TITLE
Enhance shyft core api to ease scripting

### DIFF
--- a/api/boostpython/api_priestley_taylor.cpp
+++ b/api/boostpython/api_priestley_taylor.cpp
@@ -30,7 +30,7 @@ namespace expose {
                 "Calculate PotentialEvapotranspiration, given specified parameters\n"
                 "\n"
                 "	 * param temperature in [degC]\n"
-                "	 * param global_radiation [W/m²]\n"
+                "	 * param global_radiation [W/m2]\n"
                 "	 * param rhumidity in interval [0,1]\n"
                 "	 * return PotentialEvapotranspiration in [mm/s] units\n"
                 "	 *\n"

--- a/api/boostpython/api_skaugen.cpp
+++ b/api/boostpython/api_skaugen.cpp
@@ -34,9 +34,9 @@ namespace expose {
          ;
 
         class_<response>("SkaugenResponse")
-         .def_readwrite("sca",&response::sca,"from snow-routine in [m³/s]")
-         .def_readwrite("swe",&response::swe,"from snow-routine in [m³/s]")
-         .def_readwrite("outflow",&response::outflow,"from snow-routine in [m³/s]")
+         .def_readwrite("sca",&response::sca,"from snow-routine in [m3/s]")
+         .def_readwrite("swe",&response::swe,"from snow-routine in [m3/s]")
+         .def_readwrite("outflow",&response::outflow,"from snow-routine in [m3/s]")
          .def_readwrite("total_stored_water",&response::total_stored_water,"def. as sca*(swe+lwc)")
          ;
 

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -258,6 +258,21 @@ namespace expose {
             "to get back the optimized parameters for the supplied model and target-specification\n"
             )
         )
+        .def("set_target_specification",&Optimizer::set_target_specification,boost::python::args("target_specification","parameter_lower_bound","parameter_upper_bound"),
+            "Set the target specification, parameter lower and upper bound to be used during \n"
+            "subsequent call to the .optimize() methods.\n"
+            "Only parameters with lower_bound != upper_bound will be subject to optimization\n"
+            "The object properties target_specification,lower and upper bound are updated and\n"
+            "will reflect the current setting.\n"
+            "Parameters\n"
+            "----------\n"
+            "target_specification : TargetSpecificationVectorPts\n"
+            "\t the complete target specification composition\n"
+            "parameter_lower_bound : XXXXParameter\n"
+            "\t the lower bounds of the parameters\n"
+            "parameter_upper_bound: XXXXParameter\n"
+            "\t the upper bounds of the parameters\n"
+        )
         .def("establish_initial_state_from_model", &Optimizer::establish_initial_state_from_model,
             "copies the Optimizer referenced region-model current state\n"
             "to a private store in the Optimizer object.\n"

--- a/core/core.vcxproj.filters
+++ b/core/core.vcxproj.filters
@@ -108,11 +108,21 @@
     <ClInclude Include="kalman.h">
       <Filter>interpolation</Filter>
     </ClInclude>
-    <ClInclude Include="hbv_actual_evapotranspiration.h" />
-    <ClInclude Include="hbv_soil.h" />
-    <ClInclude Include="hbv_stack.h" />
-    <ClInclude Include="hbv_stack_cell_model.h" />
-    <ClInclude Include="hbv_tank.h" />
+    <ClInclude Include="hbv_actual_evapotranspiration.h">
+      <Filter>methods</Filter>
+    </ClInclude>
+    <ClInclude Include="hbv_soil.h">
+      <Filter>methods</Filter>
+    </ClInclude>
+    <ClInclude Include="hbv_tank.h">
+      <Filter>methods</Filter>
+    </ClInclude>
+    <ClInclude Include="hbv_stack.h">
+      <Filter>method-stacks</Filter>
+    </ClInclude>
+    <ClInclude Include="hbv_stack_cell_model.h">
+      <Filter>method-stacks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="methods">

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -6,55 +6,55 @@
 #include "dream_optimizer.h"
 #include "sceua_optimizer.h"
 
-namespace shyft{
-	namespace core {
-		namespace model_calibration {
-			/** \brief Minimize the functional defined by model using the BOBYQA method
-			 *
-			 * Solve the optimization problem defined by the model M using the Bounded Optimization by Quadratic Approximation method
-			 * by Michael J. D. Powell. See the "The BOBYQA Algorithm for Bound Constrained Optimization Without Derivatives",
-			 * Technical report, Department of Applied Mathematics and Theoretical Physics, University of Cambridge, 2009.
-			 *
-			 * We use the dlib implementation of this algorithm, see www.dlib.net/optimization.html#find_min_bobyqa.
-			 *
-			 * \tparam M Model to be optimized, implementing the interface:
-			 *   - double operator()(const dlib::matrix<double, 0, 1> params) --> Evaluate the functional for parameter set params.
-			 *   -vector<double> to_scaled(std::vector<double> params) --> Scale original parameters to [0,1]
-			 *   -vector<double> from_scaled(const dlib::matrix<double, 0, 1> scaled_params) --> Unscale parameters
-			 *  \param x --> Initial guess
-			 *  \param max_n_evaluations --> stop/throw if not converging after n evaluations
-			 *  \param tr_start --> Initial trust region radius
-			 *  \param tr_stop --> Stopping trust region radius
-			 */
-			template  <class M>
-			double min_bobyqa(M& model,vector<double>& x,int max_n_evaluations, double tr_start , double tr_stop ) {
+namespace shyft {
+    namespace core {
+        namespace model_calibration {
+            /** \brief Minimize the functional defined by model using the BOBYQA method
+             *
+             * Solve the optimization problem defined by the model M using the Bounded Optimization by Quadratic Approximation method
+             * by Michael J. D. Powell. See the "The BOBYQA Algorithm for Bound Constrained Optimization Without Derivatives",
+             * Technical report, Department of Applied Mathematics and Theoretical Physics, University of Cambridge, 2009.
+             *
+             * We use the dlib implementation of this algorithm, see www.dlib.net/optimization.html#find_min_bobyqa.
+             *
+             * \tparam M Model to be optimized, implementing the interface:
+             *   - double operator()(const dlib::matrix<double, 0, 1> params) --> Evaluate the functional for parameter set params.
+             *   -vector<double> to_scaled(std::vector<double> params) --> Scale original parameters to [0,1]
+             *   -vector<double> from_scaled(const dlib::matrix<double, 0, 1> scaled_params) --> Unscale parameters
+             *  \param x --> Initial guess
+             *  \param max_n_evaluations --> stop/throw if not converging after n evaluations
+             *  \param tr_start --> Initial trust region radius
+             *  \param tr_stop --> Stopping trust region radius
+             */
+            template  <class M>
+            double min_bobyqa(M& model, vector<double>& x, int max_n_evaluations, double tr_start, double tr_stop) {
 
-				typedef dlib::matrix<double, 0, 1> column_vector;
+                typedef dlib::matrix<double, 0, 1> column_vector;
 
-				// Scale all parameter ranges to [0, 1] for better initial trust region radius balance.
-				std::vector<double> x_s = model.to_scaled(x);
+                // Scale all parameter ranges to [0, 1] for better initial trust region radius balance.
+                std::vector<double> x_s = model.to_scaled(x);
 
-				column_vector _x = dlib::mat(x_s);
+                column_vector _x = dlib::mat(x_s);
 
-				// Scaled region min and max
-				column_vector x_l(_x.nr()); x_l = 0.0;
-				column_vector x_u(_x.nr()); x_u = 1.0;
+                // Scaled region min and max
+                column_vector x_l(_x.nr()); x_l = 0.0;
+                column_vector x_u(_x.nr()); x_u = 1.0;
 
-				double res = find_min_bobyqa([&model](column_vector x) { return model(x); },
-					_x,
-					2 * _x.nr() + 1,    // Recommended number of interpolation points
-					x_l,
-					x_u,
-					tr_start,   // initial trust region radius
-					tr_stop,    // stopping trust region radius
-					max_n_evaluations         // max number of objective function evaluations
-					);
+                double res = find_min_bobyqa([&model](column_vector x) { return model(x); },
+                    _x,
+                    2 * _x.nr() + 1,    // Recommended number of interpolation points
+                    x_l,
+                    x_u,
+                    tr_start,   // initial trust region radius
+                    tr_stop,    // stopping trust region radius
+                    max_n_evaluations         // max number of objective function evaluations
+                );
 
-				// Convert back to real parameter range
-				x = model.from_scaled(_x);
-				return res;
-			}
-			///<Template class to transform model evaluation into something that dream can run
+                // Convert back to real parameter range
+                x = model.from_scaled(_x);
+                return res;
+            }
+            ///<Template class to transform model evaluation into something that dream can run
             template<class M>
             struct dream_fx : public shyft::core::optimizer::ifx {
                 M& m;
@@ -71,19 +71,19 @@ namespace shyft{
              * \param max_n_evaluations is the maximum number of iterations, currently not used, the routine returns when convergence is reached
              * \return the goal function of m value, corresponding to the found x-vector
              */
-			template  <class M>
-			double min_dream( M& model, vector<double>& x, int max_n_evaluations) {
-				// Scale all parameter ranges to [0, 1]
-				std::vector<double> x_s = model.to_scaled(x);
+            template  <class M>
+            double min_dream(M& model, vector<double>& x, int max_n_evaluations) {
+                // Scale all parameter ranges to [0, 1]
+                std::vector<double> x_s = model.to_scaled(x);
                 dream_fx<M> fx_m(model);
                 shyft::core::optimizer::dream dr;
-				double res = dr.find_max(fx_m, x_s, max_n_evaluations);
-				// Convert back to real parameter range
-				x = model.from_scaled(x_s);
-				return res;
-			}
+                double res = dr.find_max(fx_m, x_s, max_n_evaluations);
+                // Convert back to real parameter range
+                x = model.from_scaled(x_s);
+                return res;
+            }
 
-			///<Template class to transform model evaluation into something that dream can run
+            ///<Template class to transform model evaluation into something that dream can run
             template<class M>
             struct sceua_fx : public shyft::core::optimizer::ifx {
                 M& m;
@@ -103,158 +103,162 @@ namespace shyft{
              * \throw runtime_error with text sceua: max_iterations reached before convergence
              */
             template <class M>
-            double min_sceua(M& model, vector<double>& x, size_t max_n_evaluations, double x_eps=0.0001, double y_eps=0.0001) {
-				// Scale all parameter ranges to [0, 1]
-				vector<double> x_s = model.to_scaled(x);
-				vector<double> x_min(x_s.size(), 0.0);///normalized range is 0..1 so is min..max
-				vector<double> x_max(x_s.size(), 1.0);
-				vector<double> x_epsv(x_s.size(),x_eps);
-				// notice that there is some adapter code here, for now, just to keep
-				// the sceua as close to origin as possible(it is fast&efficient, with stack-based mem.allocs)
-				double *xv=__autoalloc__(double, x_s.size()); shyft::core::optimizer::fastcopy(xv, x_s.data(), x_s.size());
+            double min_sceua(M& model, vector<double>& x, size_t max_n_evaluations, double x_eps = 0.0001, double y_eps = 0.0001) {
+                // Scale all parameter ranges to [0, 1]
+                vector<double> x_s = model.to_scaled(x);
+                vector<double> x_min(x_s.size(), 0.0);///normalized range is 0..1 so is min..max
+                vector<double> x_max(x_s.size(), 1.0);
+                vector<double> x_epsv(x_s.size(), x_eps);
+                // notice that there is some adapter code here, for now, just to keep
+                // the sceua as close to origin as possible(it is fast&efficient, with stack-based mem.allocs)
+                double *xv = __autoalloc__(double, x_s.size()); shyft::core::optimizer::fastcopy(xv, x_s.data(), x_s.size());
                 sceua_fx<M> fx_m(model);
                 shyft::core::optimizer::sceua opt;
                 double y_result = 0;
                 // optimize with no specific range for y-exit (max-less than min):
                 auto opt_state = opt.find_min(x_s.size(), x_min.data(), x_max.data(), xv, y_result, fx_m, y_eps, -1.0, -2.0, x_epsv.data(), max_n_evaluations);
-                for(size_t i=0; i < x_s.size(); ++i) x_s[i]=xv[i];//copy from raw vector
-				// Convert back to real parameter range
-				x = model.from_scaled(x_s);
-				if( !(opt_state == shyft::core::optimizer::OptimizerState::FinishedFxConvergence || opt_state == shyft::core::optimizer::OptimizerState::FinishedXconvergence))
+                for (size_t i = 0; i < x_s.size(); ++i) x_s[i] = xv[i];//copy from raw vector
+                // Convert back to real parameter range
+                x = model.from_scaled(x_s);
+                if (!(opt_state == shyft::core::optimizer::OptimizerState::FinishedFxConvergence || opt_state == shyft::core::optimizer::OptimizerState::FinishedXconvergence))
                     throw runtime_error("sceua: max-iterations reached before convergence"); //FinishedMaxIterations)
-				return y_result;
+                return y_result;
 
             }
 
-		/**\brief utility class to help transfrom time-series into suitable resolution
-		*/
-		struct ts_transform {
-			/**\brief transform the supplied time-series, f(t) interpreted according to its point_interpretation() policy
-			* into a new time-series,
-			* that represents the true average for each of the n intervals of length dt, starting at start.
-			* the result ts will have the policy is set to POINT_AVERAGE_VALUE
-			* \note that the resulting ts is a fresh new ts, not connected to the source
-			*/
-			template < class TS, class TSS>
-			shared_ptr<TS> to_average(utctime start, utctimespan dt, size_t n,const TSS& src) {
-				shyft::timeseries::timeaxis time_axis(start, dt, n);
-				shyft::timeseries::average_accessor< TSS, shyft::timeseries::timeaxis> avg(src,time_axis);
-				auto r =make_shared< TS>(time_axis, 0.0);
-				r->set_point_interpretation(shyft::timeseries::POINT_AVERAGE_VALUE);
-				for (size_t i = 0; i < avg.size(); ++i) r->set(i, avg.value(i));
-				return r;
-			}
-			template < class TS, class TSS>
-			shared_ptr<TS> to_average(utctime start, utctimespan dt, size_t n, shared_ptr<TSS> src) {
-				return to_average<TS, TSS>(start, dt, n, *src);
-			}
-		};
-		/** \brief calc_type to provide simple start of more than NS critera, first extension is diff of sum 2 */
-		enum target_spec_calc_type {
-			NASH_SUTCLIFFE , // obsolete, should be replaced by using KLING_GUPTA
-			KLING_GUPTA, // ref. Gupta09, Journal of Hydrology 377(2009) 80-91
-		};
+            /**\brief utility class to help transfrom time-series into suitable resolution
+            */
+            struct ts_transform {
+                /**\brief transform the supplied time-series, f(t) interpreted according to its point_interpretation() policy
+                * into a new time-series,
+                * that represents the true average for each of the n intervals of length dt, starting at start.
+                * the result ts will have the policy is set to POINT_AVERAGE_VALUE
+                * \note that the resulting ts is a fresh new ts, not connected to the source
+                */
+                template < class TS, class TSS>
+                shared_ptr<TS> to_average(utctime start, utctimespan dt, size_t n, const TSS& src) {
+                    shyft::timeseries::timeaxis time_axis(start, dt, n);
+                    shyft::timeseries::average_accessor< TSS, shyft::timeseries::timeaxis> avg(src, time_axis);
+                    auto r = make_shared< TS>(time_axis, 0.0);
+                    r->set_point_interpretation(shyft::timeseries::POINT_AVERAGE_VALUE);
+                    for (size_t i = 0; i < avg.size(); ++i) r->set(i, avg.value(i));
+                    return r;
+                }
+                template < class TS, class TSS>
+                shared_ptr<TS> to_average(utctime start, utctimespan dt, size_t n, shared_ptr<TSS> src) {
+                    return to_average<TS, TSS>(start, dt, n, *src);
+                }
+            };
+            /** \brief calc_type to provide simple start of more than NS critera, first extension is diff of sum 2 */
+            enum target_spec_calc_type {
+                NASH_SUTCLIFFE, // obsolete, should be replaced by using KLING_GUPTA
+                KLING_GUPTA, // ref. Gupta09, Journal of Hydrology 377(2009) 80-91
+            };
 
-		/** \brief property_type for target specification */
-		enum catchment_property_type {
-            DISCHARGE,
-            SNOW_COVERED_AREA,
-            SNOW_WATER_EQUIVALENT
-		};
+            /** \brief property_type for target specification */
+            enum catchment_property_type {
+                DISCHARGE,
+                SNOW_COVERED_AREA,
+                SNOW_WATER_EQUIVALENT
+            };
 
-		/** \brief The target specification contains:
-		* -# a target ts (the observed quantity)
-		* -# a list of catchment ids (zero-based), that denotes the catchment.discharges that should equal the target ts.
-		* -# a scale_factor that is used to construct the final goal function as
-		*
-		* goal_function = sum of all: scale_factor*(1 - nash-sutcliff factor) or KLING-GUPTA
-		*
-		* \tparam PS type of the target time-series, any type that is time-series compatible will work. Usually a point-based series.
-		*/
-		template<class PS>
-		struct target_specification {
-			typedef PS target_time_series_t;
-			target_specification()
-              : scale_factor(1.0), calc_mode(NASH_SUTCLIFFE), catchment_property(DISCHARGE), s_r(1.0), s_a(1.0), s_b(1.0) {}
-			target_specification(const target_specification& c)
-              : ts(c.ts), catchment_indexes(c.catchment_indexes), scale_factor(c.scale_factor),
-                calc_mode(c.calc_mode),catchment_property(c.catchment_property), s_r(c.s_r), s_a(c.s_a), s_b(c.s_b),uid(c.uid) {}
-			target_specification(target_specification&&c)
-              : ts(std::move(c.ts)),
-                catchment_indexes(std::move(c.catchment_indexes)),
-                scale_factor(c.scale_factor), calc_mode(c.calc_mode),catchment_property(c.catchment_property),
-                s_r(c.s_r), s_a(c.s_a), s_b(c.s_b),uid(c.uid) {}
-			target_specification& operator=(target_specification&& c) {
-				ts = std::move(c.ts);
-				catchment_indexes = move(c.catchment_indexes);
-				scale_factor = c.scale_factor;
-				calc_mode = c.calc_mode;
-				catchment_property=c.catchment_property;
-				s_r = c.s_r; s_a = c.s_a; s_b = c.s_b;
-				uid = c.uid;
-				return *this;
-			}
-			target_specification& operator=(const target_specification& c) {
-                if(this == &c) return *this;
-                ts = c.ts;
-                catchment_indexes = c.catchment_indexes;
-                scale_factor = c.scale_factor;
-                calc_mode = c.calc_mode;
-                catchment_property=c.catchment_property;
-				s_r = c.s_r; s_a = c.s_a; s_b = c.s_b;
-				uid = c.uid;
-                return *this;
-			}
-			bool operator==(const target_specification& x) const {
-			    return catchment_indexes == x.catchment_indexes && catchment_property==x.catchment_property;
-			}
-            /** \brief Constructs a target specification element for calibration, specifying all needed parameters
-             *
-             * \param ts; the target time-series that contain the target/observed discharge values
-             * \param cids;  a vector of the catchment ids in the model that together should add up to the target time-series
-             * \param scale_factor; the weight that this target_specification should have relative to the possible other target_specs.
-             */
-			target_specification(const target_time_series_t& ts, vector<int> cids, double scale_factor,
-                                 target_spec_calc_type calc_mode = NASH_SUTCLIFFE, double s_r=1.0,
-                                 double s_a=1.0, double s_b=1.0, catchment_property_type catchment_property_ = DISCHARGE,std::string uid="")
-              : ts(ts), catchment_indexes(cids), scale_factor(scale_factor),
-                calc_mode(calc_mode), catchment_property(catchment_property_), s_r(s_r), s_a(s_a), s_b(s_b),uid(uid) {}
-			
-			target_time_series_t ts; ///< The target ts, - any type that is time-series compatible
-			std::vector<int> catchment_indexes; ///< the catchment_indexes that denotes the catchments in the model that together should match the target ts
-			double scale_factor; ///<< the scale factor to be used when considering multiple target_specifications.
-			target_spec_calc_type calc_mode;///< *NASH_SUTCLIFFE, KLING_GUPTA
-			catchment_property_type catchment_property;///<  *DISCHARGE,SNOW_COVERED_AREA, SNOW_WATER_EQUIVALENT
-			double s_r; ///< KG-scalefactor for correlation
-			double s_a; ///< KG-scalefactor for alpha (variance)
-			double s_b; ///< KG-scalefactor for beta (bias)
-			std::string uid;///< external user specified id associated with this target spec.
-		};
+            /** \brief The target specification contains:
+            * -# a target ts (the observed quantity)
+            * -# a list of catchment ids (zero-based), that denotes the catchment.discharges that should equal the target ts.
+            * -# a scale_factor that is used to construct the final goal function as
+            *
+            * goal_function = sum of all: scale_factor*(1 - nash-sutcliff factor) or KLING-GUPTA
+            *
+            * \tparam PS type of the target time-series, any type that is time-series compatible will work. Usually a point-based series.
+            */
+            template<class PS>
+            struct target_specification {
+                typedef PS target_time_series_t;
+                target_specification()
+                    : scale_factor(1.0), calc_mode(NASH_SUTCLIFFE), catchment_property(DISCHARGE), s_r(1.0), s_a(1.0), s_b(1.0) {
+                }
+                target_specification(const target_specification& c)
+                    : ts(c.ts), catchment_indexes(c.catchment_indexes), scale_factor(c.scale_factor),
+                    calc_mode(c.calc_mode), catchment_property(c.catchment_property), s_r(c.s_r), s_a(c.s_a), s_b(c.s_b), uid(c.uid) {
+                }
+                target_specification(target_specification&&c)
+                    : ts(std::move(c.ts)),
+                    catchment_indexes(std::move(c.catchment_indexes)),
+                    scale_factor(c.scale_factor), calc_mode(c.calc_mode), catchment_property(c.catchment_property),
+                    s_r(c.s_r), s_a(c.s_a), s_b(c.s_b), uid(c.uid) {
+                }
+                target_specification& operator=(target_specification&& c) {
+                    ts = std::move(c.ts);
+                    catchment_indexes = move(c.catchment_indexes);
+                    scale_factor = c.scale_factor;
+                    calc_mode = c.calc_mode;
+                    catchment_property = c.catchment_property;
+                    s_r = c.s_r; s_a = c.s_a; s_b = c.s_b;
+                    uid = c.uid;
+                    return *this;
+                }
+                target_specification& operator=(const target_specification& c) {
+                    if (this == &c) return *this;
+                    ts = c.ts;
+                    catchment_indexes = c.catchment_indexes;
+                    scale_factor = c.scale_factor;
+                    calc_mode = c.calc_mode;
+                    catchment_property = c.catchment_property;
+                    s_r = c.s_r; s_a = c.s_a; s_b = c.s_b;
+                    uid = c.uid;
+                    return *this;
+                }
+                bool operator==(const target_specification& x) const {
+                    return catchment_indexes == x.catchment_indexes && catchment_property == x.catchment_property;
+                }
+                /** \brief Constructs a target specification element for calibration, specifying all needed parameters
+                 *
+                 * \param ts; the target time-series that contain the target/observed discharge values
+                 * \param cids;  a vector of the catchment ids in the model that together should add up to the target time-series
+                 * \param scale_factor; the weight that this target_specification should have relative to the possible other target_specs.
+                 */
+                target_specification(const target_time_series_t& ts, vector<int> cids, double scale_factor,
+                    target_spec_calc_type calc_mode = NASH_SUTCLIFFE, double s_r = 1.0,
+                    double s_a = 1.0, double s_b = 1.0, catchment_property_type catchment_property_ = DISCHARGE, std::string uid = "")
+                    : ts(ts), catchment_indexes(cids), scale_factor(scale_factor),
+                    calc_mode(calc_mode), catchment_property(catchment_property_), s_r(s_r), s_a(s_a), s_b(s_b), uid(uid) {
+                }
+
+                target_time_series_t ts; ///< The target ts, - any type that is time-series compatible
+                std::vector<int> catchment_indexes; ///< the catchment_indexes that denotes the catchments in the model that together should match the target ts
+                double scale_factor; ///<< the scale factor to be used when considering multiple target_specifications.
+                target_spec_calc_type calc_mode;///< *NASH_SUTCLIFFE, KLING_GUPTA
+                catchment_property_type catchment_property;///<  *DISCHARGE,SNOW_COVERED_AREA, SNOW_WATER_EQUIVALENT
+                double s_r; ///< KG-scalefactor for correlation
+                double s_a; ///< KG-scalefactor for alpha (variance)
+                double s_b; ///< KG-scalefactor for beta (bias)
+                std::string uid;///< external user specified id associated with this target spec.
+            };
 
 
-        ///< template helper classes to be used in enable_if_t in the optimizer for snow swe/sca:
-        template< bool B, class T = void >
-        using enable_if_tx = typename enable_if<B,T>::type;
+            ///< template helper classes to be used in enable_if_t in the optimizer for snow swe/sca:
+            template< bool B, class T = void >
+            using enable_if_tx = typename enable_if<B, T>::type;
 
-			#ifdef __GNUC__
-            #pragma GCC diagnostic push
-            #pragma GCC diagnostic ignored "-Wunused-value"
-			#endif
-            template<class T,class=void>            // we only want compute_sca_sum IF the response-collector do have snow_sca attribute
-            struct detect_snow_sca:false_type{};    // detect_snow_sca, default it to false,
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+            template<class T, class = void>            // we only want compute_sca_sum IF the response-collector do have snow_sca attribute
+            struct detect_snow_sca :false_type {};    // detect_snow_sca, default it to false,
 
             template<class T>                       // then specialize it for T that have snow_sca
-            struct detect_snow_sca<T,decltype(T::snow_sca,void())>:true_type{}; // to true.
+            struct detect_snow_sca<T, decltype(T::snow_sca, void())> :true_type {}; // to true.
 
-            template<class T,class=void> // ref similar pattern for template specific generation of snow_sca above.
-            struct detect_snow_swe:false_type{};
+            template<class T, class = void> // ref similar pattern for template specific generation of snow_sca above.
+            struct detect_snow_swe :false_type {};
 
             template<class T>
-            struct detect_snow_swe<T,decltype(T::snow_swe,void())>:true_type{};
-			#ifdef __GNUC__
-            #pragma GCC diagnostic pop
-			#endif
-			/** when doing catchment area related optimization, e.g. snow sca/swe
+            struct detect_snow_swe<T, decltype(T::snow_swe, void())> :true_type {};
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+            /** when doing catchment area related optimization, e.g. snow sca/swe
              *  we need to
              *  keep track of the area of each catchment so that we get
              *  true average values
@@ -262,397 +266,484 @@ namespace shyft{
             struct area_ts {
                 double area;///< area in m^2
                 pts_t ts; ///< ts representing the property for the area, e.g. sca, swe
-                area_ts(double area_m2,pts_t ts):area(area_m2),ts(move(ts)){}
-                area_ts():area(0.0) {}                              // maybe we could drop this and rely on defaults ?
-                area_ts(area_ts&&c):area(c.area),ts(move(ts)) {}
-                area_ts(const area_ts&c):area(c.area),ts(c.ts) {}
-                area_ts& operator=(const area_ts&c ) {
-                    if(&c != this) {
-                        area=c.area;
-                        ts=c.ts;
+                area_ts(double area_m2, pts_t ts) :area(area_m2), ts(move(ts)) {}
+                area_ts() :area(0.0) {}                              // maybe we could drop this and rely on defaults ?
+                area_ts(area_ts&&c) :area(c.area), ts(move(ts)) {}
+                area_ts(const area_ts&c) :area(c.area), ts(c.ts) {}
+                area_ts& operator=(const area_ts&c) {
+                    if (&c != this) {
+                        area = c.area;
+                        ts = c.ts;
                     }
                     return *this;
                 }
                 area_ts& operator=(area_ts && c) {
-                    if(&c != this) {
-                        ts=move(c.ts);
-                        area=c.area;
+                    if (&c != this) {
+                        ts = move(c.ts);
+                        area = c.area;
                     }
                     return *this;
                 }
             };
 
 
-		/** \brief The optimizer for parameters in a \ref shyft::core::region_model
-		 * provides needed functionality to orchestrate a search for the optimal parameters so that the goal function
-		 * specified by the target_specifications are minmized.
-		 * The user can specify which parameters (model specific) to optimize, giving range min..max for each of the
-		 * parameters. Only parameters with min != max are used, thus minimizing the parameter space.
-		 *
-		 * Target specification \ref target_specification allows a lot of flexiblity when it comes to what
-		 * goes into the \ref nash_sutcliffe goal function.
-		 *
-		 * The search for optimium starts with the current parameter-set, the current start state, over the specified model time-axis.
-		 * After a run, the goal function is calculated and returned back to the minbobyqa algorithm that continue searching for the minimum
-		 * value until tolerances/iterations area reached.
-		 *
-		 * \tparam M the region model, and we use that supports the following member:
-		 *  -# .time_axis, a time-axis value and type used by the model, the optimizer needs this during goal function evaluation.
-		 *  -# .run(), the region model from  state (s0) over .time_axis, using current values of parameters.
-		 *
-		 * \tparam PA a template parameter for the parameters, supporting vector form access
-		 * \tparam PS type of the target time-series, inside. the target specification..(SiH: can we turn it the other way around ??)
-		 *
-		 */
-        template< class M, class PA, class PS>
-        class optimizer {
-          public:
-            typedef dlib::matrix<double, 0, 1> column_vector; ///< dlib optimizer enjoys dlib matrix types.
-            typedef PS target_time_series_t; ///< target_time_series_t. could that be of same type as model calc, always, or is it supplied from outside?
-
-			typedef target_specification<PS> target_specification_t;///< describes how to calculate the goal function, maybe better 'retemplate' on this
-			typedef M region_model_t; ///< obvious and Ok template, the region_model, and there is just a few things that we need from this template.
-            typedef typename M::state_t state_t;
-            typedef typename M::parameter_t parameter_t;
-            typedef typename M::cell_t cell_t;
-            typedef typename cell_t::response_collector_t response_collector_t;
-          private:
-		public:
-            PA& parameter_accessor; ///<  a *reference* to the model parameters in the target  model, all cells share this!
-            region_model_t& model; ///< a reference to the region model that we optimize
-		private:
-            vector<target_specification_t> targets; ///<  list of targets ts& catchments indexes to be optimized, used to calculate goal function
-			// internal parameter vectors
-			vector<double> p_expanded;
-            vector<double> p_min; // min==max, no- optimization..
-            vector<double> p_max;
-            vector<state_t> initial_state;
-			int print_progress_level;
-			size_t n_catchments;///< optimized counted number of model.catchments available
-			//Need to handle expanded/reduced parameter vector based on min..max range to optimize speed for bobyqa
-			bool is_active_parameter(size_t i) const { return fabs(p_max[i] - p_min[i]) > 0.000001; }
-			vector<double> reduce_p_vector(const vector<double>& fp) const {
-				std::vector<double> r; r.reserve(fp.size());
-				for (size_t i = 0; i < fp.size(); ++i) {
-					if (is_active_parameter(i))
-						r.push_back(fp[i]);// only pick values that are active in optimization
-				}
-				return r;
-			}
-			vector<double> expand_p_vector(const vector<double>& rp) const {
-				std::vector<double> r; r.reserve(p_expanded.size());
-				size_t j = 0;
-				for (size_t i = 0; i < p_expanded.size(); ++i) {
-					if (is_active_parameter(i))
-						r.push_back(rp[j++]);// pick from reduced vector
-					else
-						r.push_back(p_expanded[i]); // just use already set class global parameter
-				}
-				return r;
-			}
-
-		public:
-			/**\brief construct an opt model for ptgsk, use p_min=p_max to disable optimization for a parameter
-			* \param model reference to the model to be optimized, the model should be initialized, i.e. the interpolation step done.
-			* \param vector<target_specification_t> specifies how to calculate the goal-function, \ref shyft::core::model_calibration::target_specification
-			* \param p_min minimum values for the parameters to be optimized
-			* \param p_max maximum values for the parameters to be  optimized
-			*/
-			optimizer(region_model_t& model, const vector<target_specification_t>& targetsA,
-                      const vector<double>& p_min, const vector<double>& p_max)
-              : parameter_accessor(model.get_region_parameter()),
-                model(model),
-                targets(targetsA),
-                p_min(p_min),
-				p_max(p_max), print_progress_level(0) {
-                // 0. figure out n_catchments, asking the model
-                n_catchments=model.number_of_catchments();
-				// 1. figure out the catchment indexes to evaluate..
-				//    and if we need to turn on snow collection
-
-				vector<int> catchment_indexes;
-				model.set_snow_sca_swe_collection(-1,false);//turn off all snow by default.
-				for (const auto&t : targets) {
-					catchment_indexes.insert(catchment_indexes.end(), begin(t.catchment_indexes), end(t.catchment_indexes));
-					if(t.catchment_property!=DISCHARGE)
-                        for(auto cid:t.catchment_indexes)
-                            model.set_snow_sca_swe_collection(cid,true);//turn on for those with something like snow enabled
-				}
-				if (catchment_indexes.size() > 1) {
-					sort(begin(catchment_indexes), end(catchment_indexes));
-					auto unique_end = unique(begin(catchment_indexes), end(catchment_indexes));
-					catchment_indexes.resize(distance(begin(catchment_indexes), unique_end));
-				}
-                for (auto i: catchment_indexes) {
-                    if (model.has_catchment_parameter(i))
-                        throw runtime_error("Cannot calibrate on local parameters.");
-                }
-				model.set_catchment_calculation_filter(catchment_indexes); //Only calculate the catchments that we optimize
-				// 2. fetch the initial state (s0) from the supplied model, and store it so that we start each run with same state s0
-                auto cells = model.get_cells();
-                initial_state.reserve((*cells).size());
-                for(const auto& cell:*cells) initial_state.emplace_back(cell.state);
-           }
-
-            state_t get_initial_state(size_t idx) {
-                return initial_state[idx];
-            }
-
-			/**\brief Call to optimize model, starting with p parameter set, using p_min..p_max as boundaries.
-			 * where p is the full parameter vector.
-			 * the p_min,p_max specified in constructor is used to reduce the parameterspace for the optimizer
-			 * down to a minimum number to facilitate fast run.
-			 * \param p contains the starting point for the parameters
-			 * \param max_n_evaluations stop after n calls of the objective functions, i.e. simulations.
-			 * \param tr_start is the trust region start , default 0.1, ref bobyqa
-			 * \param tr_stop is the trust region stop, default 1e-5, ref bobyqa
-			 * \return the optimized parameter vector
-			 */
-           vector<double> optimize(vector<double> p, size_t max_n_evaluations=1500, double tr_start=0.1, double tr_stop=1.0e-5) {
-				// reduce using min..max the parameter space,
-				p_expanded = p;//put all parameters into class scope so that we can reduce/expand as needed during optimization
-				auto rp = reduce_p_vector(p);
-				min_bobyqa(*this, rp, max_n_evaluations, tr_start, tr_stop);
-				// expand,put inplace p to return vector.
-				p = expand_p_vector(rp);
-                return p;
-            }
-
-			/**\brief Call to optimize model, using DREAM alg., find p, using p_min..p_max as boundaries.
-			 * where p is the full parameter vector.
-			 * the p_min,p_max specified in constructor is used to reduce the parameterspace for the optimizer
-			 * down to a minimum number to facilitate fast run.
-			 * \param p is used as start point (not really, DREAM use random, but we should be able to pass u and q....
-			 * \param max_n_evaluations stop after n calls of the objective functions, i.e. simulations.
-			 * \return the optimized parameter vector
-			 */
-            vector<double> optimize_dream(vector<double> p,size_t max_n_evaluations=1500) {
-				// reduce using min..max the parameter space,
-				p_expanded = p;//put all parameters into class scope so that we can reduce/expand as needed during optimization
-				auto rp = reduce_p_vector(p);
-				min_dream<optimizer>(*this, rp, max_n_evaluations);
-				p = expand_p_vector(rp);// expand,put inplace p to return vector.
-                return p;
-            }
-
-			/**\brief Call to optimize model, using SCE UA, using p as startpoint, find p, using p_min..p_max as boundaries.
-			 * where p is the full parameter vector.
-			 * the p_min,p_max specified in constructor is used to reduce the parameterspace for the optimizer
-			 * down to a minimum number to facilitate fast run.
-			 * \param p is used as start point and is updated with the found optimal points
-			 * \param max_n_evaluations stop after n calls of the objective functions, i.e. simulations.
-			 * \param x_eps is stop condition when all changes in x's are within this range
-			 * \param y_eps is stop condition, and search is stopped when goal function does not improve anymore within this range
-			 * \return the optimized parameter vector
-			 */
-            vector<double> optimize_sceua(vector<double> p,size_t max_n_evaluations=1500, double x_eps=0.0001, double y_eps=1.0e-5) {
-				// reduce using min..max the parameter space,
-				p_expanded = p;//put all parameters into class scope so that we can reduce/expand as needed during optimization
-				auto rp = reduce_p_vector(p);
-				min_sceua(*this, rp, max_n_evaluations, x_eps, y_eps);
-				p = expand_p_vector(rp);				// expand,put inplace p to return vector.
-                return p;
-            }
-
-
-			/**\brief reset the state of the model to the initial state before starting the run/optimize*/
-            void reset_states() {
-                auto cells = model.get_cells();
-                size_t i = 0;
-                for_each(begin(*cells), end(*cells), [this, &i] (cell_t& cell) { cell.set_state(initial_state[i++]); });
-            }
-			/**\brief set the parameter ranges, set min=max=wanted parameter value for those not subject to change during optimization */
-			void set_parameter_ranges(vector<double> p_min, vector<double> p_max) { this->p_min = p_min; this->p_max = p_max; }
-			void set_verbose_level(int level) { print_progress_level = level; }
-			/**\brief calculate the goal_function as used by minbobyqa,
-			 *   using the full set of  parameters vectors (as passed to optimize())
-			 *   and also ensures that the shyft state/cell/catchment result is consistent
-			 *   with the passed parameters passed
-			 * \param full_vector_of_parameters contains all parameters that will be applied to the run.
-			 *  \returns the goal-function, weigthed nash_sutcliffe sum
-			 */
-			double calculate_goal_function(std::vector<double> full_vector_of_parameters) {
-				p_expanded = full_vector_of_parameters;// ensure all parameters are  according to full_vector..
-				return run(reduce_p_vector(full_vector_of_parameters));// then run with parameters as if from optimize
-			}
-            friend class calibration_test;// to enable testing of individual methods
-			/** called by bobyqua: */
-            double operator() (const column_vector& p_s) { return run(from_scaled(p_s)); }
-            double operator() (const vector<double>&p_s) { return run(from_scaled(p_s)); }
-
-			/** called by bobyqua:reduced parameter space p */
-           vector<double> to_scaled(const vector<double>& rp) const {
-                if (p_min.size() == 0) throw runtime_error("Parameter ranges are not set");
-                vector<double> p_s;
-                auto rp_min = reduce_p_vector(p_min);
-                auto rp_max = reduce_p_vector(p_max);
-                const size_t n_params = rp.size();
-                p_s.reserve(n_params);
-                for (size_t i = 0; i < n_params; ++i)
-                    p_s.emplace_back((rp[i] - rp_min[i])/(rp_max[i] - rp_min[i]));
-                return p_s;
-            }
-			/** called by bobyqua: reduced parameter space p */
-           vector<double> from_scaled(column_vector p_s) const {
-                if (p_min.size() == 0) throw runtime_error("Parameter ranges are not set");
-                vector<double> p;
-                auto rp_min = reduce_p_vector(p_min);
-                auto rp_max = reduce_p_vector(p_max);
-                p.reserve(p_s.nr());
-                for (int i = 0; i < p_s.nr(); ++i)
-                    p.emplace_back((rp_max[i] - rp_min[i])*p_s(i) + rp_min[i]);
-                return p;
-            }
-			/** called by bobyqua: reduced parameter space p */
-           vector<double> from_scaled(vector<double> p_s) const {
-                if (p_min.size() == 0) throw runtime_error("Parameter ranges are not set");
-                vector<double> p;
-                auto rp_min = reduce_p_vector(p_min);
-                auto rp_max = reduce_p_vector(p_max);
-                p.reserve(p_s.size());
-                for (size_t i = 0; i < p_s.size(); ++i)
-                    p.emplace_back((rp_max[i] - rp_min[i])*p_s[i] + rp_min[i]);
-                return p;
-            }
-		  private:
-
-            pts_t compute_discharge_sum(const target_specification_t& t,vector<pts_t>& catchment_d) const {
-                if(catchment_d.empty())
-                    model.catchment_discharges(catchment_d);
-                pts_t discharge_sum(model.time_axis,0.0,shyft::timeseries::POINT_AVERAGE_VALUE);
-                for(auto i : t.catchment_indexes)
-                    discharge_sum.add(catchment_d[model.cix_from_cid(i)]);// important! the catchment_d(ischarge) is in internal index order
-                return discharge_sum;
-            }
-
-            /** \brief extracts vector of area_ts for all calculated catchments using the
-             * given property function tsf that should have signature pts_t (const cell& c)
-             * \note that this function sum together contributions at cell-level.
-             * TODO: Avoid duplicate code, - use average_catchment_feature(*model.cells, catchment_index, []() return c.rc.snow_sca) but it returns a shared_ptr..
+            /** \brief The optimizer for parameters in a \ref shyft::core::region_model
+             * provides needed functionality to orchestrate a search for the optimal parameters so that the goal function
+             * specified by the target_specifications are minmized.
+             * The user can specify which parameters (model specific) to optimize, giving range min..max for each of the
+             * parameters. Only parameters with min != max are used, thus minimizing the parameter space.
+             *
+             * Target specification \ref target_specification allows a lot of flexiblity when it comes to what
+             * goes into the \ref nash_sutcliffe goal function.
+             *
+             * The search for optimium starts with the current parameter-set, the current start state, over the specified model time-axis.
+             * After a run, the goal function is calculated and returned back to the minbobyqa algorithm that continue searching for the minimum
+             * value until tolerances/iterations area reached.
+             *
+             * \tparam M the region model, and we use that supports the following member:
+             *  -# .time_axis, a time-axis value and type used by the model, the optimizer needs this during goal function evaluation.
+             *  -# .run(), the region model from  state (s0) over .time_axis, using current values of parameters.
+             *
+             * \tparam PA a template parameter for the parameters, supporting vector form access
+             * \tparam PS type of the target time-series, inside. the target specification..(SiH: can we turn it the other way around ??)
+             *
              */
-            template<class property_ts_function>
-            vector<area_ts> extract_area_ts_property( property_ts_function && tsf) const {
-                vector<area_ts> r(n_catchments,area_ts(0.0,pts_t(model.time_axis,0.0,shyft::timeseries::POINT_AVERAGE_VALUE)));
-                for(const auto& c: *model.get_cells()) {
-                    if (model.is_calculated_by_catchment_ix(c.geo.catchment_ix)){
-                        r[c.geo.catchment_ix].ts.add_scale(tsf(c),c.geo.area());//the only ref. to snow_sca
-                        r[c.geo.catchment_ix].area += c.geo.area(); //using entire cell geo area for now.
+            template< class M, class PA, class PS>
+            class optimizer {
+            public:
+                typedef dlib::matrix<double, 0, 1> column_vector; ///< dlib optimizer enjoys dlib matrix types.
+                typedef PS target_time_series_t; ///< target_time_series_t. could that be of same type as model calc, always, or is it supplied from outside?
+
+                typedef target_specification<PS> target_specification_t;///< describes how to calculate the goal function, maybe better 'retemplate' on this
+                typedef M region_model_t; ///< obvious and Ok template, the region_model, and there is just a few things that we need from this template.
+                typedef typename M::state_t state_t;
+                typedef typename M::parameter_t parameter_t;
+                typedef typename M::cell_t cell_t;
+                typedef typename cell_t::response_collector_t response_collector_t;
+            public:
+                PA parameter_lower_bound;///< current setting of parameter lower bound
+                PA parameter_upper_bound;///< current setting of parameter upper bound
+                PA& parameter_accessor; ///<  a *reference* to the model parameters in the target  model, all cells share this!
+                region_model_t& model; ///< a reference to the region model that we optimize
+                vector<target_specification_t> targets; ///<  list of targets ts& catchments indexes to be optimized, used to calculate goal function
+                bool active_parameter(size_t i) const { return fabs(parameter_upper_bound.get(i) - parameter_lower_bound.get(i)) > activate_limit; }
+            private:    // internal parameter vectors
+                vector<double> p_expanded;
+                vector<double> p_min; // min==max, no- optimization..
+                vector<double> p_max;
+                vector<state_t> initial_state;
+                int print_progress_level;
+                size_t n_catchments;///< optimized counted number of model.catchments available
+                //Need to handle expanded/reduced parameter vector based on min..max range to optimize speed for bobyqa
+                const double activate_limit = 0.000001;
+                bool is_active_parameter(size_t i) const { return fabs(p_max[i] - p_min[i]) > activate_limit; }
+                
+                vector<double> reduce_p_vector(const vector<double>& fp) const {
+                    std::vector<double> r; r.reserve(fp.size());
+                    for (size_t i = 0; i < fp.size(); ++i) {
+                        if (is_active_parameter(i))
+                            r.push_back(fp[i]);// only pick values that are active in optimization
                     }
+                    return r;
                 }
-                for(size_t i=0;i<n_catchments;++i)
-                    if(model.is_calculated_by_catchment_ix(i))
-                        r[i].ts.scale_by(1/r[i].area);
-                return r;
-            }
-            /** \brief returns the area weighted sum of vector<area_ts> according to t.catchment_indexes
-            */
-            pts_t compute_weighted_area_ts_average(const target_specification_t& t, const vector<area_ts>& ats) const {
-                pts_t ts_sum(model.time_axis,0.0,shyft::timeseries::POINT_AVERAGE_VALUE);
-                double a_sum=0.0;
-                for(auto cid:t.catchment_indexes) {
-                    auto i=model.cix_from_cid(cid); // need to get the catchment zero-based index here
-                    ts_sum.add_scale(ats[i].ts,ats[i].area);
-                    a_sum += ats[i].area;
-                }
-                ts_sum.scale_by(1/a_sum);
-                return ts_sum;
-            }
-
-
-            template<class rc_t = response_collector_t> // finally,
-              enable_if_tx<detect_snow_sca<rc_t>::value,pts_t> // use enable_if_t  detect_snow_sca to enable this type
-            compute_sca_sum(const target_specification_t& t,vector<area_ts>& catchment_sca) const {
-                if(catchment_sca.empty())
-                    catchment_sca=extract_area_ts_property([](const cell_t&c) {return c.rc.snow_sca;});
-                return compute_weighted_area_ts_average(t,catchment_sca);
-            }
-
-            template<class rc_t = response_collector_t>
-              enable_if_tx<!detect_snow_sca<rc_t>::value,pts_t>
-            compute_sca_sum(const target_specification_t& t,vector<area_ts>& catchment_d) const {
-                // To support dynamic typing and python: If a cell.rc do not have snow_sca, but we pass in a criteria/target
-                // function that do specify snow_sca, we throw a runtime error.
-                // TODO: verify this in the constructor and throw as early as possible
-                throw runtime_error("resource collector doesn't have snow_sca");
-            }
-
-
-
-            template<class rc_t = response_collector_t>
-            enable_if_tx<detect_snow_swe<rc_t>::value,pts_t> compute_swe_sum(const target_specification_t& t,vector<area_ts>& catchment_swe) const {
-                if(catchment_swe.empty())
-                    catchment_swe=extract_area_ts_property([](const cell_t&c){return c.rc.snow_swe;});
-                return compute_weighted_area_ts_average(t,catchment_swe);
-            }
-            template<class rc_t = response_collector_t>
-            enable_if_tx<!detect_snow_swe<rc_t>::value,pts_t> compute_swe_sum(const target_specification_t& t,vector<area_ts>& catchment_d) const {
-                throw runtime_error("resource collector doesn't have snow_swe");
-            }
-
-			/**\brief from operator(), called by min_bobyqa, for each iteration, so p is bobyqa parameter vector
-			* notice that the function returns the value of the goal function,
-			* as specified by the target specification. The flexibility is rather large:
-			*  It's a set of target-specifications, weighted, where each of them can
-			*  be a KG or NS, for a specified period/resolution.
-			*  E.g. we can specify targets that apply to specific catchments, and specified periods/resolutions.
-			*/
-			double run(const vector<double>& rp) {
-				auto p = expand_p_vector(rp);// expand to full vector, then:
-				parameter_accessor.set(p); // Sets global parameters, all cells share a common pointer.
-				reset_states();
-				model.run_cells();
-				double goal_function_value = 0.0;// overall goal-function, intially zero
-				double scale_factor_sum = 0.0; // each target-spec have a weight, -use this to sum up weights
-				vector<pts_t> catchment_d;
-				vector<area_ts> catchment_sca,catchment_swe;// "catchment" level simulated discharge,sca,swe
-				for (const auto& t : targets) {
-					shyft::timeseries::direct_accessor<pts_t, timeaxis_t> target_accessor(t.ts, t.ts.ta);
-					pts_t property_sum;
-                    switch(t.catchment_property){
-                    case DISCHARGE:
-                        property_sum=compute_discharge_sum(t,catchment_d);
-                        break;
-                    case SNOW_COVERED_AREA:
-                        property_sum=compute_sca_sum(t,catchment_sca);
-                        break;
-                    case SNOW_WATER_EQUIVALENT:
-                        property_sum=compute_swe_sum(t,catchment_swe);
-                        break;
+                vector<double> expand_p_vector(const vector<double>& rp) const {
+                    std::vector<double> r; r.reserve(p_expanded.size());
+                    size_t j = 0;
+                    for (size_t i = 0; i < p_expanded.size(); ++i) {
+                        if (is_active_parameter(i))
+                            r.push_back(rp[j++]);// pick from reduced vector
+                        else
+                            r.push_back(p_expanded[i]); // just use already set class global parameter
                     }
-					shyft::timeseries::average_accessor<pts_t, timeaxis_t> property_sum_accessor(property_sum, t.ts.ta);
-                    double partial_goal_function_value;
-					if (t.calc_mode == target_spec_calc_type::NASH_SUTCLIFFE) {
-						partial_goal_function_value = nash_sutcliffe_goal_function(target_accessor, property_sum_accessor);
-					} else {
-						// ref. KLING-GUPTA Journal of Hydrology 377 (2009) 80–91, page 83, formula (10):
-                        // a=alpha, b=betha, q =sigma, u=my, s=simulated, o=observed
-                        partial_goal_function_value /* EDs */ = kling_gupta_goal_function<dlib::running_scalar_covariance<double>>(target_accessor,
-                                                                                                        property_sum_accessor,
-                                                                                                        t.s_r,
-                                                                                                        t.s_a,
-                                                                                                        t.s_b);
-					}
-					if(isfinite(partial_goal_function_value)) {
-                        scale_factor_sum += t.scale_factor;
-                        goal_function_value += t.scale_factor*partial_goal_function_value;
-					} else if (print_progress_level>0) {
-					    cout<<"warning: goal-function "<<t.catchment_property<<": evaluated as nan"<<endl;
-					}
-				}
-				goal_function_value /= scale_factor_sum;
-				if (print_progress_level > 0) {
-					cout << "ParameterVector(";
-					for (size_t i = 0; i < parameter_accessor.size(); ++i) {
-						cout << parameter_accessor.get(i);
-						if (i < parameter_accessor.size() - 1)cout << ", ";
-					}
-					cout << ") = " << goal_function_value << " (NS or KG)" <<endl;
-				}
-				return goal_function_value;
-			}
-        };
+                    return r;
+                }
+                vector<double> p_vector(const PA&p) const { vector<double> r;r.reserve(p.size());for (size_t i = 0;i < p.size();++i)r.push_back(p.get(i));return r; }
+                PA vector_p(const vector<double>& v)const { PA p; p.set(v); return p; }
+
+            public:
+
+                /**\brief construct an opt model for ptgsk, use p_min=p_max to disable optimization for a parameter
+                * 
+                *
+                * \param model reference to the model to be optimized, the model should be initialized, i.e. the interpolation step done.
+                * \param vector<target_specification_t> specifies how to calculate the goal-function, \ref shyft::core::model_calibration::target_specification
+                * \param p_min minimum values for the parameters to be optimized
+                * \param p_max maximum values for the parameters to be  optimized
+                */
+                optimizer(region_model_t& model, const vector<target_specification_t>& targetsA,
+                    const vector<double>& p_min, const vector<double>& p_max)
+                    : parameter_accessor(model.get_region_parameter()),
+                    model(model),
+                    targets(targetsA),
+                    print_progress_level(0) {
+                    set_parameter_ranges(p_min, p_max);
+                }
+
+                /** Create an optimizer based on the supplied model, kept as a reference(!)
+                 * To optimize, first call set_target_specification(), then 
+                 * call any of optimize_xxx(...)
+                 */
+                optimizer(region_model_t& model) :
+                    parameter_accessor(model.get_region_parameter()),
+                    model(model),print_progress_level(0) {
+
+                }
+
+                /**Set all parameters that matters for the calibration.
+                 * The lower and upper bounds determines which parameters are subject to calibration.
+                 * If lower and upper bound are equal, the parameter is untouched during calibration (regardless value)
+                 * 
+                 * \param targetsA specifies the goal function description
+                 * \param param_lower_bound specifies the lower bound of the parameter set
+                 * \param param_upper_bound specifies the upper bound of the parameter set
+                */
+                void set_target_specification(const vector<target_specification_t>& targetsA, const PA& param_lower_bound, const PA& param_upper_bound) {
+                    targets = targetsA;
+                    parameter_lower_bound = param_lower_bound;
+                    parameter_upper_bound = param_upper_bound;
+                    p_min = p_vector(param_lower_bound);
+                    p_max = p_vector(param_max);
+                }
+
+                /** copy the model current state into internal store of the calibration class */
+                void establish_initial_state_from_model() {
+                    // 2. fetch the initial state (s0) from the supplied model, and store it so that we start each run with same state s0
+                    auto cells = model.get_cells();
+                    initial_state.reserve((*cells).size());
+                    for (const auto& cell : *cells) initial_state.emplace_back(cell.state);
+
+                }
+
+                /** prepare the optimization process by looking at the current state of the supplied 
+                 * parameters.
+                 * Ensures :
+                 *  -# the model have a global parameter-set
+                 *  -# the collection of SCA/SWE is turned on if requested
+                 *  -# the catchment-filter is set according to target-specification request
+                 */
+                void prepare_optimize() {
+                    // 1. ensure vectors reflects current state of lower..upper bounds
+                    p_min = p_vector(parameter_lower_bound);
+                    p_max = p_vector(parameter_upper_bound);
+                    // 2. figure out n_catchments, asking the model
+                    n_catchments = model.number_of_catchments();
+                    // 3. figure out the catchment indexes to evaluate..
+                    //    and if we need to turn on snow collection
+                    vector<int> catchment_indexes;
+                    model.set_snow_sca_swe_collection(-1, false);//turn off all snow by default.
+                    for (const auto&t : targets) {
+                        catchment_indexes.insert(catchment_indexes.end(), begin(t.catchment_indexes), end(t.catchment_indexes));
+                        if (t.catchment_property != DISCHARGE)
+                            for (auto cid : t.catchment_indexes)
+                                model.set_snow_sca_swe_collection(cid, true);//turn on for those with something like snow enabled
+                    }
+                    if (catchment_indexes.size() > 1) {
+                        sort(begin(catchment_indexes), end(catchment_indexes));
+                        auto unique_end = unique(begin(catchment_indexes), end(catchment_indexes));
+                        catchment_indexes.resize(distance(begin(catchment_indexes), unique_end));
+                    }
+                    for (auto i : catchment_indexes) {
+                        if (model.has_catchment_parameter(i))
+                            throw runtime_error("Cannot calibrate on local parameters.");
+                    }
+                    model.set_catchment_calculation_filter(catchment_indexes); //Only calculate the catchments that we optimize
+                    // 4. detects if initial state is established, if not it automatically do a copy of the current state
+                    if (initial_state.size() != model.get_cells()->size())
+                        establish_initial_state_from_model();
+                }
+
+                /** returns the initial state for the i'th cell */
+                state_t get_initial_state(size_t idx) {
+                    return initial_state[idx];
+                }
+
+                /**\brief Call to optimize model, starting with p parameter set, using p_min..p_max as boundaries.
+                 * where p is the full parameter vector.
+                 * the p_min,p_max specified in constructor is used to reduce the parameterspace for the optimizer
+                 * down to a minimum number to facilitate fast run.
+                 * \param p contains the starting point for the parameters
+                 * \param max_n_evaluations stop after n calls of the objective functions, i.e. simulations.
+                 * \param tr_start is the trust region start , default 0.1, ref bobyqa
+                 * \param tr_stop is the trust region stop, default 1e-5, ref bobyqa
+                 * \return the optimized parameter vector
+                 */
+                vector<double> optimize(vector<double> p, size_t max_n_evaluations = 1500, double tr_start = 0.1, double tr_stop = 1.0e-5) {
+                    prepare_optimize();
+                    // reduce using min..max the parameter space,
+                    p_expanded = p;//put all parameters into class scope so that we can reduce/expand as needed during optimization
+                    auto rp = reduce_p_vector(p);
+                    min_bobyqa(*this, rp, max_n_evaluations, tr_start, tr_stop);
+                    // expand,put inplace p to return vector.
+                    p = expand_p_vector(rp);
+                    return p;
+                }
+                
+                /**optimize using minbobyqa, using p as starting parameters, return new optimized parameters */
+                PA optimize(const PA &p, size_t max_n_evaluations = 1500, double tr_start = 0.1, double tr_stop = 1.0e-5) {
+                    PA r;
+                    r.set(optimize(p_vector(p), max_n_evaluations, tr_start, tr_stop));
+                    return r;
+                }
+
+                /**\brief Call to optimize model, using DREAM alg., find p, using p_min..p_max as boundaries.
+                 * where p is the full parameter vector.
+                 * the p_min,p_max specified in constructor is used to reduce the parameterspace for the optimizer
+                 * down to a minimum number to facilitate fast run.
+                 * \param p is used as start point (not really, DREAM use random, but we should be able to pass u and q....
+                 * \param max_n_evaluations stop after n calls of the objective functions, i.e. simulations.
+                 * \return the optimized parameter vector
+                 */
+                vector<double> optimize_dream(vector<double> p, size_t max_n_evaluations = 1500) {
+                    prepare_optimize();
+                    // reduce using min..max the parameter space,
+                    p_expanded = p;//put all parameters into class scope so that we can reduce/expand as needed during optimization
+                    auto rp = reduce_p_vector(p);
+                    min_dream<optimizer>(*this, rp, max_n_evaluations);
+                    p = expand_p_vector(rp);// expand,put inplace p to return vector.
+                    return p;
+                }
+                /** optimize using the dream algorithm, returning the new optimized parameter set*/
+                PA optimize_dream(const PA &p, size_t max_n_evaluations = 1500) {
+                    PA r;
+                    r.set(optimize_dream(p_vector(p), max_n_evaluations));
+                    return r;
+                }
+
+                /**\brief Call to optimize model, using SCE UA, using p as startpoint, find p, using p_min..p_max as boundaries.
+                 * where p is the full parameter vector.
+                 * the p_min,p_max specified in constructor is used to reduce the parameterspace for the optimizer
+                 * down to a minimum number to facilitate fast run.
+                 * \param p is used as start point and is updated with the found optimal points
+                 * \param max_n_evaluations stop after n calls of the objective functions, i.e. simulations.
+                 * \param x_eps is stop condition when all changes in x's are within this range
+                 * \param y_eps is stop condition, and search is stopped when goal function does not improve anymore within this range
+                 * \return the optimized parameter vector
+                 */
+                vector<double> optimize_sceua(vector<double> p, size_t max_n_evaluations = 1500, double x_eps = 0.0001, double y_eps = 1.0e-5) {
+                    prepare_optimize();
+                    // reduce using min..max the parameter space,
+                    p_expanded = p;//put all parameters into class scope so that we can reduce/expand as needed during optimization
+                    auto rp = reduce_p_vector(p);
+                    min_sceua(*this, rp, max_n_evaluations, x_eps, y_eps);
+                    p = expand_p_vector(rp);				// expand,put inplace p to return vector.
+                    return p;
+                }
+
+                /** optimize using the dream algorithm, returning the new optimized parameter set*/
+                PA optimize_sceua(const PA& p, size_t max_n_evaluations = 1500, double x_eps = 0.0001, double y_eps = 1.0e-5) {
+                    PA r;
+                    r.set(optimize_sceua(p_vector(p), max_n_evaluations, x_eps, y_eps));
+                    return r;
+                }
+
+                /**\brief reset the state of the model to the initial state before starting the run/optimize*/
+                void reset_states() {
+                    auto cells = model.get_cells();
+                    for (size_t i = 0;i < cells->size();++i)
+                        (*cells)[i].set_state(initial_state[i]);
+                }
+                /**\brief set the parameter ranges, set min=max=wanted parameter value for those not subject to change during optimization */
+                void set_parameter_ranges(const vector<double>& p_min, const vector<double>& p_max) {
+                    parameter_lower_bound = vector_p(p_min);
+                    parameter_upper_bound = vector_p(p_max);
+                }
+
+                void set_verbose_level(int level) { print_progress_level = level; }
+                /**\brief calculate the goal_function as used by minbobyqa,
+                 *   using the full set of  parameters vectors (as passed to optimize())
+                 *   and also ensures that the shyft state/cell/catchment result is consistent
+                 *   with the passed parameters passed
+                 * \param full_vector_of_parameters contains all parameters that will be applied to the run.
+                 *  \returns the goal-function, weigthed nash_sutcliffe sum
+                 */
+                double calculate_goal_function(std::vector<double> full_vector_of_parameters) {
+                    p_expanded = full_vector_of_parameters;// ensure all parameters are  according to full_vector..
+                    return run(reduce_p_vector(full_vector_of_parameters));// then run with parameters as if from optimize
+                }
+
+                /** compute the goal function with the specified parameter set*/
+                double calculate_goal_function(const PA& p) {
+                    return calculate_goal_function(p_vector(p));
+                }
+
+                friend class calibration_test;// to enable testing of individual methods
+                /** called by bobyqua: */
+                double operator() (const column_vector& p_s) { return run(from_scaled(p_s)); }
+                double operator() (const vector<double>&p_s) { return run(from_scaled(p_s)); }
+
+                /** called by bobyqua:reduced parameter space p */
+                vector<double> to_scaled(const vector<double>& rp) const {
+                    if (p_min.size() == 0) throw runtime_error("Parameter ranges are not set");
+                    vector<double> p_s;
+                    auto rp_min = reduce_p_vector(p_min);
+                    auto rp_max = reduce_p_vector(p_max);
+                    const size_t n_params = rp.size();
+                    p_s.reserve(n_params);
+                    for (size_t i = 0; i < n_params; ++i)
+                        p_s.emplace_back((rp[i] - rp_min[i]) / (rp_max[i] - rp_min[i]));
+                    return p_s;
+                }
+                /** called by bobyqua: reduced parameter space p */
+                vector<double> from_scaled(column_vector p_s) const {
+                    if (p_min.size() == 0) throw runtime_error("Parameter ranges are not set");
+                    vector<double> p;
+                    auto rp_min = reduce_p_vector(p_min);
+                    auto rp_max = reduce_p_vector(p_max);
+                    p.reserve(p_s.nr());
+                    for (int i = 0; i < p_s.nr(); ++i)
+                        p.emplace_back((rp_max[i] - rp_min[i])*p_s(i) + rp_min[i]);
+                    return p;
+                }
+                /** called by bobyqua: reduced parameter space p */
+                vector<double> from_scaled(vector<double> p_s) const {
+                    if (p_min.size() == 0) throw runtime_error("Parameter ranges are not set");
+                    vector<double> p;
+                    auto rp_min = reduce_p_vector(p_min);
+                    auto rp_max = reduce_p_vector(p_max);
+                    p.reserve(p_s.size());
+                    for (size_t i = 0; i < p_s.size(); ++i)
+                        p.emplace_back((rp_max[i] - rp_min[i])*p_s[i] + rp_min[i]);
+                    return p;
+                }
+            private:
+
+                pts_t compute_discharge_sum(const target_specification_t& t, vector<pts_t>& catchment_d) const {
+                    if (catchment_d.empty())
+                        model.catchment_discharges(catchment_d);
+                    pts_t discharge_sum(model.time_axis, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
+                    for (auto i : t.catchment_indexes)
+                        discharge_sum.add(catchment_d[model.cix_from_cid(i)]);// important! the catchment_d(ischarge) is in internal index order
+                    return discharge_sum;
+                }
+
+                /** \brief extracts vector of area_ts for all calculated catchments using the
+                 * given property function tsf that should have signature pts_t (const cell& c)
+                 * \note that this function sum together contributions at cell-level.
+                 * TODO: Avoid duplicate code, - use average_catchment_feature(*model.cells, catchment_index, []() return c.rc.snow_sca) but it returns a shared_ptr..
+                 */
+                template<class property_ts_function>
+                vector<area_ts> extract_area_ts_property(property_ts_function && tsf) const {
+                    vector<area_ts> r(n_catchments, area_ts(0.0, pts_t(model.time_axis, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE)));
+                    for (const auto& c : *model.get_cells()) {
+                        if (model.is_calculated_by_catchment_ix(c.geo.catchment_ix)) {
+                            r[c.geo.catchment_ix].ts.add_scale(tsf(c), c.geo.area());//the only ref. to snow_sca
+                            r[c.geo.catchment_ix].area += c.geo.area(); //using entire cell geo area for now.
+                        }
+                    }
+                    for (size_t i = 0;i < n_catchments;++i)
+                        if (model.is_calculated_by_catchment_ix(i))
+                            r[i].ts.scale_by(1 / r[i].area);
+                    return r;
+                }
+                /** \brief returns the area weighted sum of vector<area_ts> according to t.catchment_indexes
+                */
+                pts_t compute_weighted_area_ts_average(const target_specification_t& t, const vector<area_ts>& ats) const {
+                    pts_t ts_sum(model.time_axis, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
+                    double a_sum = 0.0;
+                    for (auto cid : t.catchment_indexes) {
+                        auto i = model.cix_from_cid(cid); // need to get the catchment zero-based index here
+                        ts_sum.add_scale(ats[i].ts, ats[i].area);
+                        a_sum += ats[i].area;
+                    }
+                    ts_sum.scale_by(1 / a_sum);
+                    return ts_sum;
+                }
 
 
-		} // model_calibration
-	} // core
+                template<class rc_t = response_collector_t> // finally,
+                enable_if_tx<detect_snow_sca<rc_t>::value, pts_t> // use enable_if_t  detect_snow_sca to enable this type
+                    compute_sca_sum(const target_specification_t& t, vector<area_ts>& catchment_sca) const {
+                    if (catchment_sca.empty())
+                        catchment_sca = extract_area_ts_property([](const cell_t&c) {return c.rc.snow_sca;});
+                    return compute_weighted_area_ts_average(t, catchment_sca);
+                }
+
+                template<class rc_t = response_collector_t>
+                enable_if_tx<!detect_snow_sca<rc_t>::value, pts_t>
+                    compute_sca_sum(const target_specification_t& t, vector<area_ts>& catchment_d) const {
+                    // To support dynamic typing and python: If a cell.rc do not have snow_sca, but we pass in a criteria/target
+                    // function that do specify snow_sca, we throw a runtime error.
+                    // TODO: verify this in the constructor and throw as early as possible
+                    throw runtime_error("resource collector doesn't have snow_sca");
+                }
+
+
+
+                template<class rc_t = response_collector_t>
+                enable_if_tx<detect_snow_swe<rc_t>::value, pts_t> compute_swe_sum(const target_specification_t& t, vector<area_ts>& catchment_swe) const {
+                    if (catchment_swe.empty())
+                        catchment_swe = extract_area_ts_property([](const cell_t&c) {return c.rc.snow_swe;});
+                    return compute_weighted_area_ts_average(t, catchment_swe);
+                }
+                template<class rc_t = response_collector_t>
+                enable_if_tx<!detect_snow_swe<rc_t>::value, pts_t> compute_swe_sum(const target_specification_t& t, vector<area_ts>& catchment_d) const {
+                    throw runtime_error("resource collector doesn't have snow_swe");
+                }
+
+                /**\brief from operator(), called by min_bobyqa, for each iteration, so p is bobyqa parameter vector
+                * notice that the function returns the value of the goal function,
+                * as specified by the target specification. The flexibility is rather large:
+                *  It's a set of target-specifications, weighted, where each of them can
+                *  be a KG or NS, for a specified period/resolution.
+                *  E.g. we can specify targets that apply to specific catchments, and specified periods/resolutions.
+                */
+                double run(const vector<double>& rp) {
+                    auto p = expand_p_vector(rp);// expand to full vector, then:
+                    parameter_accessor.set(p); // Sets global parameters, all cells share a common pointer.
+                    reset_states();
+                    model.run_cells();
+                    double goal_function_value = 0.0;// overall goal-function, intially zero
+                    double scale_factor_sum = 0.0; // each target-spec have a weight, -use this to sum up weights
+                    vector<pts_t> catchment_d;
+                    vector<area_ts> catchment_sca, catchment_swe;// "catchment" level simulated discharge,sca,swe
+                    for (const auto& t : targets) {
+                        shyft::timeseries::direct_accessor<pts_t, timeaxis_t> target_accessor(t.ts, t.ts.ta);
+                        pts_t property_sum;
+                        switch (t.catchment_property) {
+                        case DISCHARGE:
+                            property_sum = compute_discharge_sum(t, catchment_d);
+                            break;
+                        case SNOW_COVERED_AREA:
+                            property_sum = compute_sca_sum(t, catchment_sca);
+                            break;
+                        case SNOW_WATER_EQUIVALENT:
+                            property_sum = compute_swe_sum(t, catchment_swe);
+                            break;
+                        }
+                        shyft::timeseries::average_accessor<pts_t, timeaxis_t> property_sum_accessor(property_sum, t.ts.ta);
+                        double partial_goal_function_value;
+                        if (t.calc_mode == target_spec_calc_type::NASH_SUTCLIFFE) {
+                            partial_goal_function_value = nash_sutcliffe_goal_function(target_accessor, property_sum_accessor);
+                        } else {
+                            // ref. KLING-GUPTA Journal of Hydrology 377 (2009) 80–91, page 83, formula (10):
+                            // a=alpha, b=betha, q =sigma, u=my, s=simulated, o=observed
+                            partial_goal_function_value /* EDs */ = kling_gupta_goal_function<dlib::running_scalar_covariance<double>>(target_accessor,
+                                property_sum_accessor,
+                                t.s_r,
+                                t.s_a,
+                                t.s_b);
+                        }
+                        if (isfinite(partial_goal_function_value)) {
+                            scale_factor_sum += t.scale_factor;
+                            goal_function_value += t.scale_factor*partial_goal_function_value;
+                        } else if (print_progress_level > 0) {
+                            cout << "warning: goal-function " << t.catchment_property << ": evaluated as nan" << endl;
+                        }
+                    }
+                    goal_function_value /= scale_factor_sum;
+                    if (print_progress_level > 0) {
+                        cout << "ParameterVector(";
+                        for (size_t i = 0; i < parameter_accessor.size(); ++i) {
+                            cout << parameter_accessor.get(i);
+                            if (i < parameter_accessor.size() - 1)cout << ", ";
+                        }
+                        cout << ") = " << goal_function_value << " (NS or KG)" << endl;
+                    }
+                    return goal_function_value;
+                }
+            };
+
+
+        } // model_calibration
+    } // core
 } // shyft

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -407,6 +407,7 @@ namespace shyft {
                 void establish_initial_state_from_model() {
                     // 2. fetch the initial state (s0) from the supplied model, and store it so that we start each run with same state s0
                     auto cells = model.get_cells();
+                    initial_state.resize(0);
                     initial_state.reserve((*cells).size());
                     for (const auto& cell : *cells) initial_state.emplace_back(cell.state);
 
@@ -446,12 +447,19 @@ namespace shyft {
                     }
                     model.set_catchment_calculation_filter(catchment_indexes); //Only calculate the catchments that we optimize
                     // 4. detects if initial state is established, if not it automatically do a copy of the current state
-                    if (initial_state.size() != model.get_cells()->size())
+                    auto_initial_state_check();
+                }
+                void auto_initial_state_check() {
+                    if (initial_state.size() != model.get_cells()->size()) {
+                        if (print_progress_level > 0)
+                            std::cout << "auto-establishing initial state:" << initial_state.size() << "\n";
                         establish_initial_state_from_model();
+                    }
                 }
 
                 /** returns the initial state for the i'th cell */
                 state_t get_initial_state(size_t idx) {
+                    auto_initial_state_check();// in case it's not done, do it now
                     return initial_state[idx];
                 }
 

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -401,8 +401,6 @@ namespace shyft {
                     targets = targetsA;
                     parameter_lower_bound = param_lower_bound;
                     parameter_upper_bound = param_upper_bound;
-                    p_min = p_vector(param_lower_bound);
-                    p_max = p_vector(param_max);
                 }
 
                 /** copy the model current state into internal store of the calibration class */

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -170,10 +170,14 @@ class RegionModel(unittest.TestCase):
         # This enables IDW with default temperature gradient.
         model_interpolation_parameter.use_idw_for_temperature = True
         self.assertAlmostEqual(model_interpolation_parameter.precipitation.scale_factor, 1.02)  # just verify this one is as before change to scale_factor
-        model.run_interpolation(
-            model_interpolation_parameter, time_axis,
+        model.initialize_cell_environment(time_axis)  # just show how we can split the run_interpolation into two calls(second one optional)
+        model.interpolate(
+            model_interpolation_parameter,
             self.create_dummy_region_environment(time_axis,
                                                  model.get_cells()[int(num_cells / 2)].geo.mid_point()))
+        m_ip_parameter = model.interpolation_parameter  # illustrate that we can get back the passed interpolation parameter as a property of the model
+        self.assertEqual(m_ip_parameter.use_idw_for_temperature,True)  # just to ensure we really did get back what we passed in
+        self.assertAlmostEqual(m_ip_parameter.temperature_idw.zscale, 0.5)
         s0 = pt_gs_k.PTGSKStateVector()
         for i in range(num_cells):
             si = pt_gs_k.PTGSKState()

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -1,7 +1,4 @@
-﻿from __future__ import print_function
-from six import iteritems
-
-from numpy import random
+﻿from numpy import random
 import unittest
 
 from shyft import api
@@ -9,11 +6,6 @@ from shyft.api import pt_gs_k
 from shyft.api import pt_ss_k
 from shyft.api import pt_hs_k
 from shyft.api import hbv_stack
-
-try:
-    range
-except NameError:
-    range = range
 
 
 class RegionModel(unittest.TestCase):
@@ -27,9 +19,9 @@ class RegionModel(unittest.TestCase):
             loc = (10000 * random.random(2)).tolist() + (500 * random.random(1)).tolist()
             gp = api.GeoPoint(*loc)
             cid = 0
-            if num_catchments>1:
-                cid = random.randint(1,num_catchments)
-            geo_cell_data = api.GeoCellData(gp, cell_area,cid,0.9,api.LandTypeFractions(0.01, 0.05, 0.19, 0.3, 0.45))
+            if num_catchments > 1:
+                cid = random.randint(1, num_catchments)
+            geo_cell_data = api.GeoCellData(gp, cell_area, cid, 0.9, api.LandTypeFractions(0.01, 0.05, 0.19, 0.3, 0.45))
             # geo_cell_data.land_type_fractions_info().set_fractions(glacier=0.01, lake=0.05, reservoir=0.19, forest=0.3)
             cell = model_t.cell_t()
             cell.geo = geo_cell_data
@@ -49,9 +41,9 @@ class RegionModel(unittest.TestCase):
               "iso_pot_energy": 0.0,
               "temp_swe": 0.0}
         kirchner = {"q": 0.25}
-        pt.update({(k, v) for k, v in iteritems(kwargs) if k in pt})
-        gs.update({(k, v) for k, v in iteritems(kwargs) if k in gs})
-        kirchner.update({(k, v) for k, v in iteritems(kwargs) if k in kirchner})
+        pt.update({(k, v) for k, v in kwargs.items() if k in pt})
+        gs.update({(k, v) for k, v in kwargs.items() if k in gs})
+        kirchner.update({(k, v) for k, v in kwargs.items() if k in kirchner})
         state = pt_gs_k.PTGSKState()
         state.gs.albedo = gs["albedo"]
         state.gs.lwc = gs["lwc"]
@@ -78,10 +70,10 @@ class RegionModel(unittest.TestCase):
         cal = api.Calendar()
         time_axis = api.Timeaxis(cal.time(api.YMDhms(2015, 1, 1, 0, 0, 0)), api.deltahours(1), 240)
         mid_point = api.GeoPoint(1000, 1000, 100)
-        precip_source= self._create_constant_geo_ts(api.PrecipitationSource, mid_point, time_axis.total_period(), 5.0)
+        precip_source = self._create_constant_geo_ts(api.PrecipitationSource, mid_point, time_axis.total_period(), 5.0)
         self.assertIsNotNone(precip_source.uid)
         precip_source.uid = 'abc'
-        self.assertEqual(precip_source.uid,'abc')
+        self.assertEqual(precip_source.uid, 'abc')
 
     def create_dummy_region_environment(self, time_axis, mid_point):
         re = api.ARegionEnvironment()
@@ -131,10 +123,10 @@ class RegionModel(unittest.TestCase):
         lake_area = model.statistics.lake_area(cids)
         reservoir_area = model.statistics.reservoir_area(cids)
         unspecified_area = model.statistics.unspecified_area(cids)
-        self.assertAlmostEqual(total_area,forest_area + glacier_area + lake_area + reservoir_area + unspecified_area)
+        self.assertAlmostEqual(total_area, forest_area + glacier_area + lake_area + reservoir_area + unspecified_area)
         cids.append(3)
         total_area_no_match = model.statistics.total_area(cids)  # now, cids contains 3, that matches no cells
-        self.assertAlmostEqual(total_area_no_match,0.0)
+        self.assertAlmostEqual(total_area_no_match, 0.0)
 
     def test_model_initialize_and_run(self):
         num_cells = 20
@@ -176,7 +168,7 @@ class RegionModel(unittest.TestCase):
             self.create_dummy_region_environment(time_axis,
                                                  model.get_cells()[int(num_cells / 2)].geo.mid_point()))
         m_ip_parameter = model.interpolation_parameter  # illustrate that we can get back the passed interpolation parameter as a property of the model
-        self.assertEqual(m_ip_parameter.use_idw_for_temperature,True)  # just to ensure we really did get back what we passed in
+        self.assertEqual(m_ip_parameter.use_idw_for_temperature, True)  # just to ensure we really did get back what we passed in
         self.assertAlmostEqual(m_ip_parameter.temperature_idw.zscale, 0.5)
         s0 = pt_gs_k.PTGSKStateVector()
         for i in range(num_cells):
@@ -188,17 +180,16 @@ class RegionModel(unittest.TestCase):
         model.run_cells()
         cids = api.IntVector()  # optional, we can add selective catchment_ids here
         sum_discharge = model.statistics.discharge(cids)
-        sum_discharge_value= model.statistics.discharge_value(cids, 0)  # at the first timestep
-        self.assertGreaterEqual(sum_discharge_value,130.0)
+        sum_discharge_value = model.statistics.discharge_value(cids, 0)  # at the first timestep
+        self.assertGreaterEqual(sum_discharge_value, 130.0)
         self.assertIsNotNone(sum_discharge)
         # Verify that if we pass in illegal cids, then it raises exception(with first failing
         try:
             illegal_cids = api.IntVector([0, 4, 5])
             model.statistics.discharge(illegal_cids)
-            self.assertFalse(True,"Failed test, using illegal cids should raise exception")
+            self.assertFalse(True, "Failed test, using illegal cids should raise exception")
         except RuntimeError as rte:
             pass
-
 
         avg_temperature = model.statistics.temperature(cids)
         avg_precipitation = model.statistics.precipitation(cids)
@@ -208,7 +199,7 @@ class RegionModel(unittest.TestCase):
             self.assertEqual(precip_raster.size(), num_cells)
         # example single value spatial aggregation (area-weighted) over cids for a specific timestep
         avg_gs_sc_value = model.gamma_snow_response.sca_value(cids, 1)
-        self.assertGreaterEqual(avg_gs_sc_value,0.0)
+        self.assertGreaterEqual(avg_gs_sc_value, 0.0)
         avg_gs_sca = model.gamma_snow_response.sca(cids)  # swe output
         self.assertIsNotNone(avg_gs_sca)
         # lwc surface_heat alpha melt_mean melt iso_pot_energy temp_sw
@@ -219,6 +210,68 @@ class RegionModel(unittest.TestCase):
         self.assertIsNotNone(copy_region_model)
         copy_region_model.run_cells()  # just to verify we can copy and run the new model
 
+    def test_optimization_model(self):
+        num_cells = 20
+        model_type = pt_gs_k.PTGSKOptModel
+        model = self.build_model(model_type, pt_gs_k.PTGSKParameter, num_cells)
+        cal = api.Calendar()
+        t0 = cal.time(2015, 1, 1, 0, 0, 0)
+        dt = api.deltahours(1)
+        n = 240
+        time_axis = api.Timeaxis(t0, dt, n)
+        model_interpolation_parameter = api.InterpolationParameter()
+        model.initialize_cell_environment(time_axis)  # just show how we can split the run_interpolation into two calls(second one optional)
+        model.interpolate(
+            model_interpolation_parameter,
+            self.create_dummy_region_environment(time_axis,
+                                                 model.get_cells()[int(num_cells / 2)].geo.mid_point()))
+        s0 = pt_gs_k.PTGSKStateVector()
+        for i in range(num_cells):
+            si = pt_gs_k.PTGSKState()
+            si.kirchner.q = 40.0
+            s0.append(si)
+        model.set_states(s0)
+        model.run_cells()
+        cids = api.IntVector.from_numpy([0])  # optional, we can add selective catchment_ids here
+        sum_discharge = model.statistics.discharge(cids)
+        sum_discharge_value = model.statistics.discharge_value(cids, 0)  # at the first timestep
+        self.assertGreaterEqual(sum_discharge_value, 130.0)
+        # verify we can construct an optimizer
+        optimizer = model_type.optimizer_t(model)  # notice that a model type know it's optimizer type, e.g. PTGSKOptimizer
+        self.assertIsNotNone(optimizer)
+        #
+        # create target specification
+        #
+
+        tsa = api.TsTransform().to_average(t0, dt, n, sum_discharge)
+        t_spec_1 = api.TargetSpecificationPts(tsa, cids, 0.7, api.NASH_SUTCLIFFE, 1.0, 1.0, 1.0, api.DISCHARGE, 'test_uid')
+
+        target_spec = api.TargetSpecificationVector()
+        target_spec.append(t_spec_1)
+        upper_bound = model_type.parameter_t(model.get_region_parameter())  # the model_type know it's parameter_t
+        lower_bound = model_type.parameter_t(model.get_region_parameter())
+        upper_bound.kirchner.c1 = -1.9
+        lower_bound.kirchner.c1 = -3.0
+        upper_bound.kirchner.c2 = 0.99
+        lower_bound.kirchner.c2 = 0.80
+
+        optimizer.set_target_specification(target_spec, lower_bound, upper_bound)
+        # Not needed, it will automatically get one.
+        #optimizer.establish_initial_state_from_model()
+        #s0_0 = optimizer.get_initial_state(0)
+        #optimizer.set_verbose_level(1000)
+        p0 = model_type.parameter_t(model.get_region_parameter())
+        orig_c1 = p0.kirchner.c1
+        orig_c2 = p0.kirchner.c2
+        # model.get_cells()[0].env_ts.precipitation.set(0, 5.1)
+        # model.get_cells()[0].env_ts.precipitation.set(1, 4.9)
+        #p0.kirchner.c1 = -2.4
+        # p0.kirchner.c2 = 0.91
+        opt_param = optimizer.optimize(p0, 1500, 0.1, 1e-5)
+        goal_fx = optimizer.calculate_goal_function(opt_param)
+        self.assertLessEqual(goal_fx, 10.0)
+        self.assertAlmostEqual(orig_c1, opt_param.kirchner.c1, 4)
+        self.assertAlmostEqual(orig_c2, opt_param.kirchner.c2, 4)
 
 
     def test_hbv_model_initialize_and_run(self):
@@ -228,13 +281,13 @@ class RegionModel(unittest.TestCase):
         self.assertEqual(model.size(), num_cells)
         # now modify snow_cv forest_factor to 0.1
         region_parameter = model.get_region_parameter()
-        #region_parameter.gs.snow_cv_forest_factor = 0.1
-        #region_parameter.gs.snow_cv_altitude_factor = 0.0001
-        #self.assertEqual(region_parameter.gs.snow_cv_forest_factor, 0.1)
-        #self.assertEqual(region_parameter.gs.snow_cv_altitude_factor, 0.0001)
+        # region_parameter.gs.snow_cv_forest_factor = 0.1
+        # region_parameter.gs.snow_cv_altitude_factor = 0.0001
+        # self.assertEqual(region_parameter.gs.snow_cv_forest_factor, 0.1)
+        # self.assertEqual(region_parameter.gs.snow_cv_altitude_factor, 0.0001)
 
-        #self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 0.0), region_parameter.gs.snow_cv + 0.1)
-        #self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 1000.0), region_parameter.gs.snow_cv + 0.1 + 0.1)
+        # self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 0.0), region_parameter.gs.snow_cv + 0.1)
+        # self.assertAlmostEqual(region_parameter.gs.effective_snow_cv(1.0, 1000.0), region_parameter.gs.snow_cv + 0.1 + 0.1)
         cal = api.Calendar()
         time_axis = api.Timeaxis(cal.time(2015, 1, 1, 0, 0, 0), api.deltahours(1), 240)
         model_interpolation_parameter = api.InterpolationParameter()
@@ -270,17 +323,16 @@ class RegionModel(unittest.TestCase):
         model.run_cells()
         cids = api.IntVector()  # optional, we can add selective catchment_ids here
         sum_discharge = model.statistics.discharge(cids)
-        sum_discharge_value= model.statistics.discharge_value(cids, 0)  # at the first timestep
-        self.assertGreaterEqual(sum_discharge_value,32.0)
+        sum_discharge_value = model.statistics.discharge_value(cids, 0)  # at the first timestep
+        self.assertGreaterEqual(sum_discharge_value, 32.0)
         self.assertIsNotNone(sum_discharge)
         # Verify that if we pass in illegal cids, then it raises exception(with first failing
         try:
             illegal_cids = api.IntVector([0, 4, 5])
             model.statistics.discharge(illegal_cids)
-            self.assertFalse(True,"Failed test, using illegal cids should raise exception")
+            self.assertFalse(True, "Failed test, using illegal cids should raise exception")
         except RuntimeError as rte:
             pass
-
 
         avg_temperature = model.statistics.temperature(cids)
         avg_precipitation = model.statistics.precipitation(cids)
@@ -289,13 +341,13 @@ class RegionModel(unittest.TestCase):
             precip_raster = model.statistics.precipitation(cids, time_step)  # example raster output
             self.assertEqual(precip_raster.size(), num_cells)
         # example single value spatial aggregation (area-weighted) over cids for a specific timestep
-        #avg_gs_sc_value = model.gamma_snow_response.sca_value(cids, 1)
-        #self.assertGreaterEqual(avg_gs_sc_value,0.0)
-        #avg_gs_sca = model.gamma_snow_response.sca(cids)  # swe output
-        #self.assertIsNotNone(avg_gs_sca)
+        # avg_gs_sc_value = model.gamma_snow_response.sca_value(cids, 1)
+        # self.assertGreaterEqual(avg_gs_sc_value,0.0)
+        # avg_gs_sca = model.gamma_snow_response.sca(cids)  # swe output
+        # self.assertIsNotNone(avg_gs_sca)
         # lwc surface_heat alpha melt_mean melt iso_pot_energy temp_sw
-        #avg_gs_albedo = model.gamma_snow_state.albedo(cids)
-        #self.assertIsNotNone(avg_gs_albedo)
+        # avg_gs_albedo = model.gamma_snow_state.albedo(cids)
+        # self.assertIsNotNone(avg_gs_albedo)
         self.assertEqual(avg_temperature.size(), time_axis.size(), "expect results equal to time-axis size")
         copy_region_model = model.__class__(model)
         self.assertIsNotNone(copy_region_model)
@@ -357,9 +409,10 @@ class RegionModel(unittest.TestCase):
         model = self.build_model(pt_gs_k.PTGSKModel, pt_gs_k.PTGSKParameter, n_cells)
         cell_vector = model.get_cells()
         geo_cell_data_vector = cell_vector.geo_cell_data_vector(cell_vector)  # This gives a string, ultra fast, containing the serialized form of all geo-cell data
-        self.assertEqual(len(geo_cell_data_vector) , n_values_pr_gcd * n_cells)
-        cell_vector2 = pt_gs_k.PTGSKCellAllVector.create_from_geo_cell_data_vector(geo_cell_data_vector) # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
-        self.assertEqual(len(cell_vector), len(cell_vector2))  #  just verify equal size, and then geometry, the remaining tests are covered by C++ testing
+        self.assertEqual(len(geo_cell_data_vector), n_values_pr_gcd * n_cells)
+        cell_vector2 = pt_gs_k.PTGSKCellAllVector.create_from_geo_cell_data_vector(
+            geo_cell_data_vector)  # This gives a cell_vector, of specified type, with exactly the same geo-cell data as the original
+        self.assertEqual(len(cell_vector), len(cell_vector2))  # just verify equal size, and then geometry, the remaining tests are covered by C++ testing
         for i in range(len(cell_vector)):
             self.assertAlmostEqual(cell_vector[i].geo.mid_point().z, cell_vector2[i].mid_point().z)
             self.assertAlmostEqual(cell_vector[i].geo.mid_point().x, cell_vector2[i].mid_point().x)

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -242,9 +242,9 @@ class RegionModel(unittest.TestCase):
         #
         # create target specification
         #
-
+        model.set_states(s0)  # remember to set the s0 again, so we have the same initial condition for our game
         tsa = api.TsTransform().to_average(t0, dt, n, sum_discharge)
-        t_spec_1 = api.TargetSpecificationPts(tsa, cids, 0.7, api.NASH_SUTCLIFFE, 1.0, 1.0, 1.0, api.DISCHARGE, 'test_uid')
+        t_spec_1 = api.TargetSpecificationPts(tsa, cids, 1.0, api.KLING_GUPTA, 1.0, 0.0, 0.0, api.DISCHARGE, 'test_uid')
 
         target_spec = api.TargetSpecificationVector()
         target_spec.append(t_spec_1)
@@ -265,10 +265,14 @@ class RegionModel(unittest.TestCase):
         orig_c2 = p0.kirchner.c2
         # model.get_cells()[0].env_ts.precipitation.set(0, 5.1)
         # model.get_cells()[0].env_ts.precipitation.set(1, 4.9)
-        #p0.kirchner.c1 = -2.4
-        # p0.kirchner.c2 = 0.91
+        p0.kirchner.c1 = -2.4
+        p0.kirchner.c2 = 0.91
         opt_param = optimizer.optimize(p0, 1500, 0.1, 1e-5)
         goal_fx = optimizer.calculate_goal_function(opt_param)
+        p0.kirchner.c1 = -2.4
+        p0.kirchner.c2 = 0.91
+        #goal_fx1 = optimizer.calculate_goal_function(p0)
+
         self.assertLessEqual(goal_fx, 10.0)
         self.assertAlmostEqual(orig_c1, opt_param.kirchner.c1, 4)
         self.assertAlmostEqual(orig_c2, opt_param.kirchner.c2, 4)

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -282,16 +282,20 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 			x[i] = (lower[i] + upper[i])*0.5;
 		}
 	}
-	optimizer<region_model_t, parameter_accessor_t, pts_t > rm_opt(rm, target_specs, lower, upper);
+    optimizer<region_model_t, parameter_accessor_t, pts_t > rm_opt(rm);
+    parameter_accessor_t lwr;lwr.set(lower);
+    parameter_accessor_t upr;upr.set(upper);
+    parameter_accessor_t px; px.set(x);
+    rm_opt.set_target_specification(target_specs, lwr, upr);
 	rm_opt.set_verbose_level(1);
 	auto tz = ec::utctime_now();
-	auto x_optimized = rm_opt.optimize(x, 2500, 0.2, 5e-4);
+	auto x_optimized = rm_opt.optimize(px, 2500, 0.2, 5e-4);
 	auto used = ec::utctime_now() - tz;
 	cout << "results: " << used << " seconds, nthreads = " << rm.ncore << endl;
 	cout << " goal function value:" << rm_opt.calculate_goal_function(x_optimized) << endl;
 	cout << " x-parameters before and after" << endl;
 	for (size_t i = 0; i < x.size(); ++i) {
-		cout << "'" << pa.get_name(i) << "' = " << x[i] << " -> " << x_optimized[i] << endl;
+		cout << "'" << pa.get_name(i) << "' = " << px.get(i) << " -> " << x_optimized.get(i) << endl;
 	}
 	cout << " done" << endl;
 }

--- a/test/hbv_tank_test.cpp
+++ b/test/hbv_tank_test.cpp
@@ -12,9 +12,7 @@ void hbv_tank_test::test_regression() {
 	hbv_tank::response r;
 	calendar utc;
 	utctime t0 = utc.time(2015, 1, 1);
-	auto previous_uz = s.uz;
-	auto previous_lz = s.lz;
-	
+
 	calc.step(s, r, t0, t0 + deltahours(1), 0);
 	TS_ASSERT_DELTA(r.outflow, 6.216, 0.0); //TODO: verify some more numbers
 	TS_ASSERT_DELTA(s.uz, 13.2, 0.0);


### PR DESCRIPTION
# Overview

This PR resolves issue:
#98 

by providing the script-user a more fine-grained control over the region_model run as well as calibration and parameter optimization process.

The test/demo python scripts are updated accordingly, to touch/use the new functions.
We also will provide updated notebooks to illustrate the new functionality as soon as this is part of the master branch.

As per usual, each method and property mentioned do have doc-strings where we at best effort describe functionality and purpose.

**RegionModel changes**

A more fine-grained control of running the region-model is provided by splitting the run_interpolation() function into two parts:

    `.initialize_cell_environment(time_axis)`

    that prepares the cell.environment time-series with the supplied time-axis, and
    fills in 0 for all the values.
   The supplied time_axis becomes the region_model.time_axis and is used until otherwise
    specified.

    `.interpolate(ip_parameter,region_env)`

    this function simply interpolate the region_env geo-located time-series into 
    the prepared cell.environment time-series. The supplied ip_parameter then
    becomes the self.ip_parameter, that can be accessed by the user.
    (currently region_env, is not keept by the region_model)

The take-away here is that you **can** drop interpolation if you would like to set the cell.environment time-series directly, without running the interpolation loop. 

The calibration class is also modified to keep the parameters supplied visible to the 
script-user.
This allows for easy inspection, and modification of the optimizer without the need of
keeping the parameters around elsewhere.

**Optimizer changes**

Added properties so that target specification, upper and lower parameter boundaries can be manipulated directly as SHyFT core parameters via python

    `.parameter_lower_bound
     .parameter_upper_bound
     .target_specification`

Added .parameter_active(idx) method to check if the i-th parameter is 'active', using current lower and upper bound.

Added a complete new set of overloads for optimization using native SHyFT core parameters instead of vectors of parameters that are subject to user errors and mistakes.
 
    `.optimize(parameter ...) -> parameter optimized
     .optimize_dream(parameter ...) -> parameter optimized
     .optimize_sceua(parameter ...) -> parameter optimized
     .calculate_goal_function(parameter)->double
     `
The new set of methods (the old ones are still there for bw.compat), returns the optimized parameters.

Added new constructor and methods that allows more incremental approach to the optimization process (scripting rules).

    `.__init__(region_model) -> creates an Optimizer for the model, 
      use 
     .set_target_specification(target_spec, lower_bound,upper_bound)
      to prepare it for call to optimize_xxx calls
      In addition, you can use the exposed properties to inspect and change these
      afterwards.
     .establish_initial_state_from_model()
     make a snapshot of the current region-model state to establish s0 used
     during calibration.
     `
