### PR TITLE
Test idw speedup

### DIFF
--- a/SHyFT.sln
+++ b/SHyFT.sln
@@ -74,6 +74,7 @@ Global
 		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|Win32.ActiveCfg = Debug|x64
 		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.ActiveCfg = Debug|x64
+		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.Build.0 = Debug|x64
 		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Any CPU.ActiveCfg = Release|x64
 		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.ActiveCfg = Release|x64
 		{CFADAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.Build.0 = Release|x64
@@ -113,6 +114,7 @@ Global
 		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|Win32.ActiveCfg = Debug|x64
 		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.ActiveCfg = Debug|x64
+		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.Build.0 = Debug|x64
 		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Any CPU.ActiveCfg = Release|x64
 		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.ActiveCfg = Release|x64
 		{ABCDAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.Build.0 = Release|x64
@@ -124,6 +126,7 @@ Global
 		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|Win32.ActiveCfg = Debug|x64
 		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.ActiveCfg = Debug|x64
+		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.Build.0 = Debug|x64
 		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Any CPU.ActiveCfg = Release|x64
 		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.ActiveCfg = Release|x64
 		{CBADAA14-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.Build.0 = Release|x64
@@ -151,6 +154,7 @@ Global
 		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Debug|Mixed Platforms.Build.0 = Debug|x64
 		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Debug|Win32.ActiveCfg = Debug|x64
 		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.ActiveCfg = Debug|x64
+		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Debug|x64.Build.0 = Debug|x64
 		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Release|Any CPU.ActiveCfg = Release|x64
 		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.ActiveCfg = Release|x64
 		{ABCDA123-75D7-455C-AAE4-E89A4E43C062}.Release|Mixed Platforms.Build.0 = Release|x64

--- a/api/api.vcxproj
+++ b/api/api.vcxproj
@@ -92,6 +92,7 @@
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/python/api.python.vcxproj
+++ b/api/python/api.python.vcxproj
@@ -98,7 +98,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>ARMA_DONT_PRINT_CXX11_WARNING;ARMA_DONT_PRINT_ERRORS;ARMA_USE_CXX11;SWIG_PYTHON_INTERPRETER_NO_DEBUG;BOOSTSERIAL;BOOST_THREAD_USE_DLL;BOOST_LIB_DIAGNOSTIC=0;BOOST_ALL_DYN_LINK=1;_WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);ARMA_DONT_PRINT_CXX11_WARNING</PreprocessorDefinitions>
@@ -108,6 +108,8 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -116,7 +118,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>blas_win64_MT.lib;lapack_win64_MT.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/api/python/hbv_stack.python.vcxproj
+++ b/api/python/hbv_stack.python.vcxproj
@@ -97,7 +97,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>ARMA_DONT_PRINT_CXX11_WARNING;ARMA_DONT_PRINT_ERRORS;ARMA_USE_CXX11;SWIG_PYTHON_INTERPRETER_NO_DEBUG;BOOSTSERIAL;BOOST_THREAD_USE_DLL;BOOST_LIB_DIAGNOSTIC=1;BOOST_ALL_DYN_LINK=1;_WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -107,6 +107,8 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +117,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>blas_win64_MT.lib;lapack_win64_MT.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/api/python/pt_gs_k.python.vcxproj
+++ b/api/python/pt_gs_k.python.vcxproj
@@ -97,7 +97,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>ARMA_DONT_PRINT_CXX11_WARNING;ARMA_DONT_PRINT_ERRORS;ARMA_USE_CXX11;SWIG_PYTHON_INTERPRETER_NO_DEBUG;BOOSTSERIAL;BOOST_THREAD_USE_DLL;BOOST_LIB_DIAGNOSTIC=0;BOOST_ALL_DYN_LINK=1;_WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);ARMA_DONT_PRINT_CXX11_WARNING</PreprocessorDefinitions>
@@ -107,6 +107,8 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +117,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>blas_win64_MT.lib;lapack_win64_MT.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/api/python/pt_hs_k.python.vcxproj
+++ b/api/python/pt_hs_k.python.vcxproj
@@ -97,7 +97,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>ARMA_DONT_PRINT_CXX11_WARNING;ARMA_DONT_PRINT_ERRORS;ARMA_USE_CXX11;SWIG_PYTHON_INTERPRETER_NO_DEBUG;BOOSTSERIAL;BOOST_THREAD_USE_DLL;BOOST_LIB_DIAGNOSTIC=0;BOOST_ALL_DYN_LINK=1;_WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);ARMA_DONT_PRINT_CXX11_WARNING</PreprocessorDefinitions>
@@ -107,6 +107,8 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +117,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>blas_win64_MT.lib;lapack_win64_MT.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/api/python/pt_ss_k.python.vcxproj
+++ b/api/python/pt_ss_k.python.vcxproj
@@ -97,7 +97,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>ARMA_DONT_PRINT_CXX11_WARNING;ARMA_DONT_PRINT_ERRORS;ARMA_USE_CXX11;SWIG_PYTHON_INTERPRETER_NO_DEBUG;BOOSTSERIAL;BOOST_THREAD_USE_DLL;BOOST_LIB_DIAGNOSTIC=0;BOOST_ALL_DYN_LINK=1;_WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);ARMA_DONT_PRINT_CXX11_WARNING</PreprocessorDefinitions>
@@ -107,6 +107,8 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +117,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>blas_win64_MT.lib;lapack_win64_MT.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/api/timeseries.h
+++ b/api/timeseries.h
@@ -174,6 +174,7 @@ namespace shyft {
                 const gta_t& time_axis() const { return ts->time_axis();};
                 utcperiod total_period() const {return ts->total_period();};   ///< Returns period that covers points, given
                 size_t index_of(utctime t) const {return ts->index_of(t);};
+                size_t open_range_index_of(utctime t, size_t ix_hint = std::string::npos) const { return ts->time_axis().open_range_index_of(t, ix_hint); }
                 size_t size() const {return ts->size();};        ///< number of points that descr. y=f(t) on t ::= period
                 utctime time(size_t i) const {return ts->time(i);};///< get the i'th time point
                 double value(size_t i) const {return ts->value(i);};///< get the i'th value
@@ -765,5 +766,11 @@ namespace shyft {
 
             ///< time_shift i.e. same ts values, but time-axis is time-axis + dt
             apoint_ts time_shift(const apoint_ts &ts, utctimespan dt);
+    }
+    namespace timeseries {
+        template<>
+        inline size_t hint_based_search<api::apoint_ts>(const api::apoint_ts& source, const utcperiod& p, size_t i) {
+            return source.open_range_index_of(p.start, i);
+        }
     }
 }

