### PR TITLE
Routing!

### DIFF
--- a/api/api_serialization.cpp
+++ b/api/api_serialization.cpp
@@ -84,6 +84,26 @@ void shyft::api::periodic_ts::serialize(Archive & ar, const unsigned int version
 }
 
 template<class Archive>
+void shyft::api::convolve_w_ts::serialize(Archive & ar, const unsigned int version) {
+    ar
+    & make_nvp("ipoint_ts", base_object<shyft::api::ipoint_ts>(*this))
+    & make_nvp("ts_impl", ts_impl)
+    ;
+}
+
+// kind of special, mix core and api, hmm!
+template<>
+template <class Archive>
+void shyft::timeseries::convolve_w_ts<shyft::api::apoint_ts>::serialize(Archive & ar, const unsigned int version) {
+    ar
+    & make_nvp("ts", ts)
+    & make_nvp("fx_policy", fx_policy)
+    & make_nvp("w", w)
+    & make_nvp("convolve_policy", policy)
+    ;
+}
+
+template<class Archive>
 void shyft::api::abin_op_ts::serialize(Archive & ar, const unsigned int version) {
     ar
     & make_nvp("ipoint_ts",base_object<shyft::api::ipoint_ts>(*this))
@@ -137,6 +157,8 @@ x_serialize_implement(shyft::api::average_ts);
 x_serialize_implement(shyft::api::accumulate_ts);
 x_serialize_implement(shyft::api::time_shift_ts);
 x_serialize_implement(shyft::api::periodic_ts);
+x_serialize_implement(shyft::timeseries::convolve_w_ts<shyft::api::apoint_ts>);
+x_serialize_implement(shyft::api::convolve_w_ts);
 x_serialize_implement(shyft::api::abin_op_scalar_ts);
 x_serialize_implement(shyft::api::abin_op_ts);
 x_serialize_implement(shyft::api::abin_op_ts_scalar);
@@ -158,6 +180,8 @@ x_arch(shyft::api::average_ts);
 x_arch(shyft::api::accumulate_ts);
 x_arch(shyft::api::time_shift_ts);
 x_arch(shyft::api::periodic_ts);
+x_arch(shyft::timeseries::convolve_w_ts<shyft::api::apoint_ts>);
+x_arch(shyft::api::convolve_w_ts);
 x_arch(shyft::api::abin_op_scalar_ts);
 x_arch(shyft::api::abin_op_ts);
 x_arch(shyft::api::abin_op_ts_scalar);

--- a/api/boostpython/api.cpp
+++ b/api/boostpython/api.cpp
@@ -27,6 +27,7 @@ namespace expose {
 	extern void hbv_tank();
 	extern void hbv_actual_evapotranspiration();
 	extern void glacier_melt();
+	extern void routing();
 
     void api() {
         calendar_and_time();
@@ -51,6 +52,7 @@ namespace expose {
 		hbv_tank();
 		hbv_actual_evapotranspiration();
 		glacier_melt();
+		routing();
     }
 }
 

--- a/api/boostpython/api_geo_cell_data.cpp
+++ b/api/boostpython/api_geo_cell_data.cpp
@@ -32,14 +32,16 @@ namespace expose {
                               "  land_type_fractions (unspecified=1)\n"
                               "  catchment_id   def (-1)\n"
                               "  radiation_slope_factor def 0.9\n"
+                              "  routing_info def(0,0.0), i.e. not routed and hydrological distance=0.0m\n"
         )
-        .def(init<geo_point,double,int,optional<double,const land_type_fractions&>>(args("mid_point","area","catchment_id","radiation_slope_factor","land_type_fractions"),"constructs a GeoCellData with all parameters specified"))
+        .def(init<geo_point,double,int,optional<double,const land_type_fractions&,routing_info>>(args("mid_point","area","catchment_id","radiation_slope_factor","land_type_fractions","routing_info"),"constructs a GeoCellData with all parameters specified"))
         .def("mid_point",&geo_cell_data::mid_point,"returns the mid_point",return_value_policy<copy_const_reference>())
         .def("catchment_id",&geo_cell_data::catchment_id,"returns the catchment_id")
         .def("set_catchment_id",&geo_cell_data::catchment_id,args("catchment_id"),"set the catchment_id")
         .def("radiation_slope_factor",&geo_cell_data::radiation_slope_factor,"radiation slope factor")
         .def("land_type_fractions_info",&geo_cell_data::land_type_fractions_info,"land_type_fractions",return_value_policy<copy_const_reference>())
         .def("set_land_type_fractions",&geo_cell_data::set_land_type_fractions,args("ltf"),"set new LandTypeFractions")
+        .def_readwrite("routing_info",&geo_cell_data::routing,"the routing information for the cell keep destination id and hydrological distance to destination")
         .def("area",&geo_cell_data::area,"returns the area in m^2")
         ;
     }

--- a/api/boostpython/api_routing.cpp
+++ b/api/boostpython/api_routing.cpp
@@ -82,6 +82,7 @@ namespace expose {
             " * no cycles, \n"
             " * no duplicate object-id's etc.\n"
             )
+            .def(init<const routing::river_network&>(args("clone"),"make a clone of river-network"))
             .def("add",&routing::river_network::add,args("river"),
                  "add a river to the network, verifies river id, no cycles etc.\n"
                  "\nraises exception on error\ntip: build your river-network from downstream to upstream order\n"

--- a/api/boostpython/api_routing.cpp
+++ b/api/boostpython/api_routing.cpp
@@ -1,0 +1,105 @@
+#include "boostpython_pch.h"
+#include "api/api.h"
+#include "core/routing.h"
+
+namespace expose {
+    using namespace shyft::core;
+    using namespace boost::python;
+
+    void routing_path_info() {
+
+        class_<routing_info>("RoutingInfo","Describe the hydrological distance and the id of the target routing element (river)")
+         .def(init<optional<int,double>>(args("id","distance"),"create an object with the supplied parameters"))
+         .def_readwrite("id",&routing_info::id,"id of the target,down-stream river")
+         .def_readwrite("distance",&routing_info::distance,"the hydrological distance, in unit of [m]")
+         ;
+    }
+
+    void routing_ugh_parameter() {
+
+        class_<routing::uhg_parameter>("UHGParameter",
+            "The Unit Hydro Graph Parameter contains sufficient\n"
+            "description to create a unit hydro graph, that have a shape\n"
+            "and a discretized 'time-length' according to the model time-step resolution.\n"
+            "Currently we use a gamma function for the shape:\n"
+            "<a ref='https://en.wikipedia.org/wiki/Gamma_distribution'>gamma distribution</a>\n")
+          .def(init<optional<double,double,double>>(args("velocity","alpha","beta"),"a new object with specified parameters"))
+            .def_readwrite("velocity",&routing::uhg_parameter::velocity,"default 1.0, unit [m/s]")
+            .def_readwrite("alpha", &routing::uhg_parameter::alpha,"default 3.0,unit-less, ref. shape of gamma-function")
+            .def_readwrite("beta", &routing::uhg_parameter::beta,"default 0.7, unit-less, ref. shape of gamma-function")
+        ;
+
+        def("make_uhg_from_gamma",&routing::make_uhg_from_gamma,args("n_steps","alpha","beta"),
+             "make_uhg_from_gamma a simple function to create a uhg (unit hydro graph) weight vector\n"
+             "containing n_steps, given the gamma shape factor alpha and beta.\n"
+             "ensuring the sum of the weight vector is 1.0\n"
+             "and that it has a min-size of one element (1.0)\n"
+             "n_steps: int, number of time-steps, elements, in the vector\n"
+             "alpha: float, the gamma_distribution gamma-factor\n"
+             "beta: float, the gamma_distribution beta-factor\n"
+             "return unit hydro graph factors, normalized to sum 1.0\n"
+        );
+    }
+    void routing_river() {
+        class_<routing::river>("River",
+            "A river that we use for routing, its a single piece of a RiverNetwork\n"
+            "\n"
+            " The routing river have flow from\n"
+            " a) zero or more 'cell_nodes',  typically a cell_model type, lateral flow,like cell.rc.average_discharge [m3/s]\n"
+            " b) zero or more upstream connected rivers, taking their .output_m3s()\n"
+            " then a routing river can *optionally* be connected to a down-stream river,\n"
+            " providing a routing function (currently just a convolution of a uhg).\n"
+            "\n"
+            " This definition is recursive, and we use RiverNetwork to ensure the routing graph\n"
+            " is directed and with no cycles.\n"
+            )
+            .def(init<int,optional<routing_info,routing::uhg_parameter>>(args("id","downstream","parameter"),
+                "a new object with specified parameters, notice that a valid river-id|routing-id must be >0"
+                )
+            )
+            .def_readonly("id",&routing::river::id,"a valid identifier >0 for the river|routing element")
+            .def_readwrite("downstream",&routing::river::downstream,"routing information for downstream, target-id, and hydrological distance")
+            .def_readwrite("parameter",&routing::river::parameter,"uhg_parameter, describing the downstream propagation ")
+            .def("uhg",&routing::river::uhg,args("dt"),
+                "create the hydro-graph for this river, taking specified delta-t, dt,\n"
+                "static hydrological distance as well as the shape parameters\n"
+                "alpha and beta used to form the gamma-function.\n"
+                "The length of the uhg (delay) is determined by the downstream-distance,\n"
+                "and the velocity parameter. \n"
+                "The shape of the uhg is determined by alpha&beta parameters.\n")
+            ;
+
+
+    }
+    void routing_river_network() {
+        routing::river& (routing::river_network::*griver)(int)= &routing::river_network::river_by_id;
+        class_<routing::river_network>("RiverNetwork",
+            "A RiverNetwork takes care of the routing\n"
+            "see also description of River\n"
+            "The RiverNetwork provides all needed functions to build\n"
+            "routing into the region model\n"
+            "It ensures safe manipulation of rivers:\n"
+            " * no cycles, \n"
+            " * no duplicate object-id's etc.\n"
+            )
+            .def("add",&routing::river_network::add,args("river"),
+                 "add a river to the network, verifies river id, no cycles etc.\n"
+                 "\nraises exception on error\ntip: build your river-network from downstream to upstream order\n"
+            ,return_internal_reference<>())
+            .def("remove_by_id",&routing::river_network::remove_by_id,args("id"),"disconnect and remove river for network")
+            //.def("river_by_id",&routing::river_network::river_by_id2,args("id"),"get river by id")
+            .def("river_by_id",griver,args("id"),"get river by id",return_internal_reference<>())
+            .def("upstreams_by_id",&routing::river_network::upstreams_by_id,args("id"),"returns a list(vector) of id of upstream rivers from the specified one\n")
+            .def("downstream_by_id",&routing::river_network::downstream_by_id,args("id"),"return id of downstream river, 0 if none")
+            .def("set_downstream_by_id",&routing::river_network::set_downstream_by_id,args("id","downstream_id"),"set downstream target for specified river id")
+            .def("network_contains_directed_cycle",&routing::river_network::network_contains_directed_cycle,"True if network have cycles detected")
+            ;
+    }
+
+    void routing() {
+        routing_path_info();
+        routing_ugh_parameter();
+        routing_river();
+        routing_river_network();
+    }
+}

--- a/api/boostpython/api_target_specification.cpp
+++ b/api/boostpython/api_target_specification.cpp
@@ -36,10 +36,11 @@ namespace expose {
             .value("KLING_GUPTA",model_calibration::KLING_GUPTA)
             .export_values()
             ;
-        enum_<model_calibration::catchment_property_type>("CatchmentPropertyType")
+        enum_<model_calibration::target_property_type>("CatchmentPropertyType")
             .value("DISCHARGE", model_calibration::DISCHARGE)
             .value("SNOW_COVERED_AREA", model_calibration::SNOW_COVERED_AREA)
             .value("SNOW_WATER_EQUIVALENT", model_calibration::SNOW_WATER_EQUIVALENT)
+            .value("ROUTED_DISCHARGE",model_calibration::ROUTED_DISCHARGE)
             .export_values()
             ;
         typedef shyft::core::pts_t target_ts_t;
@@ -57,8 +58,12 @@ namespace expose {
             "\n"
             )
             .def(init<const target_ts_t&,vector<int>,double,
-                 optional<model_calibration::target_spec_calc_type,double,double,double,model_calibration::catchment_property_type,std::string>>(
+                 optional<model_calibration::target_spec_calc_type,double,double,double,model_calibration::target_property_type,std::string>>(
                  args("ts","cids","scale_factor","calc_mode","s_r","s_a","s_b","catchment_property","uid"),"constructs a complete target specification using a TsFixed as target ts")
+            )
+            .def(init<const target_ts_t&, int, double,
+                optional<model_calibration::target_spec_calc_type, double, double, double, std::string>>(
+                    args("ts", "river_id", "scale_factor", "calc_mode", "s_r", "s_a", "s_b", "uid"), "constructs a complete target specification using a TsFixed as target ts")
             )
 			/*Wanted! .def(init<shyft::api::apoint_ts, vector<int>, double,
 				optional<model_calibration::target_spec_calc_type, double, double, double, model_calibration::catchment_property_type>>(
@@ -71,18 +76,16 @@ namespace expose {
             .def_readwrite("s_a",&TargetSpecificationPts::s_a,"KG-scalefactor for alpha (variance)")
             .def_readwrite("s_b",&TargetSpecificationPts::s_b,"KG-scalefactor for beta (bias)")
             .def_readwrite("ts", &TargetSpecificationPts::ts," target ts")
+            .def_readwrite("river_id",&TargetSpecificationPts::river_id,"river identifier for routed discharge calibration")
 			.def_readwrite("catchment_indexes",&TargetSpecificationPts::catchment_indexes,"catchment indexes, 'cids'")
-		    .def_readwrite("uid",&TargetSpecificationPts::uid,"user specifed identfier:string")
+		    .def_readwrite("uid",&TargetSpecificationPts::uid,"user specified identifier:string")
             ;
 
-        //.i:   %template(TargetSpecificationVector) vector<shyft::core::model_calibration::target_specification<shyft::core::pts_t>>;
+
         typedef vector<TargetSpecificationPts> TargetSpecificationVector;
         class_<TargetSpecificationVector>("TargetSpecificationVector","A list of (weighted) target specifications to be used for model calibration")
             .def(vector_indexing_suite<TargetSpecificationVector>())
          ;
-        //typedef model_calibration::ts_transform TsTransform;
-        //        %template(to_average) TsTransform::to_average<shyft::core::pts_t,shyft::api::ITimeSeriesOfPoints>;
-        //    %template(to_average) TsTransform::to_average<shyft::core::pts_t,shyft::core::pts_t>;
 
         shared_ptr<shyft::core::pts_t> (TsTransform::*m1)(utctime , utctimespan , size_t ,const shyft::api::apoint_ts& )=&TsTransform::to_average;
         shared_ptr<shyft::core::pts_t> (TsTransform::*m2)(utctime , utctimespan , size_t ,shared_ptr<shyft::api::apoint_ts> )=&TsTransform::to_average;

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -141,6 +141,17 @@ namespace expose {
 				"-------\n"
 				"a new time-series, time-shifted version of self\n"
 			)
+            .def("convolve_w", &shyft::api::apoint_ts::convolve_w, args("weights", "policy"),
+                "create a new ts that is the convolved ts with the supporteds weights list"
+                "Parameters\n"
+                "----------\n"
+                "weights : DoubleVector\n"
+                "\t the weights profile, use DoubleVector.from_numpy(...) to create these.\n"
+                "\t it's the callers responsibility to ensure the sum of weights are 1.0\n"
+                "policy : convolve_policy(.USE_FIRST|USE_ZERO|USE_NAN)\n"
+                "\t Specifies how to handle initial weight.size()-1 values\n"
+                "\t  see also ConvolvePolicy\n"
+            )
             .def("min",min_double_f,args("number"),"create a new ts that contains the min of self and number for each time-step")
             .def("min",min_ts_f,args("ts_other"),"create a new ts that contains the min of self and ts_other")
             .def("max",max_double_f,args("number"),"create a new ts that contains the max of self and number for each time-step")
@@ -342,6 +353,18 @@ namespace expose {
         enum_<timeseries::point_interpretation_policy>("point_interpretation_policy")
             .value("POINT_INSTANT_VALUE",timeseries::POINT_INSTANT_VALUE)
             .value("POINT_AVERAGE_VALUE",timeseries::POINT_AVERAGE_VALUE)
+            .export_values()
+            ;
+        enum_<timeseries::convolve_policy>(
+            "convolve_policy",
+            "Ref Timeseries.convolve_w function, this policy determinte how to handle initial conditions\n"
+            "USE_FIRST: value(0) is used for all values before value(0), 'mass preserving'\n"
+            "USE_ZERO : fill in zero for all values before value(0):shape preserving\n"
+            "USE_NAN  : nan filled in for the first length-1 values of the filter\n"
+            )
+            .value("USE_FIRST", timeseries::convolve_policy::USE_FIRST)
+            .value("USE_ZERO", timeseries::convolve_policy::USE_ZERO)
+            .value("USE_NAN", timeseries::convolve_policy::USE_NAN)
             .export_values()
             ;
         class_<timeseries::point> ("Point", "A timeseries point specifying utctime t and value v")

--- a/api/boostpython/boostpython.cbp
+++ b/api/boostpython/boostpython.cbp
@@ -158,7 +158,6 @@
 			<Add library="boost_python3" />
 			<Add library="python3.5m" />
 			<Add library="boost_serialization" />
-			<Add library="shyftcore" />
 			<Add directory="$(#python.lib)" />
 		</Linker>
 		<Unit filename="api.cpp">
@@ -226,6 +225,10 @@
 			<Option target="api_Release" />
 		</Unit>
 		<Unit filename="api_region_environment.cpp">
+			<Option target="api_Debug" />
+			<Option target="api_Release" />
+		</Unit>
+		<Unit filename="api_routing.cpp">
 			<Option target="api_Debug" />
 			<Option target="api_Release" />
 		</Unit>

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -162,15 +162,15 @@ namespace expose {
 				" env: RegionEnvironemnt\n"
 				"     contains the ref: region_environment type\n"
 		 )
-         .def("run_cells",&M::run_cells,(boost::python::arg("thread_cell_count")=0,boost::python::arg("start_step")=0,boost::python::arg("n_steps")=0),
+         .def("run_cells",&M::run_cells,(boost::python::arg("use_ncore")=0,boost::python::arg("start_step")=0,boost::python::arg("n_steps")=0),
              "run_cells calculations over specified time_axis,optionally with thread_cell_count, start_step and n_steps\n"
              "require that initialize(time_axis) or run_interpolation is done first\n"
              "If start_step and n_steps are specified, only the specified part of the time-axis is covered.\n"
              "notice that in any case, the current model state is used as a starting point\n"
              "Parameters\n"
              "----------\n"
-             "thread_cell_count : int\n"
-             "\t number of cells pr.worker thread, if 0 is passed, the the core-count is used to determine the count\n"
+             "use_ncore : int\n"
+             "\t number of worker threads, or cores to use, if 0 is passed, the the core-count is used to determine the count\n"
              "start_step : int\n"
              "\t start_step in the time-axis to start at, default=0, meaning start at the beginning\n"
              "n_steps :int\n"

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -101,6 +101,24 @@ namespace expose {
                         "0(=default) means detect by hardware probe"
                         )
          .def_readwrite("region_env",&M::region_env,"empty or the region_env as passed to run_interpolation() or interpolate()")
+         .def_readwrite("river_network",&M::river_network,
+                        "river network that when enabled do the routing part of the region-model\n"
+                        "See also RiverNetwork class for how to build a working river network\n"
+                        "Then use the connect_catchment_to_river(cid,rid) method\n"
+                        "to route cell discharge into the river-network\n")
+         .def("river_output_flow_m3s",&M::river_output_flow_m3s,args("rid"),"returns the routed output flow of the specified river id (rid))")
+         .def("river_upstream_inflow_m3s",&M::river_upstream_inflow_m3s,args("rid"),"returns the routed upstream inflow to the specified river id (rid))")
+         .def("river_local_inflow_m3s",&M::river_local_inflow_m3s,args("rid"),"returns the routed local inflow from connected cells to the specified river id (rid))")
+         .def("connect_catchment_to_river",&M::connect_catchment_to_river,args("cid","rid"),
+         "Connect routing of all the cells in the specified catchment id to the specified river id\n"
+         ""
+         "Parameters\n"
+         "----------\n"
+         " cid: int\n"
+         "\t catchment identifier\n"
+         " rid: int\n"
+         "\t river identifier, can be set to 0 to indicate disconnect from routing"
+         )
          .def("number_of_catchments",&M::number_of_catchments,"compute and return number of catchments using info in cells.geo.catchment_id()")
 		 .def("extract_geo_cell_data",&M::extract_geo_cell_data,
              "extracts the geo_cell_data and return it as GeoCellDataVector that can\n"

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -106,6 +106,7 @@ namespace expose {
                         "See also RiverNetwork class for how to build a working river network\n"
                         "Then use the connect_catchment_to_river(cid,rid) method\n"
                         "to route cell discharge into the river-network\n")
+         .def("has_routing",&M::has_routing,"true if some cells routes to river-network")
          .def("river_output_flow_m3s",&M::river_output_flow_m3s,args("rid"),"returns the routed output flow of the specified river id (rid))")
          .def("river_upstream_inflow_m3s",&M::river_upstream_inflow_m3s,args("rid"),"returns the routed upstream inflow to the specified river id (rid))")
          .def("river_local_inflow_m3s",&M::river_local_inflow_m3s,args("rid"),"returns the routed local inflow from connected cells to the specified river id (rid))")

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -214,7 +214,14 @@ namespace expose {
                     "set/reset the catchment based calculation filter. This affects what get simulate/calculated during\n"
                     "the run command. Pass an empty list to reset/clear the filter (i.e. no filter).\n"
                     "\n"
-                    "param catchment_id_list is a (zero-based) catchment id vector\n"
+                    "param catchment_id_list is a catchment id vector\n"
+         )
+         .def("set_calculation_filter", &M::set_catchment_calculation_filter, args("catchment_id_list","river_id_list"),
+                 "set/reset the catchment *and* river based calculation filter. This affects what get simulate/calculated during\n"
+                 "the run command. Pass an empty list to reset/clear the filter (i.e. no filter).\n"
+                 "\n"
+                 "param catchment_id_list is a catchment id vector\n"
+                "param river_id_list is a river id vector\n"
          )
          .def("is_calculated",&M::is_calculated,args("catchment_id"),"true if catchment id is calculated during runs, ref set_catchment_calculation_filter")
          .def("get_states",&M::get_states,args("end_states"),

--- a/api/boostpython/hbv_stack.cpp
+++ b/api/boostpython/hbv_stack.cpp
@@ -55,7 +55,7 @@ namespace expose {
 				.def(init<hbv_snow::state, hbv_soil::state, hbv_tank::state>(args("snow", "soil", "tank"), "initializes state with hbv_snow, hbv_soil and hbv_tank"))
 				.def_readwrite("snow", &state::snow, "hbv_snow state")
 				.def_readwrite("soil", &state::soil, "soil state")
-				.def_readwrite("tank", &state::soil, "tank state")
+				.def_readwrite("tank", &state::tank, "tank state")
 				;
 
 			typedef std::vector<state> HbvStateVector;

--- a/api/boostpython/hbv_stack.cpp
+++ b/api/boostpython/hbv_stack.cpp
@@ -31,7 +31,7 @@ namespace expose {
 				"Contains the parameters to the methods used in the HBV assembly\n"
 				"priestley_taylor,hbv_snow,hbv_actual_evapotranspiration,hbv_soil, hbv_tank,precipitation_correction\n"
 				)
-				.def(init<const priestley_taylor::parameter&, const hbv_snow::parameter&, const hbv_actual_evapotranspiration::parameter&, const hbv_soil::parameter&, const hbv_tank::parameter&, const precipitation_correction::parameter&, optional<glacier_melt::parameter>>(args("pt", "snow", "ae", "soil", "tank", "p_corr","gm"), "create object with specified parameters"))
+				.def(init<const priestley_taylor::parameter&, const hbv_snow::parameter&, const hbv_actual_evapotranspiration::parameter&, const hbv_soil::parameter&, const hbv_tank::parameter&, const precipitation_correction::parameter&, optional<glacier_melt::parameter,routing::uhg_parameter>>(args("pt", "snow", "ae", "soil", "tank", "p_corr","gm","routing"), "create object with specified parameters"))
 				.def(init<const parameter&>(args("p"), "clone a parameter"))
 				.def_readwrite("pt", &parameter::pt, "priestley_taylor parameter")
 				.def_readwrite("ae", &parameter::ae, "hbv actual evapotranspiration parameter")
@@ -40,6 +40,7 @@ namespace expose {
 				.def_readwrite("soil", &parameter::soil, "hbv_soil parameter")
 				.def_readwrite("tank", &parameter::tank, "hbv_tank parameter")
 				.def_readwrite("p_corr", &parameter::p_corr, "precipitation correction parameter")
+				.def_readwrite("routing",&parameter::routing,"routing cell-to-river catchment specific parameters")
 				.def("size", &parameter::size, "returns total number of calibration parameters")
 				.def("set", &parameter::set, args("p"), "set parameters from vector/list of float, ordered as by get_name(i)")
 				.def("get", &parameter::get, args("i"), "return the value of the i'th parameter, name given by .get_name(i)")

--- a/api/boostpython/pt_gs_k.cpp
+++ b/api/boostpython/pt_gs_k.cpp
@@ -32,7 +32,7 @@ namespace expose {
                               "Contains the parameters to the methods used in the PTGSK assembly\n"
                               "priestley_taylor,gamma_snow,actual_evapotranspiration,precipitation_correction,kirchner\n"
                 )
-                .def(init<priestley_taylor::parameter,gamma_snow::parameter,actual_evapotranspiration::parameter,kirchner::parameter,precipitation_correction::parameter, optional<glacier_melt::parameter>>(args("pt","gs","ae","k","p_corr","gm"),"create object with specified parameters"))
+                .def(init<priestley_taylor::parameter,gamma_snow::parameter,actual_evapotranspiration::parameter,kirchner::parameter,precipitation_correction::parameter, optional<glacier_melt::parameter,routing::uhg_parameter>>(args("pt","gs","ae","k","p_corr","gm","routing"),"create object with specified parameters"))
                 .def(init<const parameter&>(args("p"),"clone a parameter"))
                 .def_readwrite("pt",&parameter::pt,"priestley_taylor parameter")
                 .def_readwrite("gs",&parameter::gs,"gamma-snow parameter")
@@ -40,6 +40,7 @@ namespace expose {
 				.def_readwrite("ae",&parameter::ae,"actual evapotranspiration parameter")
                 .def_readwrite("kirchner",&parameter::kirchner,"kirchner parameter")
                 .def_readwrite("p_corr",&parameter::p_corr,"precipitation correction parameter")
+                .def_readwrite("routing",&parameter::routing,"routing cell-to-river catchment specific parameters")
                 .def("size",&parameter::size,"returns total number of calibration parameters")
                 .def("set",&parameter::set,args("p"),"set parameters from vector/list of float, ordered as by get_name(i)")
                 .def("get",&parameter::get,args("i"),"return the value of the i'th parameter, name given by .get_name(i)")

--- a/api/boostpython/pt_hs_k.cpp
+++ b/api/boostpython/pt_hs_k.cpp
@@ -31,7 +31,7 @@ namespace expose {
                               "Contains the parameters to the methods used in the PTHSK assembly\n"
                               "priestley_taylor,hbv_snow,actual_evapotranspiration,precipitation_correction,kirchner\n"
                 )
-                .def(init<const priestley_taylor::parameter&,const hbv_snow::parameter&,const actual_evapotranspiration::parameter&,const kirchner::parameter&,const precipitation_correction::parameter&,optional<glacier_melt::parameter>>(args("pt","snow","ae","k","p_corr","gm"),"create object with specified parameters"))
+                .def(init<const priestley_taylor::parameter&,const hbv_snow::parameter&,const actual_evapotranspiration::parameter&,const kirchner::parameter&,const precipitation_correction::parameter&,optional<glacier_melt::parameter,routing::uhg_parameter>>(args("pt","snow","ae","k","p_corr","gm","routing"),"create object with specified parameters"))
                 .def(init<const parameter&>(args("p"),"clone a parameter"))
                 .def_readwrite("pt",&parameter::pt,"priestley_taylor parameter")
 				.def_readwrite("ae", &parameter::ae, "actual evapotranspiration parameter")
@@ -39,6 +39,7 @@ namespace expose {
                 .def_readwrite("gm",&parameter::gm,"glacier melt parameter")
                 .def_readwrite("kirchner",&parameter::kirchner,"kirchner parameter")
                 .def_readwrite("p_corr",&parameter::p_corr,"precipitation correction parameter")
+                .def_readwrite("routing",&parameter::routing,"routing cell-to-river catchment specific parameters")
                 .def("size",&parameter::size,"returns total number of calibration parameters")
                 .def("set",&parameter::set,args("p"),"set parameters from vector/list of float, ordered as by get_name(i)")
                 .def("get",&parameter::get,args("i"),"return the value of the i'th parameter, name given by .get_name(i)")

--- a/api/boostpython/pt_ss_k.cpp
+++ b/api/boostpython/pt_ss_k.cpp
@@ -33,14 +33,15 @@ namespace expose {
                               "Contains the parameters to the methods used in the PTSSK assembly\n"
                               "priestley_taylor,skaugen,actual_evapotranspiration,precipitation_correction,kirchner\n"
                 )
-                .def(init<priestley_taylor::parameter,skaugen::parameter,actual_evapotranspiration::parameter,kirchner::parameter,precipitation_correction::parameter, optional<glacier_melt::parameter>>(args("pt","gs","ae","k","p_corr","gm"),"create object with specified parameters"))
+                .def(init<priestley_taylor::parameter,skaugen::parameter,actual_evapotranspiration::parameter,kirchner::parameter,precipitation_correction::parameter, optional<glacier_melt::parameter,routing::uhg_parameter>>(args("pt","gs","ae","k","p_corr","gm","routing"),"create object with specified parameters"))
                 .def(init<const parameter&>(args("p"),"clone a parameter"))
                 .def_readwrite("pt",&parameter::pt,"priestley_taylor parameter")
-				.def_readwrite("ae", &parameter::ae, "actual evapotranspiration parameter")
+                .def_readwrite("ae", &parameter::ae, "actual evapotranspiration parameter")
                 .def_readwrite("ss",&parameter::ss,"skaugen-snow parameter")
                 .def_readwrite("gm", &parameter::gm, "glacier melt parameter")
                 .def_readwrite("kirchner",&parameter::kirchner,"kirchner parameter")
                 .def_readwrite("p_corr",&parameter::p_corr,"precipitation correction parameter")
+                .def_readwrite("routing",&parameter::routing,"routing cell-to-river catchment specific parameters")
                 .def("size",&parameter::size,"returns total number of calibration parameters")
                 .def("set",&parameter::set,args("p"),"set parameters from vector/list of float, ordered as by get_name(i)")
                 .def("get",&parameter::get,args("i"),"return the value of the i'th parameter, name given by .get_name(i)")

--- a/api/timeseries.cpp
+++ b/api/timeseries.cpp
@@ -223,7 +223,9 @@ namespace shyft{
 
         apoint_ts apoint_ts::max(const apoint_ts &a, const apoint_ts&b){return shyft::api::max(a,b);}
         apoint_ts apoint_ts::min(const apoint_ts &a, const apoint_ts&b){return shyft::api::min(a,b);}
-
+        apoint_ts apoint_ts::convolve_w(const std::vector<double> &w, shyft::timeseries::convolve_policy conv_policy) const {
+            return apoint_ts(std::make_shared<shyft::api::convolve_w_ts>(*this, w, conv_policy));
+        }
         std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const gta_t& ta, const vector<int>& percentile_list) {
             std::vector<apoint_ts> r;r.reserve(percentile_list.size());
             //-- use core calc here:

--- a/core/core.cbp
+++ b/core/core.cbp
@@ -49,6 +49,7 @@
 			<Add option="-DARMA_DONT_USE_WRAPPER" />
 			<Add directory="$(#boost.include)" />
 			<Add directory="$(#armadillo.include)" />
+			<Add directory="$(#dlib.include)" />
 		</Compiler>
 		<Linker>
 			<Add option="-pthread" />

--- a/core/core.cbp
+++ b/core/core.cbp
@@ -98,6 +98,7 @@
 		<Unit filename="pt_ss_k.h" />
 		<Unit filename="pt_ss_k_cell_model.h" />
 		<Unit filename="region_model.h" />
+		<Unit filename="routing.h" />
 		<Unit filename="sceua_optimizer.cpp" />
 		<Unit filename="sceua_optimizer.h" />
 		<Unit filename="skaugen.h" />

--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="pt_hs_k_cell_model.h" />
     <ClInclude Include="pt_ss_k.h" />
     <ClInclude Include="pt_ss_k_cell_model.h" />
+    <ClInclude Include="routing.h" />
     <ClInclude Include="sceua_optimizer.h" />
     <ClInclude Include="skaugen.h" />
     <ClInclude Include="timeseries.h" />

--- a/core/core.vcxproj.filters
+++ b/core/core.vcxproj.filters
@@ -130,6 +130,7 @@
       <Filter>method-stacks</Filter>
     </ClInclude>
     <ClInclude Include="unit_conversion.h" />
+    <ClInclude Include="routing.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="methods">

--- a/core/core_pch.h
+++ b/core/core_pch.h
@@ -109,11 +109,8 @@ typedef boost::math::static_gcd_type static_gcd_type;
 //--providing all needed lin-alg:
 #include <armadillo>
 
-//-- providing all needed optimization, graphs ml etc.
+//-- providing all needed optimization
 
 #include <dlib/optimization.h>
 #include <dlib/statistics.h>
 
-#include <dlib/graph_utils.h>
-#include <dlib/graph.h>
-#include <dlib/directed_graph.h>

--- a/core/core_pch.h
+++ b/core/core_pch.h
@@ -106,5 +106,14 @@ typedef boost::math::static_gcd_type static_gcd_type;
     template void T::serialize( boost::archive::AI &,const unsigned int);
 
 
-
+//--providing all needed lin-alg:
 #include <armadillo>
+
+//-- providing all needed optimization, graphs ml etc.
+
+#include <dlib/optimization.h>
+#include <dlib/statistics.h>
+
+#include <dlib/graph_utils.h>
+#include <dlib/graph.h>
+#include <dlib/directed_graph.h>

--- a/core/core_serialization.cpp
+++ b/core/core_serialization.cpp
@@ -188,6 +188,18 @@ void shyft::timeseries::glacier_melt_ts<TS_A, TS_B>::serialize(Archive & ar, con
     & make_nvp("fx_policy", fx_policy)
     ;
 }
+
+template <class Ts>
+template <class Archive>
+void shyft::timeseries::convolve_w_ts<Ts>::serialize(Archive & ar, const unsigned int version) {
+    ar
+    & make_nvp("ts", ts)
+    & make_nvp("fx_policy", fx_policy)
+    & make_nvp("w", w)
+    & make_nvp("convolve_policy",policy)
+    ;
+}
+
 template <class A, class B, class O, class TA>
 template<class Archive>
 void shyft::timeseries::bin_op<A, B, O, TA>::serialize(Archive & ar, const unsigned int version) {
@@ -209,6 +221,7 @@ void shyft::core::geo_point::serialize(Archive& ar, const unsigned int version) 
     & make_nvp("z",z)
     ;
 }
+
 template <class Archive>
 void shyft::core::land_type_fractions::serialize(Archive& ar, const unsigned int version) {
     ar
@@ -219,6 +232,14 @@ void shyft::core::land_type_fractions::serialize(Archive& ar, const unsigned int
     ;
 }
 template <class Archive>
+void shyft::core::routing_info::serialize(Archive& ar, const unsigned int version) {
+    ar
+    & make_nvp("id", id)
+    & make_nvp("distance", distance)
+    ;
+}
+
+template <class Archive>
 void shyft::core::geo_cell_data::serialize(Archive& ar, const unsigned int version) {
     ar
     & make_nvp("mid_point_",mid_point_)
@@ -226,12 +247,14 @@ void shyft::core::geo_cell_data::serialize(Archive& ar, const unsigned int versi
     & make_nvp("catchment_id_",catchment_id_)
     & make_nvp("radiation_slope_factor_",radiation_slope_factor_)
     & make_nvp("fractions",fractions)
+    & make_nvp("routing",routing)
     ;
 }
 
 //-- export geo stuff
 x_serialize_implement(shyft::core::geo_point);
 x_serialize_implement(shyft::core::land_type_fractions);
+x_serialize_implement(shyft::core::routing_info);
 x_serialize_implement(shyft::core::geo_cell_data);
 
 //-- export utctime_utilities
@@ -263,6 +286,11 @@ x_serialize_implement(shyft::timeseries::profile_accessor<shyft::time_axis::fixe
 x_serialize_implement(shyft::timeseries::profile_accessor<shyft::time_axis::calendar_dt>);
 x_serialize_implement(shyft::timeseries::profile_accessor<shyft::time_axis::point_dt>);
 x_serialize_implement(shyft::timeseries::profile_accessor<shyft::time_axis::generic_dt>);
+
+x_serialize_implement(shyft::timeseries::convolve_w_ts<shyft::timeseries::point_ts<shyft::time_axis::fixed_dt>>);
+x_serialize_implement(shyft::timeseries::convolve_w_ts<shyft::timeseries::point_ts<shyft::time_axis::generic_dt>>);
+
+
 x_serialize_implement(shyft::timeseries::periodic_ts<shyft::time_axis::fixed_dt>);
 x_serialize_implement(shyft::timeseries::periodic_ts<shyft::time_axis::calendar_dt>);
 x_serialize_implement(shyft::timeseries::periodic_ts<shyft::time_axis::point_dt>);
@@ -291,6 +319,9 @@ x_arch(shyft::timeseries::point_ts<shyft::time_axis::calendar_dt>);
 x_arch(shyft::timeseries::point_ts<shyft::time_axis::point_dt>);
 x_arch(shyft::timeseries::point_ts<shyft::time_axis::generic_dt>);
 
+x_arch(shyft::timeseries::convolve_w_ts<shyft::timeseries::point_ts<shyft::time_axis::fixed_dt>>);
+x_arch(shyft::timeseries::convolve_w_ts<shyft::timeseries::point_ts<shyft::time_axis::generic_dt>>);
+
 x_arch(shyft::timeseries::ref_ts<shyft::timeseries::point_ts<shyft::time_axis::fixed_dt>>);
 x_arch(shyft::timeseries::ref_ts<shyft::timeseries::point_ts<shyft::time_axis::calendar_dt>>);
 x_arch(shyft::timeseries::ref_ts<shyft::timeseries::point_ts<shyft::time_axis::point_dt>>);
@@ -308,4 +339,5 @@ x_arch(shyft::timeseries::periodic_ts<shyft::time_axis::generic_dt>);
 
 x_arch(shyft::core::geo_point);
 x_arch(shyft::core::land_type_fractions);
+x_arch(shyft::core::routing_info);
 x_arch(shyft::core::geo_cell_data);

--- a/core/geo_cell_data.h
+++ b/core/geo_cell_data.h
@@ -99,8 +99,8 @@ namespace shyft {
 			geo_cell_data() :catchment_ix(0),area_m2(default_area_m2),catchment_id_(-1),radiation_slope_factor_(default_radiation_slope_factor){}
 
 			geo_cell_data(geo_point mid_point,double area=default_area_m2,
-                int catchment_id = -1, double radiation_slope_factor=default_radiation_slope_factor,const land_type_fractions& land_type_fractions=land_type_fractions()):
-				mid_point_(mid_point), area_m2(area), catchment_id_(catchment_id),radiation_slope_factor_(radiation_slope_factor),fractions(land_type_fractions)
+                int catchment_id = -1, double radiation_slope_factor=default_radiation_slope_factor,const land_type_fractions& land_type_fractions=land_type_fractions(),routing_info routing_inf=routing_info()):
+				routing(routing_inf),mid_point_(mid_point), area_m2(area), catchment_id_(catchment_id),radiation_slope_factor_(radiation_slope_factor),fractions(land_type_fractions)
 			{}
 			const geo_point& mid_point() const { return mid_point_; }
 			size_t catchment_id() const { return catchment_id_; }
@@ -111,7 +111,8 @@ namespace shyft {
 			double area() const { return area_m2; }
 			size_t catchment_ix; // internally generated zero-based catchment index, used to correlate to calc-filter, ref. region_model
             bool operator==(const geo_cell_data &o) const {
-                return o.catchment_id_ == catchment_id_ && mid_point_ == o.mid_point_ && fabs(area_m2-o.area_m2)<0.1 && fractions==o.fractions;
+                return o.catchment_id_ == catchment_id_ && mid_point_ == o.mid_point_ && fabs(area_m2-o.area_m2)<0.1 && fractions==o.fractions
+                && fabs(o.routing.distance-routing.distance)<0.1 && o.routing.id == routing.id;
             }
             routing_info routing;///< keeps the geo-static routing info, where it routes to, and routing distance.
         private:

--- a/core/geo_cell_data.h
+++ b/core/geo_cell_data.h
@@ -71,6 +71,16 @@ namespace shyft {
 			x_serialize_decl();
         };
 
+        /** The routing_info contains the geo-static parts of the relation between
+        * the cell and the routing sink point */
+        struct routing_info {
+            routing_info(int destination_id = 0, double distance = 0.0) :
+                id(destination_id), distance(distance) {
+            }
+            int id = 0; ///< target routing input identifier (similar to catchment_id), 0 means nil,none
+            double distance = 0.0; ///< static routing distance[m] to the routing point
+            x_serialize_decl();
+        };
 
         const double default_radiation_slope_factor=0.9;
 
@@ -103,6 +113,7 @@ namespace shyft {
             bool operator==(const geo_cell_data &o) const {
                 return o.catchment_id_ == catchment_id_ && mid_point_ == o.mid_point_ && fabs(area_m2-o.area_m2)<0.1 && fractions==o.fractions;
             }
+            routing_info routing;///< keeps the geo-static routing info, where it routes to, and routing distance.
         private:
 
 			geo_point mid_point_; // midpoint
@@ -118,3 +129,5 @@ namespace shyft {
 //-- serialization support shyft
 x_serialize_export_key(shyft::core::land_type_fractions);
 x_serialize_export_key(shyft::core::geo_cell_data);
+x_serialize_export_key(shyft::core::routing_info);
+

--- a/core/hbv_actual_evapotranspiration.h
+++ b/core/hbv_actual_evapotranspiration.h
@@ -36,7 +36,7 @@ namespace shyft {
 				const utctime dt) {
 				//double actevap;
 
-				return soil_moisture < lp ? pot_evapo*(soil_moisture / lp)*(1.0 - snow_fraction):pot_evapo;
+				return (1.0 - snow_fraction)*(soil_moisture < lp ? pot_evapo*(soil_moisture / lp):pot_evapo);
 				}
 		};
 	};

--- a/core/hbv_soil.h
+++ b/core/hbv_soil.h
@@ -44,9 +44,9 @@ namespace shyft {
 				template <class R,class S> 
 				void step(S& s, R& r, shyft::core::utctime t0, shyft::core::utctime t1, double insoil, double act_evap) {
 					double temp = s.sm + insoil;					//compute fraction at end of time after adding insoil
-					double fraction = pow(temp/param.fc, param.beta);
-					r.outflow = fraction*insoil;
-					s.sm = s.sm + insoil - r.outflow - act_evap;
+					double outflow = insoil*pow(temp/param.fc, param.beta);
+                    r.outflow = outflow > temp ? temp : outflow;
+					s.sm = std::max(0.0,s.sm + insoil - r.outflow - act_evap);
 				}
 			};
 		}

--- a/core/hbv_stack.h
+++ b/core/hbv_stack.h
@@ -8,7 +8,7 @@
 #include "precipitation_correction.h"
 #include "glacier_melt.h"
 #include "unit_conversion.h"
-
+#include "routing.h"
 namespace shyft {
 	namespace core {
 		namespace hbv_stack {
@@ -33,6 +33,7 @@ namespace shyft {
 				typedef hbv_tank::parameter tank_parameter_t;
 				typedef precipitation_correction::parameter precipitation_correction_parameter_t;
                 typedef glacier_melt::parameter glacier_parameter_t;
+            	typedef routing::uhg_parameter routing_parameter_t;
 
 				parameter(pt_parameter_t pt,
 					snow_parameter_t snow,
@@ -40,13 +41,15 @@ namespace shyft {
 					soil_parameter_t soil,
 					tank_parameter_t tank,
 					precipitation_correction_parameter_t p_corr,
-                    glacier_parameter_t gm = glacier_parameter_t())
-					: pt(pt), snow(snow), ae(ae), soil(soil), tank(tank), p_corr(p_corr),gm(gm)  { /*Do nothing */}
+                    glacier_parameter_t gm = glacier_parameter_t(),
+					routing_parameter_t routing=routing_parameter_t())
+					: pt(pt), snow(snow), ae(ae), soil(soil), tank(tank), p_corr(p_corr),gm(gm),routing(routing)  { /*Do nothing */}
 
-				parameter() {}
-				parameter(const parameter& other)
-					: pt(other.pt), snow(other.snow), ae(other.ae),
-					soil(other.soil), tank(other.tank), p_corr(other.p_corr),gm(other.gm)  { /*Do nothing */}
+				parameter()=default;
+				parameter(const parameter&)=default;
+				parameter(parameter&&)=default;
+				parameter& operator=(const parameter &c)=default;
+				parameter& operator=(parameter&&c)=default;
 
 				pt_parameter_t pt;						// I followed pt_gs_k but pt_hs_k differ
 				snow_parameter_t snow;
@@ -55,8 +58,9 @@ namespace shyft {
 				tank_parameter_t  tank;
 				precipitation_correction_parameter_t p_corr;
                 glacier_parameter_t gm;
+                routing_parameter_t routing;
 				///<calibration support, needs vector interface to params, size is the total count
-				size_t size() const { return 17; }
+				size_t size() const { return 20; }
 				///<calibration support, need to set values from ordered vector
 				void set(const vector<double>& p) {
 					if (p.size() != size())
@@ -79,7 +83,9 @@ namespace shyft {
 					pt.albedo = p[i++];
 					pt.alpha = p[i++];
                     gm.dtf = p[i++];
-
+					routing.velocity = p[i++];
+         	        routing.alpha = p[i++];
+               		routing.beta  = p[i++];
 				}
 
 				///< calibration support, get the value of i'th parameter
@@ -102,6 +108,9 @@ namespace shyft {
 					case 14:return pt.albedo;
 					case 15:return pt.alpha;
                     case 16:return gm.dtf;
+					case 17:return routing.velocity;
+                    case 18:return routing.alpha;
+                    case 19:return routing.beta;
 					default:
 						throw runtime_error("HBV_stack Parameter Accessor:.get(i) Out of range.");
 					}
@@ -127,7 +136,10 @@ namespace shyft {
 						"p_corr.scale_factor",
 						"pt.albedo",
 						"pt.alpha",
-                        "gm.dtf"
+                        "gm.dtf",
+						"routing.velocity",
+						"routing.alpha",
+						"routing.beta"
 					};
 					if (i >= size())
 						throw runtime_error("hbv_stack Parameter Accessor:.get_name(i) Out of range.");

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -739,6 +739,8 @@ namespace shyft {
                         case SNOW_WATER_EQUIVALENT:
                             property_sum = compute_swe_sum(t, catchment_swe);
                             break;
+                        case ROUTED_DISCHARGE:
+                            property_sum = *model.river_output_flow_m3s(t.river_id);
                         }
                         shyft::timeseries::average_accessor<pts_t, timeaxis_t> property_sum_accessor(property_sum, t.ts.ta);
                         double partial_goal_function_value;

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -101,7 +101,7 @@ namespace shyft {
              * \param x_eps stop when all x's changes less than x_eps(recall range 0..1), convergence in x
              * \param y_eps stop when last y-values (model goal functions) seems to have converged (no improvements)
              * \return the goal function of m value, and x is the corresponding parameter-set.
-             * \throw runtime_error with text sceua: max_iterations reached before convergence
+             * \throw runtime_error with text sceua: terminated before convergence or max iterations
              */
             template <class M>
             double min_sceua(M& model, vector<double>& x, size_t max_n_evaluations, double x_eps = 0.0001, double y_eps = 0.0001) {
@@ -121,8 +121,8 @@ namespace shyft {
                 for (size_t i = 0; i < x_s.size(); ++i) x_s[i] = xv[i];//copy from raw vector
                 // Convert back to real parameter range
                 x = model.from_scaled(x_s);
-                if (!(opt_state == shyft::core::optimizer::OptimizerState::FinishedFxConvergence || opt_state == shyft::core::optimizer::OptimizerState::FinishedXconvergence))
-                    throw runtime_error("sceua: max-iterations reached before convergence"); //FinishedMaxIterations)
+                if (!(opt_state == shyft::core::optimizer::OptimizerState::FinishedFxConvergence || opt_state == shyft::core::optimizer::OptimizerState::FinishedXconvergence || opt_state == shyft::core::optimizer::FinishedMaxIterations))
+                    throw runtime_error("sceua: terminated before convergence or max iterations"); //FinishedMaxIterations)
                 return y_result;
 
             }

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -180,18 +180,19 @@ namespace shyft {
                     : scale_factor(1.0), calc_mode(NASH_SUTCLIFFE), catchment_property(DISCHARGE), s_r(1.0), s_a(1.0), s_b(1.0) {
                 }
                 target_specification(const target_specification& c)
-                    : ts(c.ts), catchment_indexes(c.catchment_indexes), scale_factor(c.scale_factor),
+                    : ts(c.ts), catchment_indexes(c.catchment_indexes),river_id(c.river_id), scale_factor(c.scale_factor),
                     calc_mode(c.calc_mode), catchment_property(c.catchment_property), s_r(c.s_r), s_a(c.s_a), s_b(c.s_b), uid(c.uid) {
                 }
                 target_specification(target_specification&&c)
                     : ts(std::move(c.ts)),
-                    catchment_indexes(std::move(c.catchment_indexes)),
+                    catchment_indexes(std::move(c.catchment_indexes)),river_id(c.river_id),
                     scale_factor(c.scale_factor), calc_mode(c.calc_mode), catchment_property(c.catchment_property),
                     s_r(c.s_r), s_a(c.s_a), s_b(c.s_b), uid(c.uid) {
                 }
                 target_specification& operator=(target_specification&& c) {
                     ts = std::move(c.ts);
                     catchment_indexes = move(c.catchment_indexes);
+                    river_id = c.river_id;
                     scale_factor = c.scale_factor;
                     calc_mode = c.calc_mode;
                     catchment_property = c.catchment_property;
@@ -203,6 +204,7 @@ namespace shyft {
                     if (this == &c) return *this;
                     ts = c.ts;
                     catchment_indexes = c.catchment_indexes;
+                    river_id = c.river_id;
                     scale_factor = c.scale_factor;
                     calc_mode = c.calc_mode;
                     catchment_property = c.catchment_property;
@@ -211,7 +213,7 @@ namespace shyft {
                     return *this;
                 }
                 bool operator==(const target_specification& x) const {
-                    return catchment_indexes == x.catchment_indexes && catchment_property == x.catchment_property;
+                    return catchment_indexes == x.catchment_indexes && catchment_property == x.catchment_property && river_id==x.river_id;
                 }
                 /** \brief Constructs a target specification element for calibration, specifying all needed parameters
                  *
@@ -250,7 +252,7 @@ namespace shyft {
                 }
                 target_time_series_t ts; ///< The target ts, - any type that is time-series compatible
                 std::vector<int> catchment_indexes; ///< the catchment_indexes that denotes the catchments in the model that together should match the target ts
-                int river_id;///< in case of catchment_property = ROUTED_DISCHARGE, this identifies the river id to get discharge for
+                int river_id=0;///< in case of catchment_property = ROUTED_DISCHARGE, this identifies the river id to get discharge for
                 double scale_factor; ///<< the scale factor to be used when considering multiple target_specifications.
                 target_spec_calc_type calc_mode;///< *NASH_SUTCLIFFE, KLING_GUPTA
                 target_property_type catchment_property;///<  *DISCHARGE,SNOW_COVERED_AREA, SNOW_WATER_EQUIVALENT, ROUTED_DISCHARGE

--- a/core/model_calibration.h
+++ b/core/model_calibration.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <dlib/optimization.h>
-#include <dlib/statistics.h>
+
 #include "cell_model.h"
 #include "region_model.h"
 #include "dream_optimizer.h"

--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -7,6 +7,7 @@
 #include "precipitation_correction.h"
 #include "glacier_melt.h"
 #include "unit_conversion.h"
+#include "routing.h"
 namespace shyft {
   namespace core {
     namespace pt_gs_k {
@@ -30,16 +31,21 @@ namespace shyft {
             typedef kirchner::parameter kirchner_parameter_t;
             typedef precipitation_correction::parameter precipitation_correction_parameter_t;
             typedef glacier_melt::parameter glacier_melt_parameter_t;
+            typedef routing::uhg_parameter routing_parameter_t;
             parameter(pt_parameter_t pt,
                       gs_parameter_t gs,
                       ae_parameter_t ae,
                       kirchner_parameter_t k,
-                      precipitation_correction_parameter_t p_corr,glacier_melt_parameter_t gm=glacier_melt_parameter_t())
-             : pt(pt), gs(gs), ae(ae), kirchner(k), p_corr(p_corr) ,gm(gm){ /*Do nothing */ }
-            parameter() {}
-            parameter(const parameter& other)
-             : pt(other.pt), gs(other.gs), ae(other.ae),
-               kirchner(other.kirchner), p_corr(other.p_corr),gm(other.gm) { /*Do nothing */ }
+                      precipitation_correction_parameter_t p_corr,
+                      glacier_melt_parameter_t gm=glacier_melt_parameter_t(),
+                      routing_parameter_t routing=routing_parameter_t())
+             : pt(pt), gs(gs), ae(ae), kirchner(k), p_corr(p_corr) ,gm(gm),routing(routing){ /*Do nothing */ }
+			parameter()=default;
+			parameter(const parameter&)=default;
+			parameter(parameter&&)=default;
+			parameter& operator=(const parameter &c)=default;
+			parameter& operator=(parameter&&c)=default;
+
 
             pt_parameter_t pt;
             gs_parameter_t gs;
@@ -47,8 +53,9 @@ namespace shyft {
             kirchner_parameter_t  kirchner;
             precipitation_correction_parameter_t p_corr;
             glacier_melt_parameter_t gm;
+            routing_parameter_t routing;
             ///<calibration support, needs vector interface to params, size is the total count
-            size_t size() const { return 25; }
+            size_t size() const { return 28; }
             ///<calibration support, need to set values from ordered vector
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -79,6 +86,9 @@ namespace shyft {
 				gs.winter_end_day_of_year = size_t(p[i++]);
 				gs.calculate_iso_pot_energy = p[i++] != 0.0 ? true : false;
                 gm.dtf = p[i++];
+                routing.velocity = p[i++];
+                routing.alpha = p[i++];
+                routing.beta  = p[i++];
             }
 
             ///< calibration support, get the value of i'th parameter
@@ -109,6 +119,9 @@ namespace shyft {
 					case 22:return (double)gs.winter_end_day_of_year;
 					case 23:return gs.calculate_iso_pot_energy ? 1.0 : 0.0;
                     case 24:return gm.dtf;
+                    case 25:return routing.velocity;
+                    case 26:return routing.alpha;
+                    case 27:return routing.beta;
 
                 default:
                     throw runtime_error("PTGSK Parameter Accessor:.get(i) Out of range.");
@@ -143,7 +156,10 @@ namespace shyft {
 					"gs.initial_bare_ground_fraction",
 					"gs.winter_end_day_of_year",
 					"gs.calculate_iso_pot_energy",
-                    "gm.dtf"
+                    "gm.dtf",
+                    "routing.velocity",
+                    "routing.alpha",
+                    "routing.beta"
                 };
                 if (i >= size())
                     throw runtime_error("PTGSK Parameter Accessor:.get_name(i) Out of range.");
@@ -295,7 +311,7 @@ namespace shyft {
                 double rel_hum = rel_hum_accessor.value(i);
                 double prec = p_corr.calc(prec_accessor.value(i));
                 state_collector.collect(i, state);///< \note collect the state at the beginning of each period (the end state is saved anyway)
-                                
+
                 gs.step(state.gs, response.gs, period.start, period.timespan(), parameter.gs,
                         temp, rad, prec, wind_speed_accessor.value(i), rel_hum,forest_fraction,altitude);
                 response.gm_melt_m3s = glacier_melt::step(parameter.gm.dtf, temp, geo_cell_data.area()*response.gs.sca, glacier_area_m2);
@@ -304,9 +320,9 @@ namespace shyft {
                                   parameter.ae.ae_scale_factor, std::max(response.gs.sca,glacier_fraction), // a evap only on non-snow/non-glac area
                                   period.timespan());
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.gs.outflow, response.ae.ae); // all units mm/h over 'same' area
-                
-                response.total_discharge = 
-                      prec*total_lake_fraction 
+
+                response.total_discharge =
+                      prec*total_lake_fraction
                     + shyft::m3s_to_mmh(response.gm_melt_m3s,geo_cell_data.area())
                     + response.kirchner.q_avg*kirchner_fraction;
 

--- a/core/pt_hs_k.h
+++ b/core/pt_hs_k.h
@@ -7,6 +7,7 @@
 #include "actual_evapotranspiration.h"
 #include "precipitation_correction.h"
 #include "unit_conversion.h"
+#include "routing.h"
 namespace shyft {
   namespace core {
     namespace pt_hs_k {
@@ -19,6 +20,7 @@ namespace shyft {
             typedef kirchner::parameter kirchner_parameter_t;
             typedef precipitation_correction::parameter precipitation_correction_parameter_t;
             typedef glacier_melt::parameter glacier_parameter_t;
+            typedef routing::uhg_parameter routing_parameter_t;
 
             pt_parameter_t pt;
             snow_parameter_t hs;
@@ -26,30 +28,25 @@ namespace shyft {
             kirchner_parameter_t  kirchner;
             precipitation_correction_parameter_t p_corr;
             glacier_parameter_t gm;
-
+            routing_parameter_t routing;
 
             parameter(const pt_parameter_t& pt,
                         const snow_parameter_t& snow,
                         const ae_parameter_t& ae,
                         const kirchner_parameter_t& kirchner,
                         const precipitation_correction_parameter_t& p_corr,
-                        glacier_parameter_t gm = glacier_parameter_t()) // for backwards compatibility pass default glacier parameter
-             : pt(pt), hs(snow), ae(ae), kirchner(kirchner), p_corr(p_corr), gm(gm) { /* Do nothing */ }
-             			parameter(const parameter &c) : pt(c.pt), hs(c.hs), ae(c.ae), kirchner(c.kirchner), p_corr(c.p_corr), gm(c.gm) {}
-			parameter(){}
-			parameter& operator=(const parameter &c) {
-                if(&c != this) {
-                    pt = c.pt;
-                    hs = c.hs;
-                    gm = c.gm;
-                    ae = c.ae;
-                    kirchner = c.kirchner;
-                    p_corr = c.p_corr;
-                }
-                return *this;
-			}
+                        glacier_parameter_t gm = glacier_parameter_t(),
+                        routing_parameter_t routing=routing_parameter_t()
+                      ) // for backwards compatibility pass default glacier parameter
+             : pt(pt), hs(snow), ae(ae), kirchner(kirchner), p_corr(p_corr), gm(gm),routing(routing) { /* Do nothing */ }
+
+			parameter()=default;
+			parameter(const parameter&)=default;
+			parameter(parameter&&)=default;
+			parameter& operator=(const parameter &c)=default;
+			parameter& operator=(parameter&&c)=default;
             ///< Calibration support, size is the total number of calibration parameters
-            size_t size() const { return 13; }
+            size_t size() const { return 16; }
 
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -68,6 +65,9 @@ namespace shyft {
                 p_corr.scale_factor = p[i++];
 				pt.albedo = p[i++];
 				pt.alpha = p[i++];
+                routing.velocity = p[i++];
+                routing.alpha = p[i++];
+                routing.beta  = p[i++];
             }
             //
             ///< calibration support, get the value of i'th parameter
@@ -86,6 +86,10 @@ namespace shyft {
                     case 10:return p_corr.scale_factor;
 					case 11:return pt.albedo;
 					case 12:return pt.alpha;
+                    case 13:return routing.velocity;
+                    case 14:return routing.alpha;
+                    case 15:return routing.beta;
+
                 default:
                     throw runtime_error("pt_hs_k parameter accessor:.get(i) Out of range.");
                 }
@@ -107,7 +111,10 @@ namespace shyft {
                     "gm.dtf",
                     "p_corr.scale_factor",
                     "pt.albedo",
-                    "pt.alpha"
+                    "pt.alpha",
+                    "routing.velocity",
+                    "routing.alpha",
+                    "routing.beta"
 				};
                 if (i >= size())
                     throw runtime_error("pt_hs_k parameter accessor:.get_name(i) Out of range.");
@@ -197,12 +204,12 @@ namespace shyft {
                 hbv_snow.step(state.snow, response.snow, period.start, period.end, parameter.hs, prec, temp); // outputs mm/h, interpreted as over the entire area
 
                 response.gm_melt_m3s = glacier_melt::step(parameter.gm.dtf,temp,geo_cell_data.area()*state.snow.sca,glacier_area_m2);// m3/s, that is, how much flow from the snow free glacier parts
-                
+
                 response.pt.pot_evapotranspiration = pt.potential_evapotranspiration(temp, rad, rel_hum)*calendar::HOUR;// mm/s -> mm/h, interpreted as over the entire area(!)
-                response.ae.ae = actual_evapotranspiration::calculate_step(state.kirchner.q, response.pt.pot_evapotranspiration, 
-                                    parameter.ae.ae_scale_factor,std::max(state.snow.sca,glacier_fraction),  // a evap only on non-snow/non-glac area 
+                response.ae.ae = actual_evapotranspiration::calculate_step(state.kirchner.q, response.pt.pot_evapotranspiration,
+                                    parameter.ae.ae_scale_factor,std::max(state.snow.sca,glacier_fraction),  // a evap only on non-snow/non-glac area
                                     period.timespan());
-                
+
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.snow.outflow, response.ae.ae); //all units mm/h over 'same' area
 
                 response.total_discharge = prec*total_lake_fraction

--- a/core/pt_ss_k.h
+++ b/core/pt_ss_k.h
@@ -7,7 +7,7 @@
 #include "precipitation_correction.h"
 #include "glacier_melt.h"
 #include "unit_conversion.h"
-
+#include "routing.h"
 namespace shyft {
   namespace core {
     namespace pt_ss_k {
@@ -19,35 +19,30 @@ namespace shyft {
             typedef kirchner::parameter kirchner_parameter_t;
             typedef precipitation_correction::parameter precipitation_correction_parameter_t;
             typedef glacier_melt::parameter glacier_melt_parameter_t;
+            typedef routing::uhg_parameter routing_parameter_t;
             pt_parameter_t pt;
             snow_parameter_t ss;
             ae_parameter_t ae;
             kirchner_parameter_t  kirchner;
             precipitation_correction_parameter_t p_corr;
             glacier_melt_parameter_t gm;
+            routing_parameter_t routing;
             parameter(pt_parameter_t pt,
                       snow_parameter_t snow,
                       ae_parameter_t ae,
                       kirchner_parameter_t kirchner,
                       precipitation_correction_parameter_t p_corr,
-                    glacier_melt_parameter_t gm=glacier_melt_parameter_t())
-             : pt(pt), ss(snow), ae(ae), kirchner(kirchner), p_corr(p_corr),gm(gm) { /* Do nothing */ }
+                      glacier_melt_parameter_t gm=glacier_melt_parameter_t(),
+                      routing_parameter_t routing=routing_parameter_t())
+             : pt(pt), ss(snow), ae(ae), kirchner(kirchner), p_corr(p_corr),gm(gm),routing(routing) { /* Do nothing */ }
 
-			parameter(const parameter &c) : pt(c.pt), ss(c.ss), ae(c.ae), kirchner(c.kirchner), p_corr(c.p_corr),gm(c.gm) {}
-			parameter(){}
-			parameter& operator=(const parameter &c) {
-                if(&c != this) {
-                    pt = c.pt;
-                    ss = c.ss;
-                    ae = c.ae;
-                    kirchner = c.kirchner;
-                    p_corr = c.p_corr;
-                    gm=c.gm;
-                }
-                return *this;
-			}
+			parameter()=default;
+			parameter(const parameter&)=default;
+			parameter(parameter&&)=default;
+			parameter& operator=(const parameter &c)=default;
+			parameter& operator=(parameter&&c)=default;
             ///< Calibration support, size is the total number of calibration parameters
-            size_t size() const { return 16; }
+            size_t size() const { return 19; }
 
             void set(const vector<double>& p) {
                 if (p.size() != size())
@@ -69,6 +64,9 @@ namespace shyft {
 				pt.albedo = p[i++];
 				pt.alpha = p[i++];
                 gm.dtf = p[i++];
+                routing.velocity = p[i++];
+                routing.alpha = p[i++];
+                routing.beta  = p[i++];
             }
             //
             ///< calibration support, get the value of i'th parameter
@@ -90,6 +88,9 @@ namespace shyft {
 					case 13:return pt.albedo;
 					case 14:return pt.alpha;
                     case 15:return gm.dtf;
+                    case 16:return routing.velocity;
+                    case 17:return routing.alpha;
+                    case 18:return routing.beta;
 
                 default:
                     throw runtime_error("pt_ss_k parameter accessor:.get(i) Out of range.");
@@ -115,7 +116,10 @@ namespace shyft {
                     "p_corr.scale_factor",
                     "pt.albedo",
                     "pt.alpha",
-                    "gm.dtf"
+                    "gm.dtf",
+                    "routing.velocity",
+                    "routing.alpha",
+                    "routing.beta"
 				};
                 if (i >= size())
                     throw runtime_error("pt_ss_k parameter accessor:.get_name(i) Out of range.");

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -501,6 +501,7 @@ namespace shyft {
                 if (initial_state.size() != cells->size())
                     get_states(initial_state); // snap the initial state here, unless it's already set by the user
                 parallel_run(time_axis,start_step,n_steps, begin(*cells), end(*cells), thread_cell_count);
+                run_routing(start_step,n_steps);
             }
 
             /** \brief set the region parameter, apply it to all cells
@@ -690,6 +691,19 @@ namespace shyft {
                         cr[c.geo.catchment_ix].add(c.rc.avg_discharge);
                 }
             }
+
+            /**\brief return all discharges at the output of the routing points
+             *
+             * For all routing nodes,(maybe terminal routing nodes ?)
+             * compute the routed discharge.
+             *
+             */
+            template <class TSV>
+            void routing_discharges( TSV& cr) const {
+                typedef typename TSV::value_type ts_t;
+                cr.clear();
+                //TODO: iterate over the routing model, return results
+            }
         protected:
             /** \brief parallell_run using a mid-point split + async to engange multicore execution
              *
@@ -738,6 +752,22 @@ namespace shyft {
                 for(auto &f:calcs)
                     f.get();
                 return;
+            }
+            void run_routing(int start_step,int n_steps) {
+                // TODO: implement
+                // things to consider:
+                //  a) start_step,n_steps could be a problem due to the time-delay/convolution window.
+                //     so data is not available through the convolution until after window-size.
+                //  b) for convolution, we can base the approach on 'pull', calculate on demand, possibly with memory-cached result time-series
+                //     in that scenario, we would need a 'dirty' bit to be set (initially) and when starting the run-cells step.
+                //  c) the catchment filter, based on cids, could also be extended to routing ids (rids).
+                //     also: if routing, only rids type of filter allowed ?
+                //           if rids, cell to rid is possibly multi-step lookup. Need to make a rids-filter, where members are all reachable
+                //           cells from wanted rids (to be calculated).
+                //  d) consistency: if cids are used, and routing (and rids) are enabled, auto-extend the cids so that all connected cells(and corresponding cids)
+                //     are calculated (avoid partial calculation of something that goes into a routing network...
+                //     question: how much of this consistency/complexity should we put to the user setting the calculation filter
+
             }
         };
 

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -736,27 +736,27 @@ namespace shyft {
                 }
                 return cr;
             }
-            pts_t river_output_flow_m3s(int rid) const {
-                pts_t r(time_axis,0.0,timeseries::fx_policy_t::POINT_AVERAGE_VALUE);
+            std::shared_ptr<pts_t> river_output_flow_m3s(int rid) const {
+                auto r= std::make_shared<pts_t>(time_axis,0.0,timeseries::fx_policy_t::POINT_AVERAGE_VALUE);
                 if(has_routing()) {
                     routing::model<C> rn(river_network,cells,time_axis);
-                    r=rn.output_m3s(rid);
+                    r=std::make_shared<pts_t>(rn.output_m3s(rid));
                 }
                 return r;
             }
-            pts_t river_upstream_inflow_m3s(int rid) const {
-                pts_t r(time_axis,0.0,timeseries::fx_policy_t::POINT_AVERAGE_VALUE);
+            std::shared_ptr<pts_t> river_upstream_inflow_m3s(int rid) const {
+                auto r= std::make_shared<pts_t>(time_axis,0.0,timeseries::fx_policy_t::POINT_AVERAGE_VALUE);
                 if(has_routing()) {
                     routing::model<C> rn(river_network,cells,time_axis);
-                    r=rn.upstream_inflow(rid);
+                    r=std::make_shared<pts_t>(rn.upstream_inflow(rid));
                 }
                 return r;
             }
-            pts_t river_local_inflow_m3s(int rid) const {
-                pts_t r(time_axis,0.0,timeseries::fx_policy_t::POINT_AVERAGE_VALUE);
+            std::shared_ptr<pts_t> river_local_inflow_m3s(int rid) const {
+                auto r= std::make_shared<pts_t>(time_axis,0.0,timeseries::fx_policy_t::POINT_AVERAGE_VALUE);
                 if(has_routing()) {
                     routing::model<C> rn(river_network,cells,time_axis);
-                    r=rn.local_inflow(rid);
+                    r=std::make_shared<pts_t>(rn.local_inflow(rid));
                 }
                 return r;
             }

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -831,7 +831,7 @@ namespace shyft {
                 vector<future<void>> calcs;
                 mutex pos_mx;
                 size_t pos = 0;
-                for (size_t i = 0;i < use_ncore;++i) { // using ncore = logical available core saturates cpu 100%
+                for (int i = 0;i < use_ncore;++i) { // using ncore = logical available core saturates cpu 100%
                     calcs.emplace_back(
                         async(launch::async, 
                             [this,&pos,&pos_mx,len,&time_axis,&beg,start_step,n_steps]() {

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -758,12 +758,21 @@ namespace shyft {
                 // things to consider:
                 //  a) start_step,n_steps could be a problem due to the time-delay/convolution window.
                 //     so data is not available through the convolution until after window-size.
+                //     possible solutions:
+                //         1) leave it to the user
+                //         2)  always run from start_step=0 ?
+                //         3) as the routing model for the largest delay counted in timesteps, start - longest delay
                 //  b) for convolution, we can base the approach on 'pull', calculate on demand, possibly with memory-cached result time-series
                 //     in that scenario, we would need a 'dirty' bit to be set (initially) and when starting the run-cells step.
+                //         1) optimization, maybe later
                 //  c) the catchment filter, based on cids, could also be extended to routing ids (rids).
                 //     also: if routing, only rids type of filter allowed ?
                 //           if rids, cell to rid is possibly multi-step lookup. Need to make a rids-filter, where members are all reachable
                 //           cells from wanted rids (to be calculated).
+                //         1) leave it to user
+                //         2) make alg. given rid's: compute cid's needed
+                //         3) if river_network available, deny cids based filter, insist on rids ?
+                //
                 //  d) consistency: if cids are used, and routing (and rids) are enabled, auto-extend the cids so that all connected cells(and corresponding cids)
                 //     are calculated (avoid partial calculation of something that goes into a routing network...
                 //     question: how much of this consistency/complexity should we put to the user setting the calculation filter

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -700,8 +700,8 @@ namespace shyft {
              */
             template <class TSV>
             void routing_discharges( TSV& cr) const {
-                typedef typename TSV::value_type ts_t;
-                cr.clear();
+                //typedef typename TSV::value_type ts_t;
+                //cr.clear();
                 //TODO: iterate over the routing model, return results
             }
         protected:

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -306,7 +306,7 @@ namespace shyft {
                 if(cid_to_cix.find(cid)==cid_to_cix.end()) throw std::runtime_error(string("specified catchment id=") + std::to_string(cid)+string(" not found"));
                 if(routing::valid_routing_id(rid)) river_network.check_rid(rid);// verify it exists.
                 for(auto&c:*cells)
-                    if(c.geo.catchment_id()==cid) c.geo.routing.id=rid;
+                    if(int(c.geo.catchment_id())==cid) c.geo.routing.id=rid;
             }
 
             bool has_routing() const {
@@ -833,7 +833,7 @@ namespace shyft {
                 size_t pos = 0;
                 for (int i = 0;i < use_ncore;++i) { // using ncore = logical available core saturates cpu 100%
                     calcs.emplace_back(
-                        async(launch::async, 
+                        async(launch::async,
                             [this,&pos,&pos_mx,len,&time_axis,&beg,start_step,n_steps]() {
                                 while (true) {
                                     size_t ci;

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -306,7 +306,7 @@ namespace shyft {
                 if(cid_to_cix.find(cid)==cid_to_cix.end()) throw std::runtime_error(string("specified catchment id=") + std::to_string(cid)+string(" not found"));
                 if(routing::valid_routing_id(rid)) river_network.check_rid(rid);// verify it exists.
                 for(auto&c:*cells)
-                    c.geo.routing.id=rid;
+                    if(c.geo.catchment_id()==cid) c.geo.routing.id=rid;
             }
 
             bool has_routing() const {

--- a/core/routing.h
+++ b/core/routing.h
@@ -128,7 +128,7 @@ namespace shyft {
                     if(!valid_routing_id(rid)) throw std::runtime_error("valid river|routing id must be >0");
                     if(must_exist)
                         if(rid_map.find(rid)==rid_map.end())
-                            throw std::runtime_error(std::string("the supplied river|routing id is not registered/does not exist")+std::to_string(rid));
+                            throw std::runtime_error(std::string("the supplied river|routing id is not registered/does not exist, id=")+std::to_string(rid));
                 }
 
                 /** verify there is no directed cycles in the river-network */
@@ -142,7 +142,7 @@ namespace shyft {
                         auto downstream_id=it->second.downstream.id;// indicates a cycle
                         while(valid_routing_id(downstream_id)) { // follow downstream
                             if(visited[downstream_id])
-                                return false;// got you, this is a cycle!
+                                return true;// got you, this is a cycle!
                             visited[downstream_id]=true;// mark it as visited
                             downstream_id=rid_map.find(downstream_id)->second.downstream.id;// continue downstream
                         }
@@ -172,6 +172,9 @@ namespace shyft {
                 ///< .remove_by_id(river-id)
                 void remove_by_id(int rid) {
                     check_rid(rid);
+                    auto upstreams=upstreams_by_id(rid);
+                    for(auto i:upstreams)
+                        rid_map[i].downstream.id=0;// zero out references (could also bypass,but leave it for now)
                     rid_map.erase(rid);
                 }
                 ///< .river(river-id).. --> the river-object itself, r/w

--- a/core/routing.h
+++ b/core/routing.h
@@ -203,8 +203,9 @@ namespace shyft {
                 std::vector<int> all_upstreams_by_id(int rid) const {
                     check_rid(rid);
                     auto rids=upstreams_by_id(rid);
-                    for (auto id : rids) {
-                        auto xtra = all_upstreams_by_id(id);
+                    auto n =rids.size();//since we are going to extend it in loop below
+                    for (size_t i=0;i<n;++i) {
+                        auto xtra = all_upstreams_by_id(rids[i]);
                         for (auto x : xtra)
                             rids.push_back(x);
                     }

--- a/core/routing.h
+++ b/core/routing.h
@@ -1,0 +1,29 @@
+#pragma once
+#pragma once
+namespace shyft {
+    namespace core {
+        namespace routing {
+            /*
+            Routing concepts:
+
+            routing point/object:
+            act as *destination* for other sources, like cells, or other upstream routing objects
+            have an optional state (if the implementation need it).
+            have one optional output to downstream routing point|object
+            and 'routing-shape' that determine the response at the output.
+
+            cells have routing info, describing the
+            routing destination identifier (a number, used to bind to a certain node the routing network)
+            routing parameter(s) (how discharge are shaped before reaching the routing destination)
+
+            implementation:
+
+            -# routing-network [ { routing-node { id,opt output id + shape } ]
+            -# region_model can be created with a routing-network
+            -# cell.geo.routing { id, shape-parameters }
+
+
+            */
+        }
+    }
+}

--- a/core/routing.h
+++ b/core/routing.h
@@ -1,4 +1,8 @@
 #pragma once
+#include "geo_cell_data.h"
+#include "time_axis.h"
+#include "timeseries.h"
+
 namespace shyft {
     namespace core {
         namespace routing {

--- a/core/routing.h
+++ b/core/routing.h
@@ -229,7 +229,8 @@ namespace shyft {
              *    in it's current form, since it invite to duplicate data from the region-model.
              *    Thus, the current plan is to use it as a temporary object, for calculations,
              *    provided by the member-functions of region_model. The region model then keep
-             *    the river-routing network, cells, etc. and this class is constructed on request.
+             *    the river-routing network, cells, etc. and this class is constructed on request,
+             *    with life-time equal to  the scope of the corresponding function.
              *
              */
 
@@ -272,7 +273,7 @@ namespace shyft {
                 void verify_cell_river_connections() const {
                     for(const auto&c:*cells) {
                         if(c.geo.routing.id>0)
-                            rivers->check_rid(c.geo.routing.id);
+                            rivers->check_rid(c.geo.routing.id);// throws if id does not exist
                     }
                 }
 

--- a/core/routing.h
+++ b/core/routing.h
@@ -200,6 +200,16 @@ namespace shyft {
                     }
                     return rids;
                 }
+                std::vector<int> all_upstreams_by_id(int rid) const {
+                    check_rid(rid);
+                    auto rids=upstreams_by_id(rid);
+                    for (auto id : rids) {
+                        auto xtra = all_upstreams_by_id(id);
+                        for (auto x : xtra)
+                            rids.push_back(x);
+                    }
+                    return rids;
+                }
 
                 int downstream_by_id(int rid) const {
                     check_rid(rid);

--- a/core/routing.h
+++ b/core/routing.h
@@ -1,29 +1,234 @@
 #pragma once
-#pragma once
 namespace shyft {
     namespace core {
         namespace routing {
-            /*
-            Routing concepts:
 
-            routing point/object:
-            act as *destination* for other sources, like cells, or other upstream routing objects
-            have an optional state (if the implementation need it).
-            have one optional output to downstream routing point|object
-            and 'routing-shape' that determine the response at the output.
+            /**
+             *  There are two stages in the routing:
+             *
+             *  1) Cell to river routing
+             *
+             *  Routing of water-flow from the cells to the closest river routing object, providing
+             *  the lateral inflow to the river.
+             *
+             *  In this stage, using cell.geo.routing velocity and distance along with
+             *  catchment-specific uhg shape parameters.
+             *  Thus, the routing down to the first routing point, river, is then determined by each cell along with possibly
+             *    catchment specific shape/routing parameters.
+             *
+             *  2) River network routing
+             *
+             *  Routing from one river object to the next. In addition to lateral inflow from shyft-cells,
+             *  a river takes the output from upstream rivers.
+             *  The sum of these two flows are then passed on to the downstream (if any) river.
+             *
+             *  This allow the user to configure and setup larger river networks to fit the purpose.
+             *
+             *  For some of the rivers, we might have observation of the flow, represented as time-series.
+             *  These time-series can be utilized to calibrate/tune the parameters of the complete shyft-model.
+             *
+             *
+             *  This stage of routing allow for several strategies, like
+             *
+             *  Skaugen: sum together all cell-responses that belong to a routing point, then
+             *    use distance distribution profile to generate a uhg that together with convolution
+             *    determines the response out from those cells to the first routing point
+             *
+             *  Time-delay-zones: Group cells output to routing time-delay points,with no local delay.
+             *   then use a response function that take the shape and time-delay characteristics for the group
+             *   to the 'observation routing point'
+             *
+             *  A number of various routing methods can be utilized, but we start out with a simple uhg based approach,
+             *  enriched with a generic topology.
+             *
+             */
 
-            cells have routing info, describing the
-            routing destination identifier (a number, used to bind to a certain node the routing network)
-            routing parameter(s) (how discharge are shaped before reaching the routing destination)
 
-            implementation:
+            /** The unit hydro graph parameter contains sufficient
+             * description to create a unit hydro graph, that have a shape
+             * and a discretized 'time-length' according to the model time-step resolution.
+             *
+             */
+            struct uhg_parameter {
+                uhg_parameter(double velocity=1.0,double alpha=3.0,double beta=0.7):velocity(velocity),alpha(alpha),beta(beta) {}
+                double velocity= 1.0;
+                double alpha=3.0;
+                double beta =0.7;
+            };
 
-            -# routing-network [ { routing-node { id,opt output id + shape } ]
-            -# region_model can be created with a routing-network
-            -# cell.geo.routing { id, shape-parameters }
+            inline std::vector<double>  make_uhg_from_gamma(int n_steps, double alpha, double beta);// fwd decl
 
 
-            */
+
+
+            /**\brief A river that we use for routing
+             *
+             * The routing river have flow from
+             * -# zero or more 'cell_nodes',  typically a cell_model type, lateral flow,like cell.rc.average_discharge [m3/s]
+             * -# zero or more upstream connected rivers, taking their .output_m3s()
+             * then a routing river can *optionally* be connected to a down-stream river,
+             * providing a routing function (currently just a convolution of a uhg).
+             *
+             * This definition is recursive, and we use other means to ensure the routing graph
+             * is directed and with no cycles.
+             */
+            struct river {
+                // binding information
+                //  not really needed at core level, as we could to only with ref's in the core
+                //  but we plan to expose to python and external persistence models
+                //  so providing some handles do make sense for now.
+                int id;// self.id, >0 means valid id, 0= null
+                shyft::core::routing_info downstream;
+                uhg_parameter parameter;///< We assume each river do have distinct parameter, so no shared pointer
+                // here we could have a link to the observed time-series (can use the self.id to associate)
+
+                /** create the hydro-graph, taking specified delta-t, dt,
+                 * static hydrological distance as well as the shape parameters
+                 * alpha and beta used to form the gamma-function.
+                 * The length of the uhg (delay) is determined by the downstream-distance,
+                 * and the velocity parameter. The shape of the uhg is determined by alpha&beta parameters.
+                 */
+                std::vector<double> uhg(utctimespan dt) const {
+                    double steps = (downstream.distance / parameter.velocity) / dt;// time = distance / velocity[s] // dt[s]
+                    int n_steps = int(steps + 0.5);
+                    return std::move(make_uhg_from_gamma(n_steps, parameter.alpha, parameter.beta));
+                }
+            };
+
+            /**
+             * Convenient function to get the frozen values out,
+             * maybe candidate for timeseries, but keep it here for now
+             */
+            template <class Ts>
+            inline std::vector<double> ts_values(const Ts& ts) {
+                std::vector<double> r; r.reserve(ts.size());
+                for (size_t i = 0;i < ts.size();++i) r.push_back(ts.value(i));
+                return std::move(r);
+            }
+            /** A routing model
+             *
+             *
+             * Based on modelling the routing using repeated convolution of a unit hydro-graph.
+             * First from the lateral local cells that feeds into the routing-point (river/creek).
+             * Then add up the flow from the upstream rivers(they might or might not have local-cells, up-streams rivers etc.)
+             * Then finally compute output as the convolution using the uhg of the sum_inflow to the river.
+             *
+             * \tparam C
+             *  Cell type that should provide
+             *  -# C::ts_t the current core time-series representation, currently point_ts<fixed_dt>..
+             *  -# C::output_m3s_t the type of the call C::output_m3s() const (we could rater use result_of..)
+             *
+             * \note implementation:
+             *    technically we are currently flattening out the ts-expression tree by computing the full
+             *    point representation of every flow in the directed graph.
+             *    Later we could utilize a dynamic dispatch to to build the recursive
+             *    accumulated expression tree at any river in the routing graph. This could
+             *    improve performance and resource usage in certain scenarios.
+             *
+             */
+
+            template<class C>
+            struct model {
+                typedef typename C::ts_t rts_t; // the result computed in the cell.rc.avg_discharge [m3/s]
+                //typedef typename C::output_m3s_t ots_t; // the output result from the cell, it's a convolution_w_ts<rts_t>..
+                //typedef typename shyft::timeseries::uniform_sum_ts<ots_t> sum_ts_t; // could be possible using api::apoint_ts
+
+                std::map<int, river> river_map; ///< keeps structure and routing properties
+
+                std::shared_ptr<std::vector<C>> cells; ///< shared with the region_model !
+                timeseries::timeaxis ta;///< shared with the region_model,  should be simulation time-axis
+
+
+                std::vector<double> cell_uhg(const C& c, utctimespan dt) const {
+                    double steps = (c.geo.routing.distance / c.parameter->routing_uhg.velocity)/dt;// time = distance / velocity[s] // dt[s]
+                    int n_steps = int(steps + 0.5);
+                    return std::move(make_uhg_from_gamma(n_steps, c.parameter->routing_uhg.alpha, c.parameter->routing_uhg.beta));//std::vector<double>{0.1,0.5,0.2,0.1,0.05,0.030,0.020};
+                }
+
+                /** compute the cell_output, taking the cell-route to routing river into consideration
+                 *
+                 */
+                timeseries::convolve_w_ts<rts_t> cell_output_m3s(const C&c ) const {
+                    // return discharge, notice that this function assumes that time_axis() do have a uniform delta() (requirement)
+                    return std::move(timeseries::convolve_w_ts<rts_t>(c.rc.avg_discharge,cell_uhg(c,ta.delta()),timeseries::convolve_policy::USE_ZERO));
+                }
+
+
+                /** compute the local lateral inflow from connected shyft-cells into given river-id
+                 *
+                 */
+                rts_t local_inflow(int node_id) const {
+                    rts_t r(ta,0.0,timeseries::POINT_AVERAGE_VALUE);// default null to null ts.
+                    for (const auto& c : *cells) {
+                        if (c.geo.routing.id == node_id) {
+                            auto node_output_m3s (cell_output_m3s(c));
+                            for (size_t t = 0;t < r.size();++t)
+                                r.add(t, node_output_m3s.value(t));
+                        }
+                    }
+                    return std::move(r);
+                }
+
+                /** Aggregate the upstream inflow that flows into this cell
+                 * Notice that this is a recursive function that will go upstream
+                 * and collect *all* upstream flow
+                 */
+                rts_t upstream_inflow(int node_id) const {
+                    rts_t r(ta, 0.0, timeseries::POINT_AVERAGE_VALUE);
+                    for (const auto& i : river_map) {
+                        if (i.second.downstream.id == node_id) {
+                            auto flow_m3s = output_m3s(i.first);
+                            for (size_t t = 0;t < ta.size();++t)
+                                r.add(t, flow_m3s.value(t));
+                        }
+                    }
+                    return std::move(r);
+                }
+
+                /** Utilizing the local_inflow and upstream_inflow function,
+                 * calculate the output_m3s leaving the specified river.
+                 * This is a walk in the park, since we can just use
+                 * already existing (possibly recursive) functions to do the work.
+                 */
+                rts_t output_m3s(int node_id) const {
+                    utctimespan dt = ta.delta(); // for now need to pick up delta from the sources
+                    std::vector<double> uhg_weights = river_map.at(node_id).uhg(dt);
+                    auto sum_input_m3s = local_inflow(node_id)+ upstream_inflow(node_id);
+                    auto response = timeseries::convolve_w_ts<decltype(sum_input_m3s)>(sum_input_m3s, uhg_weights, timeseries::convolve_policy::USE_ZERO);
+                    return std::move(rts_t(ta, ts_values(response), timeseries::POINT_AVERAGE_VALUE)); // flatten values
+                }
+
+            };
+
+            /** make_uhg_from_gamma a simple function to create a uhg (unit hydro graph) weight vector
+             * containing n_steps, given the gamma shape factor alpha and beta.
+             * ensuring the sum of the weight vector is 1.0
+             * and that it has a min-size of one element (1.0)
+             *
+             * Later we can replace the implementation of this to depend on the configured parameters of the
+             * model.
+             * \param n_steps number of time-steps, elements, in the vector
+             * \param alpha the gamma_distribution gamma-factor
+             * \param beta the gamma_distribution beta-factor
+             * \return unit hydro graph factors, normalized to sum 1.0
+             */
+            inline std::vector<double>  make_uhg_from_gamma(int n_steps, double alpha, double beta) {
+                using boost::math::gamma_distribution;
+                gamma_distribution<double> gdf(alpha, beta);
+                std::vector<double> r;r.reserve(n_steps);
+                double s = 0.0;
+                double d = 1.0 / double(n_steps);
+                for (double q = d;q < 1.0; q += d) {
+                    double x = quantile(gdf, q);
+                    double y = pdf(gdf, x);
+                    s += y;
+                    r.push_back(y);
+                }
+                for (auto& y : r) y /= s;
+                if (r.size() == 0) r.push_back(1.0);// at a minimum 1.0, no delay
+                return std::move(r);
+            };
+
         }
     }
 }

--- a/core/time_axis.h
+++ b/core/time_axis.h
@@ -35,6 +35,25 @@ namespace shyft {
             static const bool value = true;
         };
 
+		/** generic test if two different time-axis types resembles the same conceptual time-axis
+		*
+		* Given time-axis are of differnt types (point, versus period versus fixed_dt etc.)
+		* just compare and see if they produces the same number of periods, and that each
+		* period is equal.
+		*/
+		template<class A, class B>
+		bool equivalent_time_axis(const A& a, const B& b) {
+			if (a.size() != b.size())
+				return false;
+			for (size_t i = 0;i < a.size();++i) { if (a.period(i) != b.period(i)) return false; }
+			return true;
+		}
+		/** Specialization of the equivalent_time_axis given that they are of the same type.
+		*  In this case we forward the comparison to the type it self relying on the
+		*  fact that the time_axis it self knows how to fastest figure out if it's equal.
+		*/
+		template <class A>
+		bool equivalent_time_axis(const A& a, const A&b) { return a == b; }
 
         /**\brief a simple regular time-axis, starting at t, with n consecutive periods of fixed length dt
          *
@@ -48,7 +67,8 @@ namespace shyft {
             utctimespan delta() const {return dt;}//BW compat
             utctime start() const {return t;} //BW compat
             size_t size() const {return n;}
-
+			bool operator==(const fixed_dt& other) const {return t==other.t && dt== other.dt && n==other.n;}
+			bool operator!=(const fixed_dt& other) const { return !this->operator==(other); }
             utcperiod total_period() const {
                 return n == 0 ?
                        utcperiod( min_utctime, min_utctime ) :  // maybe just a non-valid period?
@@ -108,6 +128,9 @@ namespace shyft {
                 }
                 return *this;
             }
+			/** equality, notice that calendar is equal if they refer to exactly same calendar pointer */
+			bool operator==(const calendar_dt& other) const { return cal.get()== other.cal.get() && t == other.t && dt == other.dt && n == other.n; }
+			bool operator!=(const calendar_dt& other) const { return !this->operator==(other); }
 
             size_t size() const {return n;}
 
@@ -192,6 +215,8 @@ namespace shyft {
                 }
                 return *this;
             }
+            bool operator==(const point_dt &other)const {return t == other.t && t_end == other.t_end;}
+			bool operator!=(const point_dt& other) const { return !this->operator==(other); }
             size_t size() const {return t.size();}
 
             utcperiod total_period() const {
@@ -293,7 +318,18 @@ namespace shyft {
                 }
                 return *this;
             }
-
+			bool operator==(const generic_dt& other) const {
+				if (gt != other.gt) {// they are represented differently:
+					switch (gt) {
+					default:
+					case FIXED: return equivalent_time_axis(f, other);
+					case CALENDAR: return equivalent_time_axis(c, other);
+					case POINT: return equivalent_time_axis(p, other);
+					}
+				} // else they have same-representation, use equality directly
+				switch (gt) { default: case FIXED: return f == other.f; case CALENDAR: return c==other.c; case POINT: return p == other.p; }
+			}
+			bool operator!=(const generic_dt& other) const { return !this->operator==(other); }
             //--
             bool is_fixed_dt() const {return gt != POINT;}
 
@@ -370,7 +406,8 @@ namespace shyft {
                 }
                 return *this;
             }
-
+			bool operator==(const calendar_dt_p& other)const { return p==other.p && cta== other.cta;}
+			bool operator!=(const calendar_dt_p& other) const { return !this->operator==(other); }
             size_t size() const { return cta.size() * ( p.size() ? p.size() : 1 );}
 
             utcperiod total_period() const {
@@ -448,6 +485,8 @@ namespace shyft {
                     r.p.push_back( ta.period( i ) );
                 return r;
             }
+            bool operator==(const period_list& other) const {return p == other.p;}
+			bool operator!=(const period_list& other) const { return !this->operator==(other); }
             size_t size() const {return p.size();}
 
             utcperiod total_period() const {

--- a/shyft/tests/api/test_calibration_types.py
+++ b/shyft/tests/api/test_calibration_types.py
@@ -29,7 +29,7 @@ class ShyftApi(unittest.TestCase):
             self.assertEqual(valid_names[i],p_name)
 
     def test_pt_hs_k_param(self):
-        pthsk_size = 13
+        pthsk_size = 16
         pthsk = pt_hs_k.PTHSKParameter()
         self.assertIsNotNone(pthsk)
         self.assertEqual(pthsk.size(), pthsk_size)
@@ -53,12 +53,14 @@ class ShyftApi(unittest.TestCase):
                     "p_corr.scale_factor",
                     "pt.albedo",
                     "pt.alpha",
-                    "gm.dtf"
+                    "routing.velocity",
+                    "routing.alpha",
+                    "routing.beta"
 				]
         self.verify_parameter_for_calibration(pthsk, pthsk_size,valid_names)
 
     def test_hbv_stack_param(self):
-        hbv_size = 17
+        hbv_size = 20
         hbv = hbv_stack.HbvParameter()
         self.assertIsNotNone(hbv)
         self.assertEqual(hbv.size(), hbv_size)
@@ -79,12 +81,15 @@ class ShyftApi(unittest.TestCase):
         "p_corr.scale_factor",
         "pt.albedo",
         "pt.alpha",
-        "gm.dtf"
+        "gm.dtf",
+        "routing.velocity",
+        "routing.alpha",
+        "routing.beta"
         ]
         self.verify_parameter_for_calibration(hbv, hbv_size, valid_names)
 
     def test_pt_gs_k_param(self):
-        ptgsk_size = 25
+        ptgsk_size = 28
         valid_names = [
         "kirchner.c1",
         "kirchner.c2",
@@ -110,7 +115,10 @@ class ShyftApi(unittest.TestCase):
         "gs.initial_bare_ground_fraction",
         "gs.winter_end_day_of_year",
         "gs.calculate_iso_pot_energy",
-        "gm.dtf"
+        "gm.dtf",
+        "routing.velocity",
+        "routing.alpha",
+        "routing.beta"
         ]
         p=pt_gs_k.PTGSKParameter()
         self.verify_parameter_for_calibration(p, ptgsk_size,valid_names)
@@ -128,9 +136,16 @@ class ShyftApi(unittest.TestCase):
         pv[23]=0.0;
         p.set(pv)
         self.assertFalse(p.gs.calculate_iso_pot_energy)
+        # checkout new parameters for routing
+        p.routing.velocity = 1/3600.0
+        p.routing.alpha = 1.1
+        p.routing.beta = 0.8
+        self.assertAlmostEqual(p.routing.velocity, 1/3600.0)
+        self.assertAlmostEqual(p.routing.alpha, 1.1)
+        self.assertAlmostEqual(p.routing.beta, 0.8)
 
     def test_pt_ss_k_param(self):
-        ptssk_size = 16
+        ptssk_size = 19
         valid_names=[
             "kirchner.c1",
             "kirchner.c2",
@@ -147,7 +162,10 @@ class ShyftApi(unittest.TestCase):
             "p_corr.scale_factor",
             "pt.albedo",
             "pt.alpha",
-            "gm.dtf"
+            "gm.dtf",
+            "routing.velocity",
+            "routing.alpha",
+            "routing.beta"
         ]
         self.verify_parameter_for_calibration(pt_ss_k.PTSSKParameter(), ptssk_size,valid_names)
 

--- a/shyft/tests/api/test_convolve_ts.py
+++ b/shyft/tests/api/test_convolve_ts.py
@@ -1,0 +1,24 @@
+import unittest
+
+from shyft.api import Calendar
+from shyft.api import DoubleVector
+from shyft.api import Timeaxis
+from shyft.api import Timeseries
+from shyft.api import convolve_policy
+from shyft.api import deltahours
+from shyft.api import point_interpretation_policy as point_fx
+
+
+class ConvolveTs(unittest.TestCase):
+    """Verify and illustrate the ts.convolve_w(weights,policy)
+
+     """
+
+    def test_convolve_policy(self):
+        utc = Calendar()
+        ts = Timeseries(ta=Timeaxis(utc.time(2001, 1, 1), deltahours(1), 24), fill_value=10.0, point_fx=point_fx.POINT_AVERAGE_VALUE)
+        w = DoubleVector.from_numpy([0.05, 0.15, 0.6, 0.15, 0.05])
+        cts = ts.convolve_w(w, convolve_policy.USE_FIRST)  # ensure mass-balance between source and cts
+        self.assertIsNotNone(cts)
+        self.assertEquals(len(cts), len(ts))
+        self.assertEquals(cts.values.to_numpy().sum(), ts.values.to_numpy().sum())

--- a/shyft/tests/api/test_geo_cell_data.py
+++ b/shyft/tests/api/test_geo_cell_data.py
@@ -8,16 +8,22 @@ class GeoCellData(unittest.TestCase):
      """
 
     def test_create(self):
-        p=api.GeoPoint(100,200,300)
-        ltf=api.LandTypeFractions()
-        ltf.set_fractions(glacier=0.1,lake=0.1,reservoir=0.1,forest=0.1)
-        self.assertAlmostEqual(ltf.unspecified(),0.6)
-        gcd=api.GeoCellData(p,1000000.0,1,0.9,ltf)
-        
-        self.assertAlmostEqual(gcd.area(),1000000)
-        self.assertAlmostEqual(gcd.catchment_id(),1)
+        p = api.GeoPoint(100, 200, 300)
+        ltf = api.LandTypeFractions()
+        ltf.set_fractions(glacier=0.1, lake=0.1, reservoir=0.1, forest=0.1)
+        self.assertAlmostEqual(ltf.unspecified(), 0.6)
+        routing_info = api.RoutingInfo(2, 12000.0)
+        gcd = api.GeoCellData(p, 1000000.0, 1, 0.9, ltf, routing_info)
 
-     
+        self.assertAlmostEqual(gcd.area(), 1000000)
+        self.assertAlmostEqual(gcd.catchment_id(), 1)
+        self.assertAlmostEqual(gcd.routing_info.distance, 12000.0)
+        self.assertAlmostEqual(gcd.routing_info.id, 2)
+        gcd.routing_info.distance = 13000.0
+        gcd.routing_info.id = 3
+        self.assertAlmostEqual(gcd.routing_info.distance, 13000.0)
+        self.assertAlmostEqual(gcd.routing_info.id, 3)
+
     def test_land_type_fractions(self):
         """ 
          LandTypeFractions describes how large parts of a cell is 
@@ -30,22 +36,22 @@ class GeoCellData(unittest.TestCase):
          
         """
         # constructor 1 :all in one: specify glacier_size,lake_size,reservoir_size,forest_size,unspecified_size
-        a=api.LandTypeFractions(1000.0,2000.0,3000.0,4000.0,5000.0)# keyword arguments does not work ??
+        a = api.LandTypeFractions(1000.0, 2000.0, 3000.0, 4000.0, 5000.0)  # keyword arguments does not work ??
         # constructor 2: create, and set (with possible exceptions)
-        b=api.LandTypeFractions()
-        b.set_fractions(glacier=1/15.0,lake=2/15.0,reservoir=3/15.0,forest=4/15.0)
-        self.assertAlmostEqual(a.glacier(),b.glacier())
-        self.assertAlmostEqual(a.lake(),b.lake())
-        self.assertAlmostEqual(a.reservoir(),b.reservoir())
-        self.assertAlmostEqual(a.forest(),b.forest())
-        self.assertAlmostEqual(a.unspecified(),b.unspecified())
+        b = api.LandTypeFractions()
+        b.set_fractions(glacier=1 / 15.0, lake=2 / 15.0, reservoir=3 / 15.0, forest=4 / 15.0)
+        self.assertAlmostEqual(a.glacier(), b.glacier())
+        self.assertAlmostEqual(a.lake(), b.lake())
+        self.assertAlmostEqual(a.reservoir(), b.reservoir())
+        self.assertAlmostEqual(a.forest(), b.forest())
+        self.assertAlmostEqual(a.unspecified(), b.unspecified())
         try:
-            
-            b.set_fractions(glacier=0.9,forest=0.2,lake=0.0,reservoir=0.0)
+
+            b.set_fractions(glacier=0.9, forest=0.2, lake=0.0, reservoir=0.0)
             self.fail("expected exception, nothing raised")
-        except  :
-            self.assertTrue(True,"If we reach here all is ok")
-        
-        
+        except:
+            self.assertTrue(True, "If we reach here all is ok")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -193,6 +193,10 @@ class RegionModel(unittest.TestCase):
         sum_discharge = model.statistics.discharge(cids)
         sum_discharge_value = model.statistics.discharge_value(cids, 0)  # at the first timestep
         self.assertGreaterEqual(sum_discharge_value, 130.0)
+
+        #
+        # check values
+        #
         self.assertIsNotNone(sum_discharge)
         # now, re-run the process in 24-hours steps x 10
         model.set_states(s0)  # restore state s0
@@ -231,6 +235,27 @@ class RegionModel(unittest.TestCase):
         copy_region_model = model.__class__(model)
         self.assertIsNotNone(copy_region_model)
         copy_region_model.run_cells()  # just to verify we can copy and run the new model
+        #
+        # Play with routing and river-network
+        #
+        # 1st: add a river, with 36.000 meter hydro length, a UHGParameter with 1m/hour speed, alpha/beta suitable
+        model.river_network.add(
+            api.River(1, api.RoutingInfo(0, 3000.0), api.UHGParameter(1 / 3.60, 1.0, 0.7)))  # river id =1
+        # 2nd: let cells route to the river
+        model.connect_catchment_to_river(0, 1)  # now all cells in catchment 0 routes to river with id 1.
+        self.assertTrue(model.has_routing())
+        # 3rd: now we can have a look at water coming in and out
+        river_out_m3s = model.river_output_flow_m3s(1)  # should be delayed and reshaped
+        river_local_m3s = model.river_local_inflow_m3s(
+            1)  # should be equal to cell outputs (no routing stuff from cell to river)
+        river_upstream_inflow_m3s = model.river_upstream_inflow_m3s(
+            1)  # should be 0.0 in this case, since we do not have a routing network
+        self.assertIsNotNone(river_out_m3s)
+        self.assertAlmostEqual(river_out_m3s.value(0), 87.4, 0)
+        self.assertIsNotNone(river_local_m3s)
+        self.assertIsNotNone(river_upstream_inflow_m3s)
+        model.connect_catchment_to_river(0, 0)
+        self.assertFalse(model.has_routing())
 
     def test_optimization_model(self):
         num_cells = 20

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -139,7 +139,7 @@ class RegionModel(unittest.TestCase):
         model = self.build_model(model_type, pt_gs_k.PTGSKParameter, num_cells)
         self.assertEqual(model.size(), num_cells)
         # demo of feature for threads
-        self.assertGreaterEqual(model.ncore,1)  # defaults to hardware concurrency*4
+        self.assertGreaterEqual(model.ncore,1)  # defaults to hardware concurrency
         model.ncore = 4  # set it to 4, and
         self.assertEqual(model.ncore, 4)  # verify it works
 
@@ -202,7 +202,7 @@ class RegionModel(unittest.TestCase):
         model.set_states(s0)  # restore state s0
         self.assertEqual(s0.size(),model.initial_state.size())
         for section in range(10):
-            model2.run_cells(thread_cell_count=0, start_step=section*24, n_steps=24)
+            model2.run_cells(use_ncore=0, start_step=section*24, n_steps=24)
             section_discharge = model2.statistics.discharge(cids)
             self.assertEqual(section_discharge.size(),sum_discharge.size()) # notice here that the values after current step are 0.0
         stepwise_sum_discharge = model2.statistics.discharge(cids)

--- a/shyft/tests/api/test_routing.py
+++ b/shyft/tests/api/test_routing.py
@@ -1,0 +1,64 @@
+import unittest
+
+from shyft.api import Calendar
+from shyft.api import DoubleVector
+from shyft.api import Timeaxis
+from shyft.api import Timeseries
+from shyft.api import convolve_policy
+from shyft.api import deltahours
+from shyft.api import point_interpretation_policy as point_fx
+from shyft.api import River
+from shyft.api import RoutingInfo
+from shyft.api import UHGParameter
+from shyft.api import RiverNetwork
+
+
+class Routing(unittest.TestCase):
+    """Verify and illustrate the Routing classes
+
+
+     """
+    def test_routing_info(self):
+        ri= RoutingInfo(2,1000.0)
+        self.assertIsNotNone(ri)
+        self.assertEqual(ri.id,2)
+        self.assertAlmostEqual(ri.distance,1000.0)
+        ri.distance=2000.0
+        self.assertAlmostEqual(ri.distance, 2000.0)
+
+    def test_unit_hydrograph_parameter(self):
+        p = UHGParameter()
+        self.assertIsNotNone(p)
+        self.assertAlmostEqual(p.alpha,3.0)  # default values
+        self.assertAlmostEqual(p.beta,0.7)
+        self.assertAlmostEqual(p.velocity,1.0)
+        p.alpha=2.7
+        p.beta=0.77
+        p.velocity = 1/3600.0
+        self.assertAlmostEqual(p.alpha,2.7)
+        self.assertAlmostEqual(p.beta,0.77)
+        self.assertAlmostEqual(p.velocity,1.0/3600.0)
+
+    def test_river(self):
+        r1 = River(1)
+        self.assertIsNotNone(r1)
+        self.assertEqual(r1.id, 1)
+        r2 = River(2,RoutingInfo(3,1000.0),UHGParameter(1/3600.0,1.0,0.7))
+        self.assertEqual(r2.id, 2)
+        r3 = River(3,RoutingInfo(id=1,distance=36000.00))
+        self.assertEqual(r3.id,3)
+        self.assertEqual(r3.downstream.id,1)
+        self.assertEqual(r3.downstream.distance, 36000.0)
+
+        r3_uhg = r3.uhg(deltahours(1))
+        self.assertEqual(len(r3_uhg), 10)
+        r2.parameter.alpha = 2.0
+        r2.parameter.beta = 0.99
+        r2.parameter.velocity = 1/3600.0
+        self.assertAlmostEqual(r2.parameter.alpha, 2.0)
+        self.assertAlmostEqual(r2.parameter.beta, 0.99)
+        self.assertAlmostEqual(r2.parameter.velocity,1/3600.0)
+        r2.downstream = RoutingInfo(2,2000.0)
+        self.assertEqual(r2.downstream.id,2)
+        self.assertAlmostEqual(r2.downstream.distance, 2000.0)
+        # not possible, read only: r2.id = 3

--- a/shyft/tests/api/test_routing.py
+++ b/shyft/tests/api/test_routing.py
@@ -1,12 +1,12 @@
 import unittest
 
-from shyft.api import Calendar
+#from shyft.api import Calendar
 from shyft.api import DoubleVector
-from shyft.api import Timeaxis
-from shyft.api import Timeseries
-from shyft.api import convolve_policy
+#from shyft.api import Timeaxis
+#from shyft.api import Timeseries
+#from shyft.api import convolve_policy
 from shyft.api import deltahours
-from shyft.api import point_interpretation_policy as point_fx
+#from shyft.api import point_interpretation_policy as point_fx
 from shyft.api import River
 from shyft.api import RoutingInfo
 from shyft.api import UHGParameter
@@ -62,3 +62,37 @@ class Routing(unittest.TestCase):
         self.assertEqual(r2.downstream.id,2)
         self.assertAlmostEqual(r2.downstream.distance, 2000.0)
         # not possible, read only: r2.id = 3
+
+    def test_river_network(self):
+        rn = RiverNetwork()
+        self.assertIsNotNone(rn)
+        rn.add(River(1))
+        rn.add(River(2))  # important detail, #2 must be added before referred
+        rn.add(River(3, RoutingInfo(2,1000.0),UHGParameter(1/3600.0,1.0,0.7)))
+        rn.set_downstream_by_id(1,2)
+        # already done as pr. constuction above: rn.set_downstream_by_id(3,2)
+        rn.add(River(4))
+        rn.set_downstream_by_id(2,4)
+        self.assertEqual(len(rn.upstreams_by_id(4)), 1)
+        self.assertEqual(len(rn.upstreams_by_id(2)), 2)
+        self.assertEqual(len(rn.upstreams_by_id(1)), 0)
+        self.assertEqual(rn.downstream_by_id(1), 2)
+        self.assertEqual(rn.downstream_by_id(3), 2)
+        up2 = rn.upstreams_by_id(2)
+        self.assertIn(1,up2)
+        self.assertIn(3,up2)
+        rn.add(River(6))
+        rn.set_downstream_by_id(6,1)
+        rn.remove_by_id(1)
+        self.assertEqual(rn.downstream_by_id(6), 0)  # auto fix references ok
+        rn_clone = RiverNetwork(rn)
+        self.assertIsNotNone(rn_clone)
+        rn_clone.add(River(1,RoutingInfo(2,1000.0)))
+        self.assertEqual(len(rn_clone.upstreams_by_id(2)),2)
+        self.assertEqual(len(rn.upstreams_by_id(2)), 1)  # still just one in original netw.
+        r3 = rn.river_by_id(3)
+        r3.downstream.distance = 1234.0  # got a reference We can modify
+        r3b = rn.river_by_id(3)  # pull out the reference once again
+        self.assertAlmostEqual(r3b.downstream.distance, 1234.0)  # verify its modified
+
+

--- a/shyft/tests/api/test_routing.py
+++ b/shyft/tests/api/test_routing.py
@@ -1,12 +1,6 @@
 import unittest
 
-#from shyft.api import Calendar
-from shyft.api import DoubleVector
-#from shyft.api import Timeaxis
-#from shyft.api import Timeseries
-#from shyft.api import convolve_policy
 from shyft.api import deltahours
-#from shyft.api import point_interpretation_policy as point_fx
 from shyft.api import River
 from shyft.api import RoutingInfo
 from shyft.api import UHGParameter
@@ -14,52 +8,51 @@ from shyft.api import RiverNetwork
 
 
 class Routing(unittest.TestCase):
-    """Verify and illustrate the Routing classes
+    """Verify and illustrate the building of Routing classes
+    """
 
-
-     """
     def test_routing_info(self):
-        ri= RoutingInfo(2,1000.0)
+        ri = RoutingInfo(2, 1000.0)
         self.assertIsNotNone(ri)
-        self.assertEqual(ri.id,2)
-        self.assertAlmostEqual(ri.distance,1000.0)
-        ri.distance=2000.0
+        self.assertEqual(ri.id, 2)
+        self.assertAlmostEqual(ri.distance, 1000.0)
+        ri.distance = 2000.0
         self.assertAlmostEqual(ri.distance, 2000.0)
 
     def test_unit_hydrograph_parameter(self):
         p = UHGParameter()
         self.assertIsNotNone(p)
-        self.assertAlmostEqual(p.alpha,3.0)  # default values
-        self.assertAlmostEqual(p.beta,0.7)
-        self.assertAlmostEqual(p.velocity,1.0)
-        p.alpha=2.7
-        p.beta=0.77
-        p.velocity = 1/3600.0
-        self.assertAlmostEqual(p.alpha,2.7)
-        self.assertAlmostEqual(p.beta,0.77)
-        self.assertAlmostEqual(p.velocity,1.0/3600.0)
+        self.assertAlmostEqual(p.alpha, 3.0)  # default values
+        self.assertAlmostEqual(p.beta, 0.7)
+        self.assertAlmostEqual(p.velocity, 1.0)
+        p.alpha = 2.7
+        p.beta = 0.77
+        p.velocity = 1 / 3600.0
+        self.assertAlmostEqual(p.alpha, 2.7)
+        self.assertAlmostEqual(p.beta, 0.77)
+        self.assertAlmostEqual(p.velocity, 1.0 / 3600.0)
 
     def test_river(self):
         r1 = River(1)
         self.assertIsNotNone(r1)
         self.assertEqual(r1.id, 1)
-        r2 = River(2,RoutingInfo(3,1000.0),UHGParameter(1/3600.0,1.0,0.7))
+        r2 = River(2, RoutingInfo(3, 1000.0), UHGParameter(1 / 3600.0, 1.0, 0.7))
         self.assertEqual(r2.id, 2)
-        r3 = River(3,RoutingInfo(id=1,distance=36000.00))
-        self.assertEqual(r3.id,3)
-        self.assertEqual(r3.downstream.id,1)
+        r3 = River(3, RoutingInfo(id=1, distance=36000.00))
+        self.assertEqual(r3.id, 3)
+        self.assertEqual(r3.downstream.id, 1)
         self.assertEqual(r3.downstream.distance, 36000.0)
 
         r3_uhg = r3.uhg(deltahours(1))
         self.assertEqual(len(r3_uhg), 10)
         r2.parameter.alpha = 2.0
         r2.parameter.beta = 0.99
-        r2.parameter.velocity = 1/3600.0
+        r2.parameter.velocity = 1 / 3600.0
         self.assertAlmostEqual(r2.parameter.alpha, 2.0)
         self.assertAlmostEqual(r2.parameter.beta, 0.99)
-        self.assertAlmostEqual(r2.parameter.velocity,1/3600.0)
-        r2.downstream = RoutingInfo(2,2000.0)
-        self.assertEqual(r2.downstream.id,2)
+        self.assertAlmostEqual(r2.parameter.velocity, 1 / 3600.0)
+        r2.downstream = RoutingInfo(2, 2000.0)
+        self.assertEqual(r2.downstream.id, 2)
         self.assertAlmostEqual(r2.downstream.distance, 2000.0)
         # not possible, read only: r2.id = 3
 
@@ -68,31 +61,29 @@ class Routing(unittest.TestCase):
         self.assertIsNotNone(rn)
         rn.add(River(1))
         rn.add(River(2))  # important detail, #2 must be added before referred
-        rn.add(River(3, RoutingInfo(2,1000.0),UHGParameter(1/3600.0,1.0,0.7)))
-        rn.set_downstream_by_id(1,2)
+        rn.add(River(3, RoutingInfo(2, 1000.0), UHGParameter(1 / 3600.0, 1.0, 0.7)))
+        rn.set_downstream_by_id(1, 2)
         # already done as pr. constuction above: rn.set_downstream_by_id(3,2)
         rn.add(River(4))
-        rn.set_downstream_by_id(2,4)
+        rn.set_downstream_by_id(2, 4)
         self.assertEqual(len(rn.upstreams_by_id(4)), 1)
         self.assertEqual(len(rn.upstreams_by_id(2)), 2)
         self.assertEqual(len(rn.upstreams_by_id(1)), 0)
         self.assertEqual(rn.downstream_by_id(1), 2)
         self.assertEqual(rn.downstream_by_id(3), 2)
         up2 = rn.upstreams_by_id(2)
-        self.assertIn(1,up2)
-        self.assertIn(3,up2)
+        self.assertIn(1, up2)
+        self.assertIn(3, up2)
         rn.add(River(6))
-        rn.set_downstream_by_id(6,1)
+        rn.set_downstream_by_id(6, 1)
         rn.remove_by_id(1)
         self.assertEqual(rn.downstream_by_id(6), 0)  # auto fix references ok
         rn_clone = RiverNetwork(rn)
         self.assertIsNotNone(rn_clone)
-        rn_clone.add(River(1,RoutingInfo(2,1000.0)))
-        self.assertEqual(len(rn_clone.upstreams_by_id(2)),2)
+        rn_clone.add(River(1, RoutingInfo(2, 1000.0)))
+        self.assertEqual(len(rn_clone.upstreams_by_id(2)), 2)
         self.assertEqual(len(rn.upstreams_by_id(2)), 1)  # still just one in original netw.
         r3 = rn.river_by_id(3)
         r3.downstream.distance = 1234.0  # got a reference We can modify
         r3b = rn.river_by_id(3)  # pull out the reference once again
         self.assertAlmostEqual(r3b.downstream.distance, 1234.0)  # verify its modified
-
-

--- a/shyft/tests/api/tests.api.pyproj
+++ b/shyft/tests/api/tests.api.pyproj
@@ -5,7 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{3e3b8f45-003f-4f88-bf3f-400e7af8cb1f}</ProjectGuid>
     <ProjectHome />
-    <StartupFile>test_grid_pp.py</StartupFile>
+    <StartupFile>test_interpolation.py</StartupFile>
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
@@ -19,12 +19,13 @@
     <Name>test.python</Name>
     <IsWindowsApplication>False</IsWindowsApplication>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <CommandLineArguments />
+    <CommandLineArguments>-v</CommandLineArguments>
     <InterpreterPath>
     </InterpreterPath>
-    <InterpreterArguments />
+    <InterpreterArguments>
+    </InterpreterArguments>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <Environment>PYTHONPATH=%PYTHONPATH%;$(SolutionDir)</Environment>
+    <Environment>PYTHONPATH=$(SolutionDir);$(PYTHONPATH)</Environment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,5 +72,7 @@ add_test(hbv_actual_evapotranspiration_test ${target} hbv_actual_evapotranspirat
 add_test(glacier_melt_test ${target} glacier_melt_test)
 add_test(kriging_test ${target} kriging_test)
 add_test(serialization_test ${target} serialization_test)
+add_test(routing_test ${target} routing_test)
+
 
 

--- a/test/Makefile.testupdate
+++ b/test/Makefile.testupdate
@@ -27,7 +27,8 @@ CoreTests = time_axis_test.h \
 	hbv_stack_test.h \
 	glacier_melt_test.h \
 	kriging_test.h \
-	serialization_test.h
+	serialization_test.h \
+    routing_test.h
 
 TestHeaders = $(CoreTests)
 

--- a/test/NMakeFile.testupdate
+++ b/test/NMakeFile.testupdate
@@ -27,7 +27,8 @@ CoreTests = time_axis_test.h \
 	hbv_stack_test.h \
 	glacier_melt_test.h \
 	kriging_test.h \
-	serialization_test.h
+	serialization_test.h \
+    routing_test.h
 
 TestHeaders = $(CoreTests)
 

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -166,10 +166,7 @@ static void print(ostream&os, const ts_t& ts, size_t i0, size_t max_sz) {
 #include <boost/filesystem.hpp>
 
 void cell_builder_test::test_read_and_run_region_model(void) {
-	if (!getenv("SHYFT_FULL_TEST")) {
-		TS_TRACE("Please define SHYFT_FULL_TEST, export SHYFT_FULL_TEST=TRUE; or win: set SHYFT_FULL_TEST=TRUE to enable real run of nea-nidelv in this test");
-		return;
-	}
+
 	//
 	// Arrange
 	//
@@ -265,8 +262,24 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 
 	cout << endl << "5. now a run with just two catchments" << endl;
 	vector<int> catchment_ids{ 38, 87 };
+    auto sum_discharge2x = ec::cell_statistics::sum_catchment_feature(*rm.get_cells(), catchment_ids, [](const cell_t&c) {return c.rc.avg_discharge; });
+    // also setup a river network for these two catchments
+    // so that they end up in a common river
 	rm.set_catchment_calculation_filter(catchment_ids);
-
+    int common_river_id = 1;
+    ec::routing::river sum_river_38_87(common_river_id, ec::routing_info(0, 0.0));// sum river of 38 and 87
+    ec::routing::river river_38(38, ec::routing_info(common_river_id, 0.0));// use river-id eq. catchment-id, but any value would do
+    ec::routing::river river_87(87, ec::routing_info(common_river_id, 0.0));
+    // add to region model:
+    rm.river_network.add(sum_river_38_87).add(river_38).add(river_87);
+    rm.connect_catchment_to_river(38, 38);// make the connections for the cells
+    rm.connect_catchment_to_river(87, 87);// currently, the effective routing is zero, should be equal:
+    // and both these river
+    auto sum_discharge_38_87 = ec::cell_statistics::sum_catchment_feature(*rm.get_cells(), catchment_ids, [](const cell_t&c) {return c.rc.avg_discharge; });
+    auto sum_river_discharge = rm.river_output_flow_m3s(common_river_id);// verify it's equal
+    for (size_t i = 0;i < sum_discharge_38_87->size();++i) {
+        TS_ASSERT_DELTA(sum_discharge_38_87->value(i), sum_river_discharge->value(i), 0.001);
+    }
 	cout << "5. b Done, now compute new sum" << endl;
 	rm.revert_to_initial_state();
 	rm.get_states(s0);// so that we start at same state.
@@ -275,7 +288,10 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 	auto sum_discharge2 = ec::cell_statistics::sum_catchment_feature(*rm.get_cells(), catchment_ids, [](const cell_t&c) {return c.rc.avg_discharge; });
 	auto snow_sca2 = ec::cell_statistics::average_catchment_feature(*rm.get_cells(), catchment_ids, [](const cell_t &c) {return c.rc.snow_sca; });
 	auto snow_swe2 = ec::cell_statistics::average_catchment_feature(*rm.get_cells(), catchment_ids, [](const cell_t &c) {return c.rc.snow_swe; });
-
+    auto sum_river_discharge2 = rm.river_output_flow_m3s(common_river_id);
+    for (size_t i = 0;i < sum_discharge2->size();++i) { // should still be equal
+        TS_ASSERT_DELTA(sum_discharge2->value(i), sum_river_discharge2->value(i), 0.001);
+    }
 	cout << "7. Sum discharge for " << catchment_ids[0] << " and " << catchment_ids[1] << " is:" << endl;
 
 	cout << "discharge:" << endl; print(cout, *sum_discharge2, i0, n_steps);
@@ -283,6 +299,12 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 	cout << "snow_swe :" << endl; print(cout, *snow_swe2, i0, n_steps);
 
 	cout << endl << "Done test read and run region-model" << endl;
+    if (!getenv("SHYFT_FULL_TEST")) {
+        TS_TRACE("Please define SHYFT_FULL_TEST, export SHYFT_FULL_TEST=TRUE; or win: set SHYFT_FULL_TEST=TRUE to enable calibration run of nea-nidelv in this test");
+        cout << "Please define SHYFT_FULL_TEST, export SHYFT_FULL_TEST = TRUE; or win: set SHYFT_FULL_TEST = TRUE to enable calibration run of nea - nidelv in this test"<<endl;
+        return;
+    }
+
 	rm.revert_to_initial_state();//set_states(s0);// get back initial state
 	cout << "Calibration/parameter optimization" << endl;
 	using namespace shyft::core::model_calibration;

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -225,7 +225,7 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 	// Step 3: make a region model
 	cout << "3. creating a region model and run it for a short period" << endl;
 	region_model_t rm(cells, *global_parameter);
-	rm.ncore = atoi(getenv("NCORE") ? getenv("NCORE") : "32");
+	rm.ncore = atoi(getenv("NCORE") ? getenv("NCORE") : "8");
 	cout << " - ncore set to " << rm.ncore << endl;
 	auto cal = ec::calendar();
 	auto start = cal.time(ec::YMDhms(2010, 9, 1, 0, 0, 0));

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -185,9 +185,9 @@ void cell_builder_test::test_read_and_run_region_model(void) {
     auto cells = make_shared<vector<cell_t>>();
     auto global_parameter = make_shared<cell_t::parameter_t>();
 #ifdef _WIN32
-    const char *cell_path = "neanidelv/geo_cell_data.win.bin";
+    const char *cell_path = "neanidelv/geo_cell_data.v2.win.bin";
 #else
-    const char *cell_path = "neanidelv/geo_cell_data.bin";
+    const char *cell_path = "neanidelv/geo_cell_data.v2.bin";
 #endif
     std::string geo_xml_fname = shyft::experimental::io::test_path(cell_path, false);
     if ( !boost::filesystem::is_regular_file(boost::filesystem::path(geo_xml_fname))) {

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -306,7 +306,7 @@ void cell_builder_test::test_read_and_run_region_model(void) {
     }
     // To enable cell-to river calibration, introduce a routing-effect between the cells and the river.
     // we do this by setting the routing distance in the cells, and then also adjust the parameter.routing.velocity
-    // 
+    //
     double hydro_distance = 1000.0;//m
     for (auto &c : *rm.get_cells()) {
         c.geo.routing.distance = hydro_distance;// all set to 1000 meter
@@ -338,7 +338,7 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 	const size_t n_params = pa.size();
 	std::vector<double> lower; lower.reserve(n_params);
 	std::vector<double> upper; upper.reserve(n_params);
-
+    auto orig_parameter= *global_parameter;
 	vector<bool> calibrate_parameter(n_params, false);
     // 25 is routing velocity
 	for (auto i : vector<int>{ 0,4,14,16,25 }) calibrate_parameter[i] = true;
@@ -372,7 +372,22 @@ void cell_builder_test::test_read_and_run_region_model(void) {
 	cout << " x-parameters before and after" << endl;
 	for (size_t i = 0; i < x.size(); ++i) {
 		if(rm_opt.active_parameter(i) )
-            cout<< "'" << pa.get_name(i) << "' = " << px.get(i) << " -> " << x_optimized.get(i) << endl;
+            cout<< "'" << pa.get_name(i) << "' = " << px.get(i) << " -> " << x_optimized.get(i) <<
+            " (orig:"<<orig_parameter.get(i)<<")"<< endl;
 	}
 	cout << " done" << endl;
+	cout <<"Retry with sceua:\n";
+	tz=ec::utctime_now();
+	auto x_optimized2=rm_opt.optimize_sceua(x_optimized);
+	used= ec::utctime_now() - tz;
+
+	cout << "results: " << used << " seconds, nthreads = " << rm.ncore << endl;
+	cout << " goal function value:" << rm_opt.calculate_goal_function(x_optimized2) << endl;
+	cout << " x-parameters before and after" << endl;
+	for (size_t i = 0; i < x.size(); ++i) {
+		if(rm_opt.active_parameter(i) )
+            cout<< "'" << pa.get_name(i) << "' = " << px.get(i) << " -> " << x_optimized2.get(i) <<
+            " (orig:"<<orig_parameter.get(i)<<")"<< endl;
+	}
+	cout<< "done"<<endl;
 }

--- a/test/hbv_actual_evapotranspiration_test.cpp
+++ b/test/hbv_actual_evapotranspiration_test.cpp
@@ -32,6 +32,17 @@ void hbv_actual_evapotranspiration_test::test_snow() {
 
 	TS_ASSERT(act_evap_no_snow > act_evap_some_snow);
 }
+void hbv_actual_evapotranspiration_test::test_evap_from_non_snow_only() {
+    const double soil_moisture = 200.0;
+    const double pot_evap = 5.0; // [mm/h]
+    const double lp = 150.0;
+    const utctime dt = deltahours(1);
+    double act_evap_no_snow = calculate_step(soil_moisture, pot_evap, lp, 0.0, dt);
+    double act_evap_some_snow = calculate_step(soil_moisture, pot_evap, lp, 0.1, dt);
+
+    TS_ASSERT(act_evap_no_snow > act_evap_some_snow);
+
+}
 
 void hbv_actual_evapotranspiration_test::test_soil_moisture_threshold() {
 	const double sca = 0.0;

--- a/test/hbv_actual_evapotranspiration_test.h
+++ b/test/hbv_actual_evapotranspiration_test.h
@@ -6,5 +6,6 @@ public:
 	void test_soil_moisture();
 	void test_snow();
 	void test_soil_moisture_threshold();
+    void test_evap_from_non_snow_only();
 };
 

--- a/test/hbv_soil_test.cpp
+++ b/test/hbv_soil_test.cpp
@@ -21,3 +21,17 @@ void hbv_soil_test::test_regression() {
 	TS_ASSERT_DELTA(s.sm, 48.6111, 0.0001);
 	TS_ASSERT_DELTA(r.outflow, 1.38888000, 0.05);
 }
+
+void hbv_soil_test::test_dry_soil_case() {
+    hbv_soil::parameter p;
+    hbv_soil::calculator<hbv_soil::parameter> calc(p);
+    hbv_soil::state s;
+    hbv_soil::response r;
+    calendar utc;
+    utctime t0 = utc.time(2015, 1, 1);
+    s.sm = 1.0;
+    calc.step(s, r, t0, t0 + deltahours(1), 1.0, 20.0);// feed in actual evap
+    TS_ASSERT_DELTA(s.sm, 0.0, 0.0);
+    TS_ASSERT_DELTA(r.outflow, 4.4444e-5, 1.0e-6);
+
+}

--- a/test/hbv_soil_test.h
+++ b/test/hbv_soil_test.h
@@ -4,4 +4,5 @@
 class hbv_soil_test : public CxxTest::TestSuite {
 public:
 	void test_regression();
+    void test_dry_soil_case();
 };

--- a/test/routing_test.cpp
+++ b/test/routing_test.cpp
@@ -14,7 +14,7 @@ namespace shyft {
 
             /**just a mock for the relevant cell parameter used in cell_node below*/
             struct cell_parameter {
-                uhg_parameter routing_uhg;
+                uhg_parameter routing;
             };
 
             /** cell_node, a workbench stand-in for a typical shyft::core::cell_model
@@ -120,19 +120,19 @@ void routing_test::test_routing_model() {
     cx.geo.routing.id = a_id;
     cx.geo.routing.distance = 10000;
     cx.parameter = std::make_shared<routing::cell_parameter>();
-    cx.parameter->routing_uhg.velocity = cx.geo.routing.distance / (10 * 3600.0);// takes 10 hours to propagate the distance
+    cx.parameter->routing.velocity = cx.geo.routing.distance / (10 * 3600.0);// takes 10 hours to propagate the distance
     cx.rc.avg_discharge= ts_t(ta, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
     cx.rc.avg_discharge.set(0, 10.0);// set 10 m3/s at timestep 0.
     cells->push_back(cx); //ship it to cell-vector
     cx.parameter = std::make_shared<routing::cell_parameter>();
-    cx.parameter->routing_uhg.velocity = cx.geo.routing.distance / (7 * 3600.0);// takes 7 hours to propagate the distance
+    cx.parameter->routing.velocity = cx.geo.routing.distance / (7 * 3600.0);// takes 7 hours to propagate the distance
     cx.rc.avg_discharge = ts_t(ta, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
     cx.rc.avg_discharge.set(0, 7.0);
     cx.rc.avg_discharge.set(6, 6.0); // a second pulse after 6 hours
     cells->push_back(cx);
     cx.geo.routing.id = c_id;// route it to cell c
     cx.parameter = std::make_shared<routing::cell_parameter>();
-    cx.parameter->routing_uhg.velocity = cx.geo.routing.distance / (24 * 3600.0);// takes 14 hours to propagate the distance
+    cx.parameter->routing.velocity = cx.geo.routing.distance / (24 * 3600.0);// takes 14 hours to propagate the distance
     cx.rc.avg_discharge = ts_t(ta, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
     cx.rc.avg_discharge.set(0, 50.0);// just one large pulse, that will spread over 24 hours
     cells->push_back(cx);

--- a/test/routing_test.cpp
+++ b/test/routing_test.cpp
@@ -3,97 +3,20 @@
 #include "core/timeseries.h"
 #include "core/utctime_utilities.h"
 #include "core/geo_cell_data.h"
+#include "core/routing.h"
 #include "api/timeseries.h"
-//#include <boost/math/distributions/gamma.hpp>
-//#include <iomanip>
 
-namespace shyft {
-    namespace timeseries {
-
-
-        // maybe a more convenient function to get the frozen values out,
-        // then we don't have to write this more than once,
-        // except for the rare cases where we would like to specialize it:
-
-        template <class Ts>
-        std::vector<double> ts_values(const Ts& ts) {
-            std::vector<double> r; r.reserve(ts.size());
-            for (size_t i = 0;i < ts.size();++i) r.push_back(ts.value(i));
-            return std::move(r);
-        }
-
-    }
-}
 namespace shyft {
     namespace core {
         namespace routing {
 
-            /** make_uhg_from_gamma a simple function to create a uhg (unit hydro graph) weight vector
-             * containing n_steps, given the gamma shape factor alpha and beta.
-             * ensuring the sum of the weight vector is 1.0
-             * and that it has a min-size of one element (1.0)
-             *
-             * Later we can replace the implementation of this to depend on the configured parameters of the
-             * model.
-             *
-             * There are some variations of how this is created, and how it is applied.
-             * Notice that there are two stages in the routing:
-             *  First from the cells to the first routing points,
-             *  Then output form the routing points can be cascaded to form
-             *  larger units (rivers etc), e.g. simulating a simple river-network.
-             *
-             *  One or more routing-points can be classified as 'observation routing points',
-             *  that is, a place where we have an observation(or a simulated observation).
-             *
-             *
-             * #1 Using cell.geo.routing velocity and distance along with catchment-specific shape parameters.
-             *    routing down to the first routing point is then determined by each cell along with possibly
-             *    catchment specific shape/routing parameters.
-             *
-             * #2 Skaugen: sum together all cell-responses that belong to a routing point, then
-             *    use distance distribution profile to generate a uhg that together with convolution
-             *    determines the response out from those cells to the first routing point
-             *
-             * #3 time-delay-zones: Group cells output to routing time-delay points,with no local delay.
-             *   then use a response function that take the shape and time-delay characteristics for the group
-             *   to the 'observation routing point'
-             *
-             *  A number of various routing methods can be utilized, we start out with a simple uhg,
-             *  and convolution to create the output response.
-             *
-             */
-            std::vector<double>  make_uhg_from_gamma(int n_steps, double alpha, double beta) {
-                using boost::math::gamma_distribution;
-                gamma_distribution<double> gdf(alpha, beta);
-                std::vector<double> r;r.reserve(n_steps);
-                double s = 0.0;
-                double d = 1.0 / double(n_steps);
-                for (double q = d;q < 1.0; q += d) {
-                    double x = quantile(gdf, q);
-                    double y = pdf(gdf, x);
-                    s += y;
-                    r.push_back(y);
-                }
-                for (auto& y : r) y /= s;
-                if (r.size() == 0) r.push_back(1.0);// at a minimum 1.0, no delay
-                return std::move(r);
-            };
 
-            /** The unit hydro graph parameter contains sufficient
-             * description to create a unit hydro graph, that have a shape
-             * and a discretized 'time-length' according to the model time-step resolution.
-             *
-             */
-            struct uhg_parameter {
-                uhg_parameter(double velocity=1.0,double alpha=3.0,double beta=0.7):velocity(velocity),alpha(alpha),beta(beta) {}
-                double velocity= 1.0;
-                double alpha=3.0;
-                double beta =0.7;
-            };
 
+            /**just a mock for the relevant cell parameter used in cell_node below*/
             struct cell_parameter {
                 uhg_parameter routing_uhg;
             };
+
             /** cell_node, a workbench stand-in for a typical shyft::core::cell_model
              *
              * Just for emulating a cell-river that do have
@@ -112,136 +35,6 @@ namespace shyft {
                     ts_t avg_discharge;
                 };
                 resource_collector rc;
-            };
-
-
-            /**\brief A routing river
-             *
-             * The routing river have flow from
-             * -# zero or more 'cell_nodes',  typically a cell_model type, lateral flow,like cell.rc.average_discharge [m3/s]
-             * -# zero or more upstream connected rivers, taking their .output_m3s()
-             * then a routing river can *optionally* be connected to a down-stream river,
-             * providing a routing function (currently just a convolution of a uhg).
-             *
-             * This definition is recursive, and we use other means to ensure the routing graph
-             * is directed and with no cycles.
-             */
-            struct river {
-                // binding information
-                //  not really needed at core level, as we could to only with ref's in the core
-                //  but we plan to expose to python and external persistence models
-                //  so providing some handles do make sense for now.
-                int id;// self.id, >0 means valid id, 0= null
-                shyft::core::routing_info downstream;
-                uhg_parameter parameter;///< We assume each river do have distinct parameter, so no shared pointer
-                // here we could have a link to the observed time-series (can use the self.id to associate)
-
-                /** create the hydro-graph, taking specified delta-t, dt,
-                 * static hydrological distance as well as the shape parameters
-                 * alpha and beta used to form the gamma-function.
-                 * The length of the uhg (delay) is determined by the downstream-distance,
-                 * and the velocity parameter. The shape of the uhg is determined by alpha&beta parameters.
-                 */
-                std::vector<double> uhg(utctimespan dt) const {
-                    double steps = (downstream.distance / parameter.velocity) / dt;// time = distance / velocity[s] // dt[s]
-                    int n_steps = int(steps + 0.5);
-                    return std::move(make_uhg_from_gamma(n_steps, parameter.alpha, parameter.beta));
-                }
-            };
-
-            /** A routing model
-             *
-             *
-             * Based on modelling the routing using repeated convolution of a unit hydro-graph.
-             * First from the lateral local cells that feeds into the routing-point (river/creek).
-             * Then add up the flow from the upstream rivers(they might or might not have local-cells, up-streams rivers etc.)
-             * Then finally compute output as the convolution using the uhg of the sum_inflow to the river.
-             *
-             * \tparam C
-             *  Cell type that should provide
-             *  -# C::ts_t the current core time-series representation, currently point_ts<fixed_dt>..
-             *  -# C::output_m3s_t the type of the call C::output_m3s() const (we could rater use result_of..)
-             *
-             * \note implementation:
-             *    technically we are currently flattening out the ts-expression tree by computing the full
-             *    point representation of every flow in the directed graph.
-             *    Later we could utilize a dynamic dispatch to to build the recursive
-             *    accumulated expression tree at any river in the routing graph. This could
-             *    improve performance and resource usage in certain scenarios.
-             *
-             */
-
-            template<class C>
-            struct model {
-                typedef typename C::ts_t rts_t; // the result computed in the cell.rc.avg_discharge [m3/s]
-                //typedef typename C::output_m3s_t ots_t; // the output result from the cell, it's a convolution_w_ts<rts_t>..
-                //typedef typename shyft::timeseries::uniform_sum_ts<ots_t> sum_ts_t; // could be possible using api::apoint_ts
-
-                std::map<int, river> node_map; ///< keeps structure and routing properties
-
-                std::shared_ptr<std::vector<C>> cells; ///< shared with the region_model !
-                timeseries::timeaxis ta;///< shared with the region_model,  should be simulation time-axis
-
-
-                std::vector<double> cell_uhg(const C& c, utctimespan dt) const {
-                    double steps = (c.geo.routing.distance / c.parameter->routing_uhg.velocity)/dt;// time = distance / velocity[s] // dt[s]
-                    int n_steps = int(steps + 0.5);
-                    return std::move(make_uhg_from_gamma(n_steps, c.parameter->routing_uhg.alpha, c.parameter->routing_uhg.beta));//std::vector<double>{0.1,0.5,0.2,0.1,0.05,0.030,0.020};
-                }
-
-                /** compute the cell_output, taking the cell-route to routing river into consideration
-                 *
-                 */
-                timeseries::convolve_w_ts<rts_t> cell_output_m3s(const C&c ) const {
-                    // return discharge, notice that this function assumes that time_axis() do have a uniform delta() (requirement)
-                    return std::move(timeseries::convolve_w_ts<rts_t>(c.rc.avg_discharge,cell_uhg(c,ta.delta()),timeseries::convolve_policy::USE_ZERO));
-                }
-
-
-                /** compute the local lateral inflow from connected shyft-cells into given river-id
-                 *
-                 */
-                rts_t local_inflow(int node_id) const {
-                    rts_t r(ta,0.0,timeseries::POINT_AVERAGE_VALUE);// default null to null ts.
-                    for (const auto& c : *cells) {
-                        if (c.geo.routing.id == node_id) {
-                            auto node_output_m3s (cell_output_m3s(c));
-                            for (size_t t = 0;t < r.size();++t)
-                                r.add(t, node_output_m3s.value(t));
-                        }
-                    }
-                    return std::move(r);
-                }
-
-                /** Aggregate the upstream inflow that flows into this cell
-                 * Notice that this is a recursive function that will go upstream
-                 * and collect *all* upstream flow
-                 */
-                rts_t upstream_inflow(int node_id) const {
-                    rts_t r(ta, 0.0, timeseries::POINT_AVERAGE_VALUE);
-                    for (const auto& i : node_map) {
-                        if (i.second.downstream.id == node_id) {
-                            auto flow_m3s = output_m3s(i.first);
-                            for (size_t t = 0;t < ta.size();++t)
-                                r.add(t, flow_m3s.value(t));
-                        }
-                    }
-                    return std::move(r);
-                }
-
-                /** Utilizing the local_inflow and upstream_inflow function,
-                 * calculate the output_m3s leaving the specified river.
-                 * This is a walk in the park, since we can just use
-                 * already existing (possibly recursive) functions to do the work.
-                 */
-                rts_t output_m3s(int node_id) const {
-                    utctimespan dt = ta.delta(); // for now need to pick up delta from the sources
-                    std::vector<double> uhg_weights = node_map.at(node_id).uhg(dt);
-                    auto sum_input_m3s = local_inflow(node_id)+ upstream_inflow(node_id);
-                    auto response = timeseries::convolve_w_ts<decltype(sum_input_m3s)>(sum_input_m3s, uhg_weights, timeseries::convolve_policy::USE_ZERO);
-                    return std::move(rts_t(ta, timeseries::ts_values(response), timeseries::POINT_AVERAGE_VALUE)); // flatten values
-                }
-
             };
 
         }
@@ -319,10 +112,10 @@ void routing_test::test_routing_model() {
     routing::model<cell_t> m;
     m.cells = cells;
     m.ta = ta;
-    m.node_map[a.id]=a;
-    m.node_map[b.id]=b;
-    m.node_map[c.id]=c;
-    m.node_map[d.id]=d;
+    m.river_map[a.id]=a;
+    m.river_map[b.id]=b;
+    m.river_map[c.id]=c;
+    m.river_map[d.id]=d;
 
     /// now, with the model in place, including some fake-timeseries at cell-level, we can expect things to happen:
     // fto establish regression, uncomment and print out out the response

--- a/test/routing_test.cpp
+++ b/test/routing_test.cpp
@@ -1,0 +1,327 @@
+#include "test_pch.h"
+#include "routing_test.h"
+#include "core/timeseries.h"
+#include "core/utctime_utilities.h"
+#include "core/geo_cell_data.h"
+#include "api/timeseries.h"
+//#include <boost/math/distributions/gamma.hpp>
+//#include <iomanip>
+
+namespace shyft {
+    namespace timeseries {
+
+
+        // maybe a more convenient function to get the frozen values out,
+        // then we don't have to write this more than once,
+        // except for the rare cases where we would like to specialize it:
+
+        template <class Ts>
+        std::vector<double> ts_values(const Ts& ts) {
+            std::vector<double> r; r.reserve(ts.size());
+            for (size_t i = 0;i < ts.size();++i) r.push_back(ts.value(i));
+            return std::move(r);
+        }
+
+    }
+}
+namespace shyft {
+    namespace core {
+        namespace routing {
+
+            /** make_uhg_from_gamma a simple function to create a uhg (unit hydro graph) weight vector
+             * containing n_steps, given the gamma shape factor alpha and beta.
+             * ensuring the sum of the weight vector is 1.0
+             * and that it has a min-size of one element (1.0)
+             *
+             * Later we can replace the implementation of this to depend on the configured parameters of the
+             * model.
+             *
+             * There are some variations of how this is created, and how it is applied.
+             * Notice that there are two stages in the routing:
+             *  First from the cells to the first routing points,
+             *  Then output form the routing points can be cascaded to form
+             *  larger units (rivers etc), e.g. simulating a simple river-network.
+             *
+             *  One or more routing-points can be classified as 'observation routing points',
+             *  that is, a place where we have an observation(or a simulated observation).
+             *
+             *
+             * #1 Using cell.geo.routing velocity and distance along with catchment-specific shape parameters.
+             *    routing down to the first routing point is then determined by each cell along with possibly
+             *    catchment specific shape/routing parameters.
+             *
+             * #2 Skaugen: sum together all cell-responses that belong to a routing point, then
+             *    use distance distribution profile to generate a uhg that together with convolution
+             *    determines the response out from those cells to the first routing point
+             *
+             * #3 time-delay-zones: Group cells output to routing time-delay points,with no local delay.
+             *   then use a response function that take the shape and time-delay characteristics for the group
+             *   to the 'observation routing point'
+             *
+             *  A number of various routing methods can be utilized, we start out with a simple uhg,
+             *  and convolution to create the output response.
+             *
+             */
+            std::vector<double>  make_uhg_from_gamma(int n_steps, double alpha, double beta) {
+                using boost::math::gamma_distribution;
+                gamma_distribution<double> gdf(alpha, beta);
+                std::vector<double> r;r.reserve(n_steps);
+                double s = 0.0;
+                double d = 1.0 / double(n_steps);
+                for (double q = d;q < 1.0; q += d) {
+                    double x = quantile(gdf, q);
+                    double y = pdf(gdf, x);
+                    s += y;
+                    r.push_back(y);
+                }
+                for (auto& y : r) y /= s;
+                if (r.size() == 0) r.push_back(1.0);// at a minimum 1.0, no delay
+                return std::move(r);
+            };
+            struct cell_parameter {
+                double velocity=0.0;
+                double alpha =3.0;
+                double beta = 0.7;
+            };
+            /** cell_node, a workbench stand-in for a typical shyft::core::cell_model
+             *
+             * Just for emulating a cell-node that do have
+             * the needed properties that we will require
+             * later when promoting the stuff to cell_model
+             *  either by explicit requirement, or by concept
+             */
+            template <class Ts>
+            struct cell_node {
+                typedef Ts ts_t;
+                typedef typename  timeseries::convolve_w_ts<ts_t> output_m3s_t;
+                cell_parameter parameter;
+                geo_cell_data geo;
+                ts_t discharge_m3s;
+
+            };
+
+            struct node_parameter {
+                node_parameter(double velocity=1.0,double alpha=3.0,double beta=0.7):velocity(velocity),alpha(alpha),beta(beta) {}
+                double velocity= 1.0;
+                double alpha=3.0;
+                double beta =0.7;
+            };
+            /**\brief A routing node
+             *
+             * The routing node have flow from
+             * -# zero or more 'cell_nodes',  typically a cell_model type, lateral flow (.output_m3s())
+             * -# zero or more upstream connected routing nodes, taking their inputs (.output_m3s())
+             * then a routing node can be connected to a down-stream node,
+             * providing a routing function (currently just a convolution of a uhg).
+             *
+             * This definition is recursive, and we use other means to ensure the routing graph
+             * is directed and with no cycles.
+             */
+            struct node {
+                // binding information
+                //  not really needed at core level, as we could to only with ref's in the core
+                //  but we plan to expose to python and external persistence models
+                //  so providing some handles do make sense for now.
+                int id;// self.id, >0 means valid id, 0= null
+                shyft::core::routing_info downstream;
+                node_parameter parameter;
+                // here we could have a link to the observed time-series (can use the self.id to associate)
+                std::vector<double> uhg(utctimespan dt) const {
+                    double steps = (downstream.distance / parameter.velocity) / dt;// time = distance / velocity[s] // dt[s]
+                    int n_steps = int(steps + 0.5);
+                    return std::move(make_uhg_from_gamma(n_steps, parameter.alpha, parameter.beta));//std::vector<double>{0.1,0.5,0.2,0.1,0.05,0.030,0.020};
+                }
+            };
+
+            /** A simple routing model
+             *
+             *
+             * Based on shaping the routing using repeated convolution a unit hydro-graph.
+             * First from the lateral local cells that feeds into the routing-point (creek).
+             * Then add up the flow from the upstream routing points(they might or might not have local-cells, upstreams routes etc.)
+             * Then finally compute output as the convolution using the uhg of the sum_inflow to the node.
+             * \tparam C
+             *  Cell type that should provide
+             *  -# C::ts_t the current core time-series representation, currently point_ts<fixed_dt>..
+             *  -# C::output_m3s_t the type of the call C::output_m3s() const (we could rater use result_of..)
+             *
+             * \note implementation:
+             *    technically we are currently flattening out the ts-expression tree.
+             *    later we could utilize a dynamic dispatch to to build the recursive
+             *    accumulated expression tree at any node in the routing graph.
+             *
+             */
+
+            template<class C>
+            struct model {
+                typedef typename C::ts_t rts_t; // the result computed in the cell.rc.avg_discharge [m3/s]
+                typedef typename C::output_m3s_t ots_t; // the output result from the cell, it's a convolution_w_ts<rts_t>..
+                //typedef typename shyft::timeseries::uniform_sum_ts<ots_t> sum_ts_t;
+
+                std::map<int, node> node_map; ///< keeps structure and routing properties
+
+                std::shared_ptr<std::vector<C>> cells; ///< shared with the region_model !
+                timeseries::timeaxis ta;///< shared with the region_model,  should be simulation time-axis
+
+
+                std::vector<double> cell_uhg(const C& c, utctimespan dt) const {
+                    double steps = (c.geo.routing.distance / c.parameter.velocity)/dt;// time = distance / velocity[s] // dt[s]
+                    int n_steps = int(steps + 0.5);
+                    return std::move(make_uhg_from_gamma(n_steps, c.parameter.alpha, c.parameter.beta));//std::vector<double>{0.1,0.5,0.2,0.1,0.05,0.030,0.020};
+                }
+
+                timeseries::convolve_w_ts<rts_t> cell_output_m3s(const C&c ) const {
+                    // return discharge, notice that this function assumes that time_axis() do have a uniform delta() (requirement)
+                    return std::move(timeseries::convolve_w_ts<rts_t>(c.discharge_m3s,cell_uhg(c,ta.delta()),timeseries::convolve_policy::USE_ZERO));
+                }
+                /** compute the local lateral inflow from connected shyft-cells into given node-id
+                 *
+                 */
+                rts_t local_inflow(int node_id) const {
+                    rts_t r(ta,0.0,timeseries::POINT_AVERAGE_VALUE);// default null to null ts.
+                    for (const auto& c : *cells) {
+                        if (c.geo.routing.id == node_id) {
+                            auto node_output_m3s = cell_output_m3s(c);
+                            for (size_t t = 0;t < r.size();++t)
+                                r.add(t, node_output_m3s.value(t));
+                        }
+                    }
+                    return std::move(r);
+                }
+
+                /** Aggregate the upstream inflow that flows into this cell
+                 * Notice that this is a recursive function that will go upstream
+                 * and collect *all* upstream flow
+                 */
+                rts_t upstream_inflow(int node_id) const {
+                    rts_t r(ta, 0.0, timeseries::POINT_AVERAGE_VALUE);
+                    for (const auto& i : node_map) {
+                        if (i.second.downstream.id == node_id) {
+                            auto flow_m3s = output_m3s(i.first);
+                            for (size_t t = 0;t < ta.size();++t)
+                                r.add(t, flow_m3s.value(t));
+                        }
+                    }
+                    return std::move(r);
+                }
+
+                /** Utilizing the local_inflow and upstream_inflow function,
+                 * calculate the output_m3s leaving the specified node.
+                 * This is a walk in the park, since we can just use
+                 * already existing (possibly recursive) functions to do the work.
+                 */
+                rts_t output_m3s(int node_id) const {
+                    utctimespan dt = ta.delta(); // for now need to pick up delta from the sources
+                    std::vector<double> uhg_weights = node_map.at(node_id).uhg(dt);
+                    auto sum_input_m3s = local_inflow(node_id)+ upstream_inflow(node_id);
+                    auto response = timeseries::convolve_w_ts<decltype(sum_input_m3s)>(sum_input_m3s, uhg_weights, timeseries::convolve_policy::USE_ZERO);
+                    return std::move(rts_t(ta, timeseries::ts_values(response), timeseries::POINT_AVERAGE_VALUE)); // flatten values
+                }
+
+            };
+
+        }
+    }
+}
+
+
+
+void routing_test::test_hydrograph() {
+    //
+    //  Just for playing around with sum of routing node response
+    //
+
+}
+
+//-- consider using dlib graph to do the graph stuff
+
+//#include <dlib/graph_utils.h>
+//#include <dlib/graph.h>
+//#include <dlib/directed_graph.h>
+
+void routing_test::test_routing_model() {
+    using namespace shyft::core;
+    using ta_t = shyft::time_axis::fixed_dt;
+    using ts_t = shyft::timeseries::point_ts<ta_t>;
+    using cell_t = routing::cell_node<ts_t>;
+    // setup a simple network
+    // a->b-> d
+    //    c-/
+    //
+    // node a and c do have local inflow through cell_t (alias shyft region model cell)
+    // node b is just a routing transport node
+    // node d is an endpoint node, observation point routing node where we
+    // would like to observed the local_inflow + the upstream_inflow
+    // --
+    // for now we just set routing parameters to
+    // values suitable for demo and verification
+    //--
+    calendar utc;
+    ta_t ta(utc.time(2016, 1, 1), deltahours(1), 24);
+    int a_id = 1;
+    int b_id = 2;
+    int c_id = 3;
+    int d_id = 4;
+
+    // build the shyft region model cells (we use local types here, so we have maximum control)
+    auto cells = std::make_shared<std::vector<cell_t>>();
+    cell_t cx;
+    cx.geo.routing.id = a_id;
+    cx.geo.routing.distance = 10000;
+    cx.parameter.velocity = cx.geo.routing.distance / (10 * 3600.0);// takes 10 hours to propagate the distance
+    cx.discharge_m3s= ts_t(ta, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
+    cx.discharge_m3s.set(0, 10.0);// set 10 m3/s at timestep 0.
+    cells->push_back(cx); //ship it to cell-vector
+    cx.parameter.velocity = cx.geo.routing.distance / (7 * 3600.0);// takes 7 hours to propagate the distance
+    cx.discharge_m3s = ts_t(ta, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
+    cx.discharge_m3s.set(0, 7.0);
+    cx.discharge_m3s.set(6, 6.0); // a second pulse after 6 hours
+    cells->push_back(cx);
+    cx.geo.routing.id = c_id;// route it to cell c
+    cx.parameter.velocity = cx.geo.routing.distance / (24 * 3600.0);// takes 14 hours to propagate the distance
+    cx.discharge_m3s = ts_t(ta, 0.0, shyft::timeseries::POINT_AVERAGE_VALUE);
+    cx.discharge_m3s.set(0, 50.0);// just one large pulse, that will spread over 24 hours
+    cells->push_back(cx);
+
+    // build the routing network as described,
+    routing::node a{ a_id,routing_info(b_id, 2*3600.0),routing::node_parameter(1.0) };// two hour delay from
+    routing::node b{ b_id,routing_info(d_id, 0),routing::node_parameter(1.0) }; // give zero delay
+    routing::node c{ c_id,routing_info(d_id, 3600.0),routing::node_parameter(1.0) };// give one hour delay
+    routing::node d{ d_id,routing_info(0) }; // here is our observation point node
+
+    routing::model<cell_t> m;
+    m.cells = cells;
+    m.ta = ta;
+    m.node_map[a.id]=a;
+    m.node_map[b.id]=b;
+    m.node_map[c.id]=c;
+    m.node_map[d.id]=d;
+
+    /// now, with the model in place, including some fake-timeseries at cell-level, we can expect things to happen:
+    // for now just print out the response
+    auto observation_m3s = m.local_inflow(d_id) + m.upstream_inflow(d_id);// this arrives into node d:
+    std::cout << "Resulting response at observation node d:\n";
+    std::cout << "timestep\t d.flow.[m3s]\n";
+    for (size_t t = 0; t < observation_m3s.size();++t) {
+        std::cout << t << "\t" << std::setprecision(2) << observation_m3s.value(t) << std::endl;
+    }
+
+#if 0
+    // this is what we can easily do with dlib
+    //
+    dlib::directed_graph<routing::node>::kernel_1a_c md;
+    md.set_number_of_nodes(4);
+    md.add_edge(0,1);
+    md.add_edge(1,3);
+    md.add_edge(2,3);
+    md.node(0).data=a;
+    md.node(1).data=b;
+    md.node(2).data=c;
+    md.node(3).data=d;
+
+    TS_ASSERT_EQUALS( md.node(3).number_of_parents(),2);
+    TS_ASSERT_EQUALS( md.node(0).number_of_parents(),0);
+    TS_ASSERT_EQUALS( md.node(0).number_of_children(),1);
+    TS_ASSERT_EQUALS( md.node(3).number_of_children(),0);
+#endif
+}

--- a/test/routing_test.cpp
+++ b/test/routing_test.cpp
@@ -74,7 +74,8 @@ void routing_test::test_build_valid_river_network() {
     TS_ASSERT_EQUALS(rn.downstream_by_id(c_id),d_id);
     TS_ASSERT_EQUALS(rn.downstream_by_id(d_id),0);
     TS_ASSERT_DELTA(rn.river_by_id(a_id).downstream.distance,a.downstream.distance,0.01);
-
+    auto all_ups = rn.all_upstreams_by_id(d_id);
+    TS_ASSERT_EQUALS(all_ups.size(), 3);
     // remove stuff:
     rn.remove_by_id(c_id);
     TS_ASSERT_THROWS(rn.check_rid(c_id),std::runtime_error);

--- a/test/routing_test.h
+++ b/test/routing_test.h
@@ -1,0 +1,8 @@
+#pragma once
+
+
+class routing_test: public CxxTest::TestSuite {
+  public:
+    void test_hydrograph();
+    void test_routing_model();
+};

--- a/test/routing_test.h
+++ b/test/routing_test.h
@@ -3,6 +3,6 @@
 
 class routing_test: public CxxTest::TestSuite {
   public:
-    void test_hydrograph();
+    void test_build_valid_river_network();
     void test_routing_model();
 };

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -128,6 +128,8 @@
 		<Unit filename="pt_ss_k_test.h" />
 		<Unit filename="region_model_test.cpp" />
 		<Unit filename="region_model_test.h" />
+		<Unit filename="routing_test.cpp" />
+		<Unit filename="routing_test.h" />
 		<Unit filename="runner.cpp" />
 		<Unit filename="sceua_test.cpp" />
 		<Unit filename="sceua_test.h" />

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -12,7 +12,7 @@
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="timeseries_test test_api_ts_ref_binding" />
+				<Option parameters="routing_test test_build_valid_river_network" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>
@@ -31,10 +31,12 @@
 				<Option type="1" />
 				<Option compiler="gcc" />
 				<Compiler>
+					<Add option="-fexpensive-optimizations" />
 					<Add option="-O3" />
 					<Add option="-DARMA_NO_DEBUG" />
 				</Compiler>
 				<Linker>
+					<Add option="-O3" />
 					<Add directory="../bin/Release" />
 				</Linker>
 				<ExtraCommands>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -128,6 +128,7 @@
     <ClInclude Include="kalman_test.h" />
     <ClInclude Include="kriging_test.h" />
     <ClInclude Include="pt_ss_k_test.h" />
+    <ClInclude Include="routing_test.h" />
     <ClInclude Include="sceua_test.h" />
     <ClInclude Include="test_pch.h" />
     <ClInclude Include="gamma_snow_test.h" />
@@ -147,9 +148,9 @@
     <ClInclude Include="serialization_test.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="actual_evapotranspiration_test.cpp"/>
-    <ClCompile Include="bayesian_kriging_test.cpp"/>
-    <ClCompile Include="calibration_test.cpp"/>
+    <ClCompile Include="actual_evapotranspiration_test.cpp" />
+    <ClCompile Include="bayesian_kriging_test.cpp" />
+    <ClCompile Include="calibration_test.cpp" />
     <ClCompile Include="cell_builder_test.cpp" />
     <ClCompile Include="api_test.cpp" />
     <ClCompile Include="glacier_melt_test.cpp" />
@@ -160,6 +161,7 @@
     <ClCompile Include="hbv_tank_test.cpp" />
     <ClCompile Include="kalman_test.cpp" />
     <ClCompile Include="pt_ss_k_test.cpp" />
+    <ClCompile Include="routing_test.cpp" />
     <ClCompile Include="sceua_test.cpp" />
     <ClCompile Include="test_pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -177,7 +179,7 @@
     <ClCompile Include="mocks.cpp" />
     <ClCompile Include="priestley_taylor_test.cpp" />
     <ClCompile Include="pt_gs_k_test.cpp" />
-    <ClCompile Include="pt_hs_k_test.cpp"/>
+    <ClCompile Include="pt_hs_k_test.cpp" />
     <ClCompile Include="region_model_test.cpp" />
     <ClCompile Include="runner.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
@@ -186,8 +188,8 @@
     <ClCompile Include="skaugen_test.cpp" />
     <ClCompile Include="timeseries_test.cpp" />
     <ClCompile Include="time_axis_test.cpp" />
-    <ClCompile Include="utctime_utilities_test.cpp"/>
-    <ClCompile Include="serialization_test.cpp"/>
+    <ClCompile Include="utctime_utilities_test.cpp" />
+    <ClCompile Include="serialization_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Makefile.testupdate" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -94,6 +94,7 @@
     <ClInclude Include="serialization_test.h">
       <Filter>serialization</Filter>
     </ClInclude>
+    <ClInclude Include="routing_test.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="actual_evapotranspiration_test.cpp">
@@ -192,6 +193,7 @@
     <ClCompile Include="serialization_test.cpp">
       <Filter>serialization</Filter>
     </ClCompile>
+    <ClCompile Include="routing_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="methods">

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>timeseries_test  test_serialization</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>cell_builder_test test_read_and_run_region_model</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>hbv_actual_evapotranspiration_test test_evap_from_non_snow_only</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>hbv_soil_test test_dry_soil_case</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>hbv_actual_evapotranspiration_test test_evap_from_non_snow_only</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>hbv_soil_test test_dry_soil_case</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>cell_builder_test test_read_and_run_region_model</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>hbv_actual_evapotranspiration_test test_evap_from_non_snow_only</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>cell_builder_test test_read_and_run_region_model</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>hbv_actual_evapotranspiration_test test_evap_from_non_snow_only</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>

--- a/test/time_axis_test.cpp
+++ b/test/time_axis_test.cpp
@@ -37,7 +37,13 @@ static bool test_if_equal( const TA& e, const TB& t ) {
         if( ei != ti )
             return false;
     }
-    return true;
+
+	if (!equivalent_time_axis(e, t)) // verify e and t produces the same periods
+		return false;
+	// now create a time-axis different from e and t, just to verify that equivalent_time_axis states it's false
+	time_axis::fixed_dt u(utctime(1234), deltahours(1), 21);
+
+	return !equivalent_time_axis(u,e) && !equivalent_time_axis(u,t);
 }
 
 void time_axis_test::test_all() {
@@ -157,10 +163,6 @@ void time_axis_test::test_all() {
 
 }
 
-namespace shyft {
-    namespace time_axis {
-    }
-}
 
 void time_axis_test::test_time_shift() {
     calendar utc;

--- a/test/timeseries_test.h
+++ b/test/timeseries_test.h
@@ -32,6 +32,8 @@ public:
 	void test_partition_by();
 	void test_unit_conversion();
 	void test_ts_ref();
+    void test_convolution_w();
+	void test_uniform_sum_ts();
 };
 
 


### PR DESCRIPTION
# Overview 
This PR adds the first options to introduce river-network based routing to shyft.

Routing steps (all optional)

1. Routing from cells to a river.

    The shape and delay are modeled through a unit hydro-graph, tuned with cell-specific distance, and catchment specific speed and shape parameters.

* cell.geo.routing_info.id sets the destination river id
* cell.geo.routing_info.distance is the hydrological distance from the cell to the river
* catchment.parameter.routing
    .alpha and .beta determines the shape of the unit-hydrograph
    .velocity determines the overall length of the unit hydrograph
   that is: number of  weights in uhg is  

    (cell.geo.routing_info.distance/parameter.routing.velocity) / simulation-time-step


2. River-network routing
    A river can as described above have lateral *routed* inflow from cells in a catchment.
In addition, it can have the accumulation of  upstream rivers. Each river can have maximum one output to the down-stream river.

    The river it-self have it's own routing parameter, similar to the catchment.routing parameters.
That is:  gamma-function alpha and beta for the overall shape, and velocity combined with hydrological distance of the river.


## Implementation details

As indicated all catchment parameters now got one extra pr. catchment routing parameter, with gamma-function shape alpha and beta parameters. The velocity parameter together with the static cell.geo.routing_info.distance, or river.downstream.distance determines the length of the unit hydro graph.

The region model now have an extra property 
region_model.river_network
That can be used to build the river-network. Ref. python tests for routing, api/routing_test.py for illustrations.

The method
region_model.connect_catchment_to_river(cid,rid)

connects all cells in a catchment to a specified river.

When this is done, the routing information, detailed flow of each river-element  can be extracted from the model using one of these methods:

region_model.river_output_flow_m3s(rid)

region_model.river_local_inflow_m3s(rid)

region_model.river_upstream_inflow_m3s(rid)


This is also illustrated briefly in test_region_model_stacks.py

```python
#
# Play with routing and river-network
#
# 1st: add a river, with 36.000 meter hydro length, a UHGParameter with 1m/hour speed, alpha/beta suitable
model.river_network.add(
            api.River(1, api.RoutingInfo(0, 3000.0), api.UHGParameter(1 / 3.60, 1.0, 0.7)))  # river id =1

# 2nd: let cells route to the river
model.connect_catchment_to_river(0, 1)  # now all cells in catchment 0 routes to river with id 1.
self.assertTrue(model.has_routing())

# 3rd: now we can have a look at water coming in and out
river_out_m3s = model.river_output_flow_m3s(1) 
river_local_m3s = model.river_local_inflow_m3s( 1) 
river_upstream_inflow_m3s = model.river_upstream_inflow_m3s(1)

```

## Calibration

Calibration for cell to river parameters are now supported.
To enable the functionality;
1.  build a model with river-network
2. create a target specification using alternative constructor:
```python
:
river_target = TargetSpecificationPts(ts,river_id,scale_factor,calc_mode,s_r,s_a,s_b,uid)
:
```
The calibrator automagically figure out which catchments to compute.

Parameters for river-network routing:
 Not yet finished, but the plan is as following:
 optionally pass parameter limits and start-points along with the target-specification.
 

## Issues and things to know

1. Since we are using convolution, the length of the convolution window around start/end of the time-series has to be considered.
2. Run by step, is also vulnerable to the delay/convolution effect. Take care when interpreting results near the start of the simulation-period/ up to the length of the unit hydro-graph measured in steps.