### PR TITLE
Fixed a bug in assigning a time_axis while running a forecast.

### DIFF
--- a/shyft/orchestration/simulators/config_simulator.py
+++ b/shyft/orchestration/simulators/config_simulator.py
@@ -201,8 +201,6 @@ class ConfigForecaster(object):
         for k, v in self.forecast_sim.items():
             v.geo_ts_repository = self.forecast_cfg[k].get_geots_repo()
             v.ip_repos = self.forecast_cfg[k].get_interp_repo()
-            #v.time_axis = self.forecast_cfg[k].time_axis
-            #v.config = self.forecast_cfg[k]
 
     def run(self, save_end_state=True, save_result_timeseries=True):
         self.historical_sim.run()

--- a/shyft/orchestration/simulators/config_simulator.py
+++ b/shyft/orchestration/simulators/config_simulator.py
@@ -212,7 +212,7 @@ class ConfigForecaster(object):
         if save_end_state:
             self.historical_sim.save_end_state()
         for k, v in self.forecast_sim.items():
-            v.run_forecast(v.time_axis, v.time_axis.start, state)
+            v.run_forecast(self.forecast_cfg[k].time_axis, self.forecast_cfg[k].time_axis.start, state)
             state = v.reg_model_state
             if save_result_timeseries:
                 v.save_result_timeseries()


### PR DESCRIPTION
This PR fixes a bug which assigned the wrong time_axis for a forecast run. The bug was introduced after the changes which removed the time_axis as a settable attribute of ConfigSimulator.