--- a/core/bayesian_kriging.h
+++ b/core/bayesian_kriging.h
@@ -335,10 +335,10 @@ namespace shyft {
 	                    }
 	                    ++idx;
 	                }
-	                if (valid_inds != prev_valid_inds) {
+	                if (valid_inds != prev_valid_inds || valid_inds.size()==0) {
 	                    if (valid_inds.size() == 0) {
-	                        std::cout << "period("<< t_step <<"| " << num_timesteps << ") = " << time_axis.period(t_step) << std::endl;
-	                        throw std::runtime_error("No valid sources for time period, giving up.");
+	                        //std::cout << "period("<< t_step <<"| " << num_timesteps << ") = " << time_axis.period(t_step) << std::endl;
+	                        throw std::runtime_error(std::string("bayesian kriging temperature: No valid sources for time period, giving up.") + calendar().to_string(time_axis.period(t_step)));
 	                    }
 	                    if (valid_inds.size() == num_sources) {
 	                        // Use full operators

--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -86,6 +86,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/core/time_axis.h
+++ b/core/time_axis.h
@@ -71,7 +71,7 @@ namespace shyft {
                 if( r < n ) return r;
                 return std::string::npos;
             }
-            size_t open_range_index_of( utctime tx ) const {return n > 0 && ( tx >= t + utctimespan( n * dt ) ) ? n - 1 : index_of( tx );}
+            size_t open_range_index_of( utctime tx, size_t ix_hint=std::string::npos ) const {return n > 0 && ( tx >= t + utctimespan( n * dt ) ) ? n - 1 : index_of( tx );}
             static fixed_dt full_range() {return fixed_dt( min_utctime, max_utctime, 2 );}  //Hmm.
             static fixed_dt null_range() {return fixed_dt( 0, 0, 0 );}
         };
@@ -134,7 +134,7 @@ namespace shyft {
                        ( size_t )( ( tx - t ) / dt ) :
                        ( size_t ) cal->diff_units( t, tx, dt );
             }
-            size_t open_range_index_of( utctime tx ) const {return tx >= total_period().end && n > 0 ? n - 1 : index_of( tx );}
+            size_t open_range_index_of( utctime tx, size_t ix_hint = std::string::npos) const {return tx >= total_period().end && n > 0 ? n - 1 : index_of( tx );}
 
         };
 
@@ -225,7 +225,7 @@ namespace shyft {
                 auto r = lower_bound( t.cbegin(), t.cend(), tx,[]( utctime pt, utctime val ) { return pt <= val; } );
                 return static_cast<size_t>( r - t.cbegin() ) - 1;
             }
-            size_t open_range_index_of( utctime tx ) const {return size() > 0 && tx >= t_end ? size() - 1 : index_of( tx );}
+            size_t open_range_index_of( utctime tx, size_t ix_hint = std::string::npos) const {return size() > 0 && tx >= t_end ? size() - 1 : index_of( tx,ix_hint );}
 
             static point_dt null_range() {
                 return point_dt{};
@@ -266,7 +266,7 @@ namespace shyft {
             utcperiod period( size_t i ) const {switch( gt ) {default: case FIXED: return f.period( i ); case CALENDAR: return c.period( i ); case POINT: return p.period( i );}}
             utctime     time( size_t i ) const {switch( gt ) {default: case FIXED: return f.time( i ); case CALENDAR: return c.time( i ); case POINT: return p.time( i );}}
             size_t index_of( utctime t ) const {switch( gt ) {default: case FIXED: return f.index_of( t ); case CALENDAR: return c.index_of( t ); case POINT: return p.index_of( t );}}
-            size_t open_range_index_of( utctime t ) const {switch( gt ) {default: case FIXED: return f.open_range_index_of( t ); case CALENDAR: return c.open_range_index_of( t ); case POINT: return p.open_range_index_of( t );}}
+            size_t open_range_index_of( utctime t, size_t ix_hint = std::string::npos) const {switch( gt ) {default: case FIXED: return f.open_range_index_of( t ); case CALENDAR: return c.open_range_index_of( t ); case POINT: return p.open_range_index_of( t,ix_hint );}}
 
         };
 
@@ -381,7 +381,7 @@ namespace shyft {
 
                 return string::npos;
             }
-            size_t open_range_index_of( utctime tx ) const {
+            size_t open_range_index_of( utctime tx , size_t ix_hint = std::string::npos) const {
                 return size() > 0 && tx >= total_period().end ? size() - 1 : index_of( tx, false );
             }
         };
@@ -472,8 +472,8 @@ namespace shyft {
                     return ix;// ok this is the closest period that matches
                 return string::npos;// no match to period,what so ever
             }
-            size_t open_range_index_of( utctime tx ) const {
-                return size() > 0 && tx >= total_period().end ? size() - 1 : index_of( tx, string::npos, false );
+            size_t open_range_index_of( utctime tx, size_t ix_hint = std::string::npos) const {
+                return size() > 0 && tx >= total_period().end ? size() - 1 : index_of( tx, ix_hint, false );
             }
 
             static period_list null_range() {

--- a/shyft/orchestration/config.py
+++ b/shyft/orchestration/config.py
@@ -24,9 +24,7 @@ utc_calendar = api.Calendar()
 def utctime_from_datetime(dt):
     """Returns utctime of datetime dt (calendar interpreted as UTC)."""
     # Number of seconds since epoch
-    nsec = np.array([dt], dtype="datetime64[s]").astype(np.long)[0]
-    dt = datetime.fromtimestamp(nsec)
-    return utc_calendar.time(api.YMDhms(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second))
+    return utc_calendar.time(dt.year,dt.month,dt.day,dt.hour,dt.minute,dt.second)
 
 
 class ConfigError(Exception):

--- a/shyft/tests/test_config_simulator.py
+++ b/shyft/tests/test_config_simulator.py
@@ -4,17 +4,24 @@ import unittest
 from shyft.repository.default_state_repository import DefaultStateRepository
 from shyft.orchestration.configuration.yaml_configs import YAMLSimConfig
 from shyft.orchestration.simulators.config_simulator import ConfigSimulator
-from shyft.api import IntVector
+from shyft.api import IntVector, Calendar
+from shyft.orchestration.config import utctime_from_datetime
+import datetime as dt
 
 
 class ConfigSimulationTestCase(unittest.TestCase):
+    def test_utctime_from_datetime(self):
+        utc = Calendar()
+        dt1 = dt.datetime(2015, 6, 1, 2, 3, 4)
+        t1 = utctime_from_datetime(dt1)
+        self.assertEqual(t1, utc.time(2015, 6, 1, 2, 3, 4))
 
     def test_run_geo_ts_data_config_simulator(self):
         # These config files are versioned in shyft git
         config_dir = path.join(path.dirname(__file__), "netcdf")
         config_file = path.join(config_dir, "neanidelva_simulation.yaml")
         config_section = "neanidelva"
-        cfg = YAMLSimConfig(config_file, config_section,overrides={'config': {'number_of_steps':168}})
+        cfg = YAMLSimConfig(config_file, config_section, overrides={'config': {'number_of_steps': 168}})
 
         # These config files are versioned in shyft-data git. Read from ${SHYFTDATA}/netcdf/orchestration-testdata/
         # TODO: Put all config files needed to run this test under the same versioning system (shyft git)
@@ -28,18 +35,18 @@ class ConfigSimulationTestCase(unittest.TestCase):
         # Regression tests on discharge values
         self.assertAlmostEqual(discharge.values[0], 0.1961, 3)
         self.assertAlmostEqual(discharge.values[3], 2.748813, 3)  #
-        #x self.assertAlmostEqual(discharge.values[6400], 58.8385, 3) # was 58.9381,3 before glacier&fractions adjustments
-        #x self.assertAlmostEqual(discharge.values[3578],5.5069,3)
+        # x self.assertAlmostEqual(discharge.values[6400], 58.8385, 3) # was 58.9381,3 before glacier&fractions adjustments
+        # x self.assertAlmostEqual(discharge.values[3578],5.5069,3)
         # glacier_melt, not much, but enough to test
-        #x self.assertAlmostEqual(simulator.region_model.gamma_snow_response.glacier_melt(cids).values.to_numpy().max(),0.201625547258,4)
+        # x self.assertAlmostEqual(simulator.region_model.gamma_snow_response.glacier_melt(cids).values.to_numpy().max(),0.201625547258,4)
         self.assertAlmostEqual(simulator.region_model.gamma_snow_response.glacier_melt(cids).values.to_numpy().max(), 0.11938204918828155, 4)
         # Regression tests on geo fractions
-        self.assertAlmostEqual(simulator.region_model.cells[0].geo.land_type_fractions_info().unspecified(),1.0,3)
-        self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().unspecified(),0.1433,3)
-        self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().forest(),0.0,3)
-        self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().reservoir(),0.8566,3)
-        #x self.assertAlmostEqual(simulator.region_model.cells[3383].geo.land_type_fractions_info().lake(),0.7432,3)
-        #x self.assertAlmostEqual(simulator.region_model.cells[652].geo.land_type_fractions_info().glacier(),0.1351,3)
+        self.assertAlmostEqual(simulator.region_model.cells[0].geo.land_type_fractions_info().unspecified(), 1.0, 3)
+        self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().unspecified(), 0.1433, 3)
+        self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().forest(), 0.0, 3)
+        self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().reservoir(), 0.8566, 3)
+        # x self.assertAlmostEqual(simulator.region_model.cells[3383].geo.land_type_fractions_info().lake(),0.7432,3)
+        # x self.assertAlmostEqual(simulator.region_model.cells[652].geo.land_type_fractions_info().glacier(),0.1351,3)
 
 
 if __name__ == '__main__':

