### PR TITLE
Reading time-series from any repository should cover request period

### DIFF
--- a/api/boostpython/api_time_axis.cpp
+++ b/api/boostpython/api_time_axis.cpp
@@ -34,7 +34,7 @@ namespace expose {
                 .def(init<const vector<utctime>& >(args("time_points"),"create a time-axis supplying n+1 points to define n intervals"))
                 .def("size",&point_dt::size,"returns number of intervals")
                 .def_readonly("t",&point_dt::t,"timepoints except last")
-                .def_readonly("t_end",&point_dt::t,"end of time-axis")
+                .def_readonly("t_end",&point_dt::t_end,"end of time-axis")
                 //.def_readonly("delta_t",&point_dt::dt,"timespan of each interval")
                 .def("total_period",&point_dt::total_period,"the period that covers the entire time-axis")
                 .def("time",&point_dt::time,args("i"),"return the start of the i'th period of the time-axis")

--- a/shyft/repository/interfaces.py
+++ b/shyft/repository/interfaces.py
@@ -269,6 +269,10 @@ class GeoTsRepository(object):
         geo_loc_ts: dictionary
             dictionary keyed by ts type, where values are api vectors of geo
             located timeseries.
+            Important notice: The returned time-series should at least cover the
+            requested period. It could return *more* data than in
+            the requested period, but must return sufficient data so
+            that the f(t) can be evaluated over the requested period.
         """
         pass
 
@@ -291,6 +295,10 @@ class GeoTsRepository(object):
         geo_loc_ts: dictionary
             dictionary keyed by ts type, where values are api vectors of geo
             located timeseries.
+            Important notice: The returned forecast time-series should at least cover the
+            requested period. It could return *more* data than in
+            the requested period, but must return sufficient data so
+            that the f(t) can be evaluated over the requested period.
         """
         pass
 
@@ -312,6 +320,10 @@ class GeoTsRepository(object):
         Returns
         -------
         ensemble: list of same type as get_timeseries
+        Important notice: The returned forecast time-series should at least cover the
+            requested period. It could return *more* data than in
+            the requested period, but must return sufficient data so
+            that the f(t) can be evaluated over the requested period.
         """
         pass
 

--- a/shyft/repository/netcdf/cf_ts_repository.py
+++ b/shyft/repository/netcdf/cf_ts_repository.py
@@ -77,7 +77,13 @@ class CFTsRepository(TsRepository):
                                            " hydroclim variable or time not found.")
         time = convert_netcdf_time(time.units,time)
         idx_min = np.searchsorted(time, utc_period.start, side='left')
+        if time[idx_min] > utc_period.start and idx_min > 0:  # important ! ensure data *cover* the requested period, Shyft ts do take care of resolution etc.
+            idx_min -= 1  # extend range downward so we cover the entire requested period
+
         idx_max = np.searchsorted(time, utc_period.end, side='right')
+
+        if time[idx_max] < utc_period.end and idx_max +1 < len(time):
+            idx_max += 1  # extend range upward so that we cover the requested period
 
         issubset = True if idx_max < len(time) - 1 else False
         time_slice = slice(idx_min, idx_max)

--- a/shyft/repository/netcdf/opendap_data_repository.py
+++ b/shyft/repository/netcdf/opendap_data_repository.py
@@ -125,6 +125,13 @@ class GFSDataRepository(interfaces.GeoTsRepository):
         time = self.ad_to_utc(time)  # Fetch all times
         idx_min = time.searchsorted(utc_period.start, side='left')
         idx_max = time.searchsorted(utc_period.end, side='right')
+
+        if 0 < idx_min < len(time) and time[idx_min]> utc_period.start:
+            idx_min -= 1  # requirement! return data to cover request period if possible
+
+        if idx_max + 1 < len(time) and time[idx_max] < utc_period.end:
+            idx_max += 1  # requirement! return data to cover request period if possible
+
         time_slice = slice(idx_min, idx_max)
         time = time[time_slice]
 

--- a/shyft/tests/api/test_time_axis.py
+++ b/shyft/tests/api/test_time_axis.py
@@ -9,66 +9,69 @@ class TimeAxis(unittest.TestCase):
        defined as n periods non-overlapping ascending
         
      """
+
     def setUp(self):
-        self.c=api.Calendar()
-        self.d=api.deltahours(1)
-        self.n=24
-        #self.t= self.c.trim(api.utctime_now(),self.d)
-        self.t= self.c.trim(self.c.time(api.YMDhms(1969,12,31,0,0,0)),self.d)
-        self.ta=api.Timeaxis2(self.t,self.d,self.n)
-        
+        self.c = api.Calendar()
+        self.d = api.deltahours(1)
+        self.n = 24
+        # self.t= self.c.trim(api.utctime_now(),self.d)
+        self.t = self.c.trim(self.c.time(api.YMDhms(1969, 12, 31, 0, 0, 0)), self.d)
+        self.ta = api.Timeaxis2(self.t, self.d, self.n)
+
     def tearDown(self):
         pass
-    
+
     def test_create_timeaxis(self):
-        self.assertEqual(self.ta.size(),self.n)
-        self.assertEqual(len(self.ta),self.n)
-        self.assertEqual(self.ta(0).start,self.t)
-        self.assertEqual(self.ta(0).end,self.t+self.d)
-        self.assertEqual(self.ta(1).start,self.t+self.d)
-        self.assertEqual(self.ta.total_period().start,self.t)
-        va=np.array([86400,3600,3],dtype=np.int64)
+        self.assertEqual(self.ta.size(), self.n)
+        self.assertEqual(len(self.ta), self.n)
+        self.assertEqual(self.ta(0).start, self.t)
+        self.assertEqual(self.ta(0).end, self.t + self.d)
+        self.assertEqual(self.ta(1).start, self.t + self.d)
+        self.assertEqual(self.ta.total_period().start, self.t)
+        va = np.array([86400, 3600, 3], dtype=np.int64)
         xta = api.Timeaxis(int(va[0]), int(va[1]), int(va[2]))
-        #xta = api.Timeaxis(va[0], va[1], va[2])# TODO: boost.python require this to be int, needs overload for np.int64 types..
-        #xta = api.Timeaxis(86400,3600,3)
-        self.assertEqual(xta.size(),3)
-    
+        # xta = api.Timeaxis(va[0], va[1], va[2])# TODO: boost.python require this to be int, needs overload for np.int64 types..
+        # xta = api.Timeaxis(86400,3600,3)
+        self.assertEqual(xta.size(), 3)
+
     def test_iterate_timeaxis(self):
-        tot_dt=0
+        tot_dt = 0
         for p in self.ta:
             tot_dt += p.timespan()
-        self.assertEqual(tot_dt,self.n*self.d)
-    
+        self.assertEqual(tot_dt, self.n * self.d)
+
     def test_timeaxis_str(self):
-        s=str(self.ta)
-        self.assertTrue(len(s)>10)
-    
+        s = str(self.ta)
+        self.assertTrue(len(s) > 10)
+
     def test_point_timeaxis_(self):
         """ 
         A point time axis takes n+1 points do describe n-periods, where
         each period is defined as [ point_i .. point_i+1 >
         """
-        tap=api.PointTimeaxis(api.UtcTimeVector([t for t in range(self.t,self.t+(self.n+1)*self.d,self.d)])) #TODO: Should work
-        #tap=api.PointTimeaxis(api.UtcTimeVector.from_numpy(np.array([t for t in range(self.t,self.t+(self.n+1)*self.d,self.d)]))) #TODO: Should work
-        self.assertEqual(tap.size(),self.ta.size())
+        all_points = api.UtcTimeVector([t for t in range(self.t, self.t + (self.n + 1) * self.d, self.d)])
+        tap = api.PointTimeaxis(all_points)
+        self.assertEqual(tap.size(), self.ta.size())
         for i in range(self.ta.size()):
             self.assertEqual(tap(i), self.ta(i))
-        s=str(tap)
-        self.assertTrue(len(s)>0)
+        self.assertEqual(tap.t_end, all_points[-1], "t_end should equal the n+1'th point if supplied")
+        s = str(tap)
+        self.assertTrue(len(s) > 0)
 
     def test_generic_timeaxis(self):
         c = api.Calendar()
         dt = api.deltahours(1)
         n = 240
-        t0 = c.time(2016,4,10)
+        t0 = c.time(2016, 4, 10)
 
         tag1 = api.Timeaxis2(t0, dt, n)
-        self.assertEqual(len(tag1),n)
-        self.assertEqual(tag1.time(0),t0)
+        self.assertEqual(len(tag1), n)
+        self.assertEqual(tag1.time(0), t0)
 
-        tag2 = api.Timeaxis2(c,t0,dt,n)
+        tag2 = api.Timeaxis2(c, t0, dt, n)
         self.assertEqual(len(tag2), n)
         self.assertEqual(tag2.time(0), t0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/shyft/tests/test_netcdf_geo_ts_repository.py
+++ b/shyft/tests/test_netcdf_geo_ts_repository.py
@@ -29,22 +29,27 @@ class NetCDFGeoTsRepositoryTestCase(unittest.TestCase):
         utc_calendar = Calendar()
         netcdf_repository = self._construct_from_test_data()
         self.assertIsNotNone(netcdf_repository)
-        utc_period = UtcPeriod(utc_calendar.time(YMDhms(2005, 1, 1, 0, 0, 0)),
-                               utc_calendar.time(YMDhms(2014, 12, 31, 0, 0, 0)))
+        utc_period = UtcPeriod(utc_calendar.time(2005, 1, 1, 0, 20, 0), # make it a challenge! ensure we get the first hour
+                               utc_calendar.time(2014, 12, 30, 0, 20, 0)) # and also, we should have the last hour!
         type_source_map = dict()
         type_source_map['temperature'] = TemperatureSource
-        geo_ts_dict =  netcdf_repository.get_timeseries(
+        geo_ts_dict = netcdf_repository.get_timeseries(
                                                 type_source_map,
                                                 geo_location_criteria=None,
                                                 utc_period=utc_period)
         self.assertIsNotNone(geo_ts_dict)
+        temperature_source = geo_ts_dict['temperature']
+        self.assertIsNotNone(temperature_source)
+        self.assertLessEqual(temperature_source[0].ts.time_axis.time(0),utc_period.start,'expect returned time-axis to cover the requested period')
+        self.assertGreaterEqual(temperature_source[0].ts.time_axis.total_period().end,utc_period.end,'expected returned time-axis to cover requested period')
+
 
     def test_returns_empty_ts_when_no_data_in_request_period(self):
         utc_calendar = Calendar()
         netcdf_repository = self._construct_from_test_data()
         self.assertIsNotNone(netcdf_repository)
-        utc_period = UtcPeriod(utc_calendar.time(YMDhms(2017, 1, 1, 0, 0, 0)),# a period where there is no data in
-                               utc_calendar.time(YMDhms(2020, 12, 31, 0, 0, 0)))# the file supplied
+        utc_period = UtcPeriod(utc_calendar.time(2017, 1, 1, 0, 0, 0),# a period where there is no data in
+                               utc_calendar.time(2020, 12, 31, 0, 0, 0))# the file supplied
         type_source_map = dict()
         type_source_map['temperature'] = TemperatureSource
         geo_ts_dict = netcdf_repository.get_timeseries(
@@ -58,8 +63,8 @@ class NetCDFGeoTsRepositoryTestCase(unittest.TestCase):
         netcdf_repository = self._construct_from_test_data()
         netcdf_repository.raise_if_no_data=True # yes, for now, just imagine this could work.
         self.assertIsNotNone(netcdf_repository)
-        utc_period = UtcPeriod(utc_calendar.time(YMDhms(2017, 1, 1, 0, 0, 0)),# a period where there is no data in
-                               utc_calendar.time(YMDhms(2020, 12, 31, 0, 0, 0)))# the file supplied
+        utc_period = UtcPeriod(utc_calendar.time(2017, 1, 1, 0, 0, 0),# a period where there is no data in
+                               utc_calendar.time(2020, 12, 31, 0, 0, 0))# the file supplied
         type_source_map = dict()
         type_source_map['temperature'] = TemperatureSource
 

--- a/shyft/tests/test_opendap_repository.py
+++ b/shyft/tests/test_opendap_repository.py
@@ -1,7 +1,5 @@
-from __future__ import print_function
 import unittest
 from os import path
-import datetime
 
 from shyft import shyftdata_dir
 from shyft import api
@@ -9,29 +7,24 @@ from shyft.repository.netcdf.opendap_data_repository import GFSDataRepository
 
 
 class GFSDataRepositoryTestCase(unittest.TestCase):
-
     @property
     def start_date(self):
-        date = datetime.datetime.utcnow() - datetime.timedelta(1)  # Yesterday....
-        return date.year, date.month, date.day
+        utc = api.Calendar()
+        today = utc.trim(api.utctime_now(), api.Calendar.DAY)
+        return today - api.Calendar.DAY  # yesterday
 
     def test_get_timeseries(self):
         """
         Simple regression test of OpenDAP data repository.
         """
         epsg, bbox = self.epsg_bbox
-
         dem_file = path.join(shyftdata_dir, "netcdf", "etopo180.nc")
-
-        # Period start
-        (year, month, day), hour = self.start_date, 7
         n_hours = 30
-        utc = api.Calendar()  # No offset gives Utc
-        t0 = api.YMDhms(year, month, day, hour)
-        period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(n_hours))
+        t0 = self.start_date + api.deltahours(7)
+        period = api.UtcPeriod(t0, t0 + api.deltahours(n_hours))
 
-        repos = GFSDataRepository(epsg, dem_file, utc.time(t0), bounding_box=bbox)
-        data_names = ("temperature", "wind_speed" , "precipitation","relative_humidity", "radiation")
+        repos = GFSDataRepository(epsg, dem_file, t0, bounding_box=bbox)
+        data_names = ("temperature", "wind_speed", "precipitation", "relative_humidity", "radiation")
         sources = repos.get_timeseries(data_names, period, None)
         self.assertEqual(set(data_names), set(sources.keys()))
         self.assertEqual(len(sources["temperature"]), 6)
@@ -40,8 +33,8 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
         self.assertNotEqual(data1.mid_point().x, data2.mid_point().x)
         self.assertNotEqual(data1.mid_point().y, data2.mid_point().y)
         self.assertNotEqual(data1.mid_point().z, data2.mid_point().z)
-        h_dt = (data1.ts.time(1) - data1.ts.time(0))/3600
-        self.assertEqual(data1.ts.size(), 30//h_dt)
+        self.assertLessEqual(data1.ts.time(0), period.start, 'expect returned fc ts to cover requested period')
+        self.assertGreaterEqual(data1.ts.total_period().end, period.end, 'expect returned fc ts to cover requested period')
 
     def test_get_forecast(self):
         """
@@ -50,17 +43,13 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
         epsg, bbox = self.epsg_bbox
 
         dem_file = path.join(shyftdata_dir, "netcdf", "etopo180.nc")
-
-        # Period start
-        (year, month, day), hour = self.start_date, 9
         n_hours = 30
-        utc = api.Calendar()  # No offset gives Utc
-        t0 = api.YMDhms(year, month, day, hour)
-        period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(n_hours))
-        t_c = utc.time(t0) + api.deltahours(7)
+        t0 = self.start_date + api.deltahours(9)
+        period = api.UtcPeriod(t0, t0 + api.deltahours(n_hours))
+        t_c = self.start_date + api.deltahours(7)  # the beginning of the forecast criteria
 
         repos = GFSDataRepository(epsg, dem_file, bounding_box=bbox)
-        data_names = ("temperature",) # "wind_speed", "precipitation", "relative_humidity", "radiation")
+        data_names = ("temperature",)  # the full set: "wind_speed", "precipitation", "relative_humidity", "radiation")
         sources = repos.get_forecast(data_names, period, t_c, None)
         self.assertEqual(set(data_names), set(sources.keys()))
         self.assertEqual(len(sources["temperature"]), 6)
@@ -69,27 +58,22 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
         self.assertNotEqual(data1.mid_point().x, data2.mid_point().x)
         self.assertNotEqual(data1.mid_point().y, data2.mid_point().y)
         self.assertNotEqual(data1.mid_point().z, data2.mid_point().z)
-        h_dt = (data1.ts.time(1) - data1.ts.time(0))/3600
-        self.assertEqual(data1.ts.size(), 30//h_dt)
+        self.assertLessEqual(data1.ts.time(0), period.start, 'expect returned fc ts to cover requested period')
+        self.assertGreaterEqual(data1.ts.total_period().end, period.end, 'expect returned fc ts to cover requested period')
 
     def test_get_ensemble(self):
         """
         Simple ensemble regression test of OpenDAP data repository.
         """
         epsg, bbox = self.epsg_bbox
-
         dem_file = path.join(shyftdata_dir, "netcdf", "etopo180.nc")
-
-        # Period start
-        (year, month, day), hour = self.start_date, 9
         n_hours = 30
-        utc = api.Calendar()  # No offset gives Utc
-        t0 = api.YMDhms(year, month, day, hour)
-        period = api.UtcPeriod(utc.time(t0), utc.time(t0) + api.deltahours(n_hours))
-        t_c = utc.time(t0) + api.deltahours(7)
+        t0 = self.start_date + api.deltahours(9)  # api.YMDhms(year, month, day, hour)
+        period = api.UtcPeriod(t0, t0 + api.deltahours(n_hours))
+        t_c = t0
 
         repos = GFSDataRepository(epsg, dem_file, bounding_box=bbox)
-        data_names = ("temperature",) # "wind_speed", "precipitation", "relative_humidity", "radiation")
+        data_names = ("temperature",)  # this is the full set: "wind_speed", "precipitation", "relative_humidity", "radiation")
         ensembles = repos.get_forecast_ensemble(data_names, period, t_c, None)
         for sources in ensembles:
             self.assertEqual(set(data_names), set(sources.keys()))
@@ -99,20 +83,20 @@ class GFSDataRepositoryTestCase(unittest.TestCase):
             self.assertNotEqual(data1.mid_point().x, data2.mid_point().x)
             self.assertNotEqual(data1.mid_point().y, data2.mid_point().y)
             self.assertNotEqual(data1.mid_point().z, data2.mid_point().z)
-            h_dt = (data1.ts.time(1) - data1.ts.time(0))/3600
-            self.assertEqual(data1.ts.size(), n_hours//h_dt)
+            self.assertLessEqual(data1.ts.time(0), period.start, 'expect returned fc ts to cover requested period')
+            self.assertGreaterEqual(data1.ts.total_period().end, period.end, 'expect returned fc ts to cover requested period')
 
     @property
     def epsg_bbox(self):
         """ this should cut a slice out of test-data located in shyft-data repository/arome  """
         EPSG = 32632
-        x0 = 436100.0   # Lower left
+        x0 = 436100.0  # Lower left
         y0 = 6823000.0  # Lower right
         nx = 74
         ny = 124
         dx = 1000.0
         dy = 1000.0
-        return EPSG, ([x0, x0 + nx*dx, x0 + nx*dx, x0], [y0, y0, y0 + ny*dy, y0 + ny*dy])
+        return EPSG, ([x0, x0 + nx * dx, x0 + nx * dx, x0], [y0, y0, y0 + ny * dy, y0 + ny * dy])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Background

During testing notebooks, and running through the regression tests, it turned out that some parts failed, and it was due to lack of data-inputs. 
Looking into the root-cause it was discovered that repositories where using a time-filter algorithm that did exclude endpoints in the range that contained data needed to cover the request period.

These PR fixes this issues, cover it up with tests, and also ensures that notebooks with netcdf data succeeds running the demonstration scripts.

Also everywhere we do have datetime, ensure to use correct handling of calendar coordinates (y,m,d,h,m,s) utilizing the shyft.api.Calendar object to do the proper conversion to utctime (seconds since 1970.01.01 utc).

