### PR TITLE
Arome namepattern fix

### DIFF
--- a/shyft/repository/netcdf/arome_data_repository.py
+++ b/shyft/repository/netcdf/arome_data_repository.py
@@ -156,7 +156,7 @@ class AromeDataRepository(interfaces.GeoTsRepository):
 
         if not path.isfile(filename):
             if '*' in filename:
-                filename = self._get_files(utc_period.start, "_(\d{8})_(\d{2}).nc$")
+                filename = self._get_files(utc_period.start, "_(\d{8})([T_])(\d{2})(Z)?.nc$")
             else:
                 raise AromeDataRepositoryError("File '{}' not found".format(filename))
         with Dataset(filename) as dataset:
@@ -187,7 +187,8 @@ class AromeDataRepository(interfaces.GeoTsRepository):
             dictionary keyed by ts type, where values are api vectors of geo
             located timeseries.
         """
-        filename = self._get_files(t_c, "_(\d{8})_(\d{2}).nc$")
+        filename = self._get_files(t_c, "_(\d{8})([T_])(\d{2})(Z)?.nc$")
+        #print(filename)
         with Dataset(filename) as dataset:
             return self._get_data_from_dataset(dataset, input_source_types, utc_period,
                                                geo_location_criteria)

--- a/shyft/repository/netcdf/arome_data_repository.py
+++ b/shyft/repository/netcdf/arome_data_repository.py
@@ -188,7 +188,6 @@ class AromeDataRepository(interfaces.GeoTsRepository):
             located timeseries.
         """
         filename = self._get_files(t_c, "_(\d{8})([T_])(\d{2})(Z)?.nc$")
-        #print(filename)
         with Dataset(filename) as dataset:
             return self._get_data_from_dataset(dataset, input_source_types, utc_period,
                                                geo_location_criteria)
@@ -495,7 +494,7 @@ class AromeDataRepository(interfaces.GeoTsRepository):
         for fn in file_names:
             match = re.search(date_pattern, fn)
             if match:
-                datestr, hourstr = match.groups()
+                datestr, _ , hourstr, _ = match.groups()
                 year, month, day = int(datestr[:4]), int(datestr[4:6]), int(datestr[6:8])
                 hour = int(hourstr)
                 t = utc.time(api.YMDhms(year, month, day, hour))


### PR DESCRIPTION
Changed regex for filename pattern of AROME to handle both the old and new filenaming. The change in name pattern resulted in the wrong file being picked (i.e. the latest availabe file with the old naming convention.)