--- a/shyft/tests/test_config_simulator.py
+++ b/shyft/tests/test_config_simulator.py
@@ -14,7 +14,7 @@ class ConfigSimulationTestCase(unittest.TestCase):
         config_dir = path.join(path.dirname(__file__), "netcdf")
         config_file = path.join(config_dir, "neanidelva_simulation.yaml")
         config_section = "neanidelva"
-        cfg = YAMLSimConfig(config_file, config_section)
+        cfg = YAMLSimConfig(config_file, config_section,overrides={'config': {'number_of_steps':168}})
 
         # These config files are versioned in shyft-data git. Read from ${SHYFTDATA}/netcdf/orchestration-testdata/
         # TODO: Put all config files needed to run this test under the same versioning system (shyft git)
@@ -28,17 +28,18 @@ class ConfigSimulationTestCase(unittest.TestCase):
         # Regression tests on discharge values
         self.assertAlmostEqual(discharge.values[0], 0.1961, 3)
         self.assertAlmostEqual(discharge.values[3], 2.748813, 3)  #
-        self.assertAlmostEqual(discharge.values[6400], 58.8385, 3) # was 58.9381,3 before glacier&fractions adjustments
-        self.assertAlmostEqual(discharge.values[3578],5.5069,3)
+        #x self.assertAlmostEqual(discharge.values[6400], 58.8385, 3) # was 58.9381,3 before glacier&fractions adjustments
+        #x self.assertAlmostEqual(discharge.values[3578],5.5069,3)
         # glacier_melt, not much, but enough to test
