### PR TITLE
add routing to known calibration parameter mapings

### DIFF
--- a/shyft/orchestration/simulators/config_simulator.py
+++ b/shyft/orchestration/simulators/config_simulator.py
@@ -165,7 +165,7 @@ class ConfigCalibrator(simulator.DefaultSimulator):
         """Save calibrated params in a model-like YAML file."""
         name_map = {"pt": "priestley_taylor", "kirchner": "kirchner", "p_corr": "precipitation_correction",
                     "ae": "actual_evapotranspiration", "gs": "gamma_snow", "ss": "skaugen_snow", "hs": "hbv_snow","gm":"glacier_melt",
-                    "hbv_actual_evapotranspiration": "ae", "hbv_soil": "soil", "hbv_tank": "tank"
+                    "hbv_actual_evapotranspiration": "ae", "hbv_soil": "soil", "hbv_tank": "tank","routing":"routing"
                     }
         model_file = self.model_config_file
         model_dict = yaml.load(open(model_file))


### PR DESCRIPTION
Fixes issue #115 

At the same time, there is also an update of the  .yaml files for the shyft-doc neanidelv notebook.

In the yaml-based ConfigSimulator, we require the calibration parameter set into the yaml files to be fully specified. This is to ensure complete and consistent parameter-sets during calibration.

The code correctly reports that the there are parameters missing, including names, - the new parameters provided by the new routing functionality.

Users are required to add this to their existing yaml calibration parameter files, like listed below.


    routing.velocity:
       min: 0.0
       max: 0.0
    routing.alpha:
       min: 0.9
       max: 0.9
    routing.beta:
       min: 3.0
       max: 3.0

Ref. to shyft-doc/noteboks/neanidelv example for details.