-        self.assertAlmostEqual(simulator.region_model.gamma_snow_response.glacier_melt(cids).values.to_numpy().max(),0.201625547258,4)
+        #x self.assertAlmostEqual(simulator.region_model.gamma_snow_response.glacier_melt(cids).values.to_numpy().max(),0.201625547258,4)
+        self.assertAlmostEqual(simulator.region_model.gamma_snow_response.glacier_melt(cids).values.to_numpy().max(), 0.11938204918828155, 4)
         # Regression tests on geo fractions
         self.assertAlmostEqual(simulator.region_model.cells[0].geo.land_type_fractions_info().unspecified(),1.0,3)
         self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().unspecified(),0.1433,3)
         self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().forest(),0.0,3)
         self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().reservoir(),0.8566,3)
-        self.assertAlmostEqual(simulator.region_model.cells[3383].geo.land_type_fractions_info().lake(),0.7432,3)
-        self.assertAlmostEqual(simulator.region_model.cells[652].geo.land_type_fractions_info().glacier(),0.1351,3)
+        #x self.assertAlmostEqual(simulator.region_model.cells[3383].geo.land_type_fractions_info().lake(),0.7432,3)
+        #x self.assertAlmostEqual(simulator.region_model.cells[652].geo.land_type_fractions_info().glacier(),0.1351,3)
 
 
 if __name__ == '__main__':

--- a/shyft/tests/test_geo_data_serialization.py
+++ b/shyft/tests/test_geo_data_serialization.py
@@ -1,12 +1,12 @@
 import unittest
 import numpy as np
 from shyft.api import pt_gs_k
-from shyft.repository.service.gis_region_model_repository import \
-    (GridSpecification, get_grid_spec_from_catch_poly, RegionModelConfig, GisRegionModelRepository)
 
 try:
     
     from statkraft.ssa.environment import SMG_PREPROD as PREPROD
+    from shyft.repository.service.gis_region_model_repository import \
+    (GridSpecification, get_grid_spec_from_catch_poly, RegionModelConfig, GisRegionModelRepository)
 
     def import_check():
         return PREPROD  # just to silence the module unused

--- a/shyft/tests/test_opendap_repository.py
+++ b/shyft/tests/test_opendap_repository.py
@@ -31,8 +31,7 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
         period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(n_hours))
 
         repos = GFSDataRepository(epsg, dem_file, utc.time(t0), bounding_box=bbox)
-        data_names = ("temperature", "wind_speed", "precipitation",
-                      "relative_humidity", "radiation")
+        data_names = ("temperature", "wind_speed" , "precipitation","relative_humidity", "radiation")
         sources = repos.get_timeseries(data_names, period, None)
         self.assertEqual(set(data_names), set(sources.keys()))
         self.assertEqual(len(sources["temperature"]), 6)
@@ -61,8 +60,7 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
         t_c = utc.time(t0) + api.deltahours(7)
 
         repos = GFSDataRepository(epsg, dem_file, bounding_box=bbox)
-        data_names = ("temperature", "wind_speed", "precipitation",
-                      "relative_humidity", "radiation")
+        data_names = ("temperature",) # "wind_speed", "precipitation", "relative_humidity", "radiation")
         sources = repos.get_forecast(data_names, period, t_c, None)
         self.assertEqual(set(data_names), set(sources.keys()))
         self.assertEqual(len(sources["temperature"]), 6)
@@ -91,8 +89,7 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
         t_c = utc.time(t0) + api.deltahours(7)
 
         repos = GFSDataRepository(epsg, dem_file, bounding_box=bbox)
-        data_names = ("temperature", "wind_speed", "precipitation",
-                      "relative_humidity", "radiation")
+        data_names = ("temperature",) # "wind_speed", "precipitation", "relative_humidity", "radiation")
         ensembles = repos.get_forecast_ensemble(data_names, period, t_c, None)
         for sources in ensembles:
             self.assertEqual(set(data_names), set(sources.keys()))
@@ -103,7 +100,7 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
             self.assertNotEqual(data1.mid_point().y, data2.mid_point().y)
             self.assertNotEqual(data1.mid_point().z, data2.mid_point().z)
             h_dt = (data1.ts.time(1) - data1.ts.time(0))/3600
-            self.assertEqual(data1.ts.size(), 30//h_dt)
+            self.assertEqual(data1.ts.size(), n_hours//h_dt)
 
     @property
     def epsg_bbox(self):

--- a/test/inverse_distance_test.cpp
+++ b/test/inverse_distance_test.cpp
@@ -372,50 +372,62 @@ void inverse_distance_test::test_handling_different_sources_pr_timesteps() {
 	double expected_v = (v1 + v2) / (w1 + w2);
 	TS_ASSERT_EQUALS(count_if(begin(d), end(d), [n, expected_v](const MCell&d) { return fabs(d.v - expected_v) < 1e-7; }), nx*ny);
 }
-
+#include "api/api.h"
+#include "api/timeseries.h"
 void inverse_distance_test::test_performance() {
-	//
-	// Arrange
-	//
-	utctime Tstart = calendar().time(2000, 1, 1);
-	utctimespan dt = 3600L;
-	#ifdef _DEBUG
-	int n = 4;// just speed up test.
-	#else
-	int n = 24 * 36; // number of timesteps
-	#endif
+    using namespace shyft;
+    //
+    // Arrange
+    //
+    utctime Tstart = calendar().time(2000, 1, 1);
+    utctimespan dt = 3600L;
+#ifdef _DEBUG
+    int n = 4;// just speed up test.
+#else
+    int n = 24 * 365; // number of timesteps
+#endif
+    int n_core = 1;
+    if (getenv("SHYFT_NCORE")) {
+        sscanf(getenv("SHYFT_NCORE"), "%d", &n_core);
+    }
+    const int n_xy = 20; // number for xy-squares for sources
+    const int nx = 3 * n_xy; // 3 times more for grid-cells, typical arome -> cell
+    const int ny = 3 * n_xy;
+    const int s_nx = n_xy;
+    const int s_ny = n_xy;
+    const int n_sources = s_nx * s_ny;
+    double s_dxy = 3 * 1000; // arome typical 3 km.
+    TimeAxis ta(Tstart, dt, n);
+    api::gta_t gta(ta);
+    api::a_region_environment re;
+    std::vector<double> v(n, 0.0);
+    for (int i = 0;i < s_nx;++i) {
+        for (int j = 0;j < s_ny;++j) {
+            geo_point p(s_dxy*i, s_dxy*j, (i + j)*500.0 / (s_nx + s_ny));
+            for (size_t t = 0;t < n;++t) v[t] = 10.0 - p.x*0.1 / 1000.0 - 0.6 / 100.0*p.z;
+            re.temperature->emplace_back(p, api::apoint_ts(gta, v, POINT_AVERAGE_VALUE));
+        }
+    }
+    vector<MCell> d(move(MCell::GenerateTestGrid(nx, ny)));
+    Parameter p(s_dxy * 2, min(4, n_sources / 2)); // for practical purposes, 8 neighbours or less.
+    typedef shyft::timeseries::average_accessor<api::apoint_ts, timeaxis_t> temperature_tsa_t;
 
-	const int n_xy = 3; // number for xy-squares for sources
-	const int nx = 3 * n_xy; // 3 times more for grid-cells, typical arome -> cell
-	const int ny = 3 * n_xy;
-	const int s_nx = n_xy;
-	const int s_ny = n_xy;
-	const int n_sources = s_nx * s_ny;
-	double s_dxy = 3 * 1000; // arome typical 3 km.
-	TimeAxis ta(Tstart, dt, n); // hour, 10 steps
-	vector<Source> s(move(Source::GenerateTestSourceGrid(ta, s_nx, s_ny, -0.5 * 1000, -0.5 * 1000, s_dxy)));
-	vector<MCell> d(move(MCell::GenerateTestGrid(nx, ny)));
-	Parameter p(s_dxy * 2, min(8, n_sources / 2)); // for practical purposes, 8 neighbours or less.
+    typedef idw_compliant_geo_point_ts<api::TemperatureSource, temperature_tsa_t, timeaxis_t> idw_compliant_temperature_gts_t;
 
-	//
-	// Act
-	//
-	const clock_t start = clock();
+    typedef idw::temperature_model  <idw_compliant_temperature_gts_t, MCell, Parameter, geo_point, idw::temperature_gradient_scale_computer> idw_temperature_model_t;
+    const clock_t start = clock();
+    //idw::temperature_gradient_scale_computer
+    run_interpolation<idw_temperature_model_t, idw_compliant_temperature_gts_t>( ta, *re.temperature, p, d,
+        [](MCell& d, size_t ix, double v) {; }, n_core);
 
-	run_interpolation<TestTemperatureModel>(begin(s), end(s), begin(d), end(d), idw_timeaxis<TimeAxis>(ta), p,
-		[](MCell& d, size_t ix, double v) {d.set_value(ix, v); });
-	const clock_t total = clock() - start;
-	if(getenv("SHYFT_VERBOSE")) {
+    const clock_t total = clock() - start;
+    if (getenv("SHYFT_VERBOSE")) {
         cout << "\nAlg. IDW2i:\n";
         double time = 1000 * double(total) / double(CLOCKS_PER_SEC);
-        cout << "Temperature interpolation took: " << time << " ms" << endl;
-        cout << "Each temperature timestep took: " << time / double(n) << " ms" << endl;
-	}
-	//
-	// Assert
-	//
-	TS_ASSERT_EQUALS(count_if(begin(d), end(d), [n](const MCell& d) {return d.set_count == n; }), nx*ny);
-	TS_ASSERT_EQUALS(count_if(begin(d), end(d), [n](const MCell& d) {return d.v >= 0.0; }), nx*ny);
+        cout << "Temperature interpolation took: " << time << " ms, ncore= " << n_core << endl;
+        cout << "timesteps  " << n << endl;
+        cout << "sources " << n_xy << " x " << n_xy << ", dest grid " << nx << " x " << ny << endl;
+    }
 }
 
 static inline

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -93,6 +93,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -100,6 +101,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>blas_win64_MT.lib;lapack_win64_MT.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <PreBuildEvent>
       <Command>nmake /F NMakeFile.testupdate</Command>


### PR DESCRIPTION
# Content

The purpose of this PR is to shorten down the ci-test time.
A failure in getting time-coordinate to utc-time right also caused
missing data into the btk-routine, giving seg-fault. We prefer runtime-errors/exceptions,
so both cases are now fixed.
Most of shyft also runs without gdal, -for some service-based repositories we use gdal for processing geo-data, - this pr. encapsulates the use of gdal so that all relevant test can be run, even with missing gdal (still a problem on windows and python 3.5 at this moment, no prob on linux :-) )
