### PR TITLE
gamma snow and corr_lwc issues

### DIFF
--- a/core/gamma_snow.h
+++ b/core/gamma_snow.h
@@ -195,49 +195,20 @@ namespace shyft {
                 }
 
                 double corr_lwc(const double z1, const double a1, const double b1,
-                                double z2, const double a2, const double b2) const {
-                    double zmax = z1;
-                    double zmin = 0.0;
-                    double dz = fabs(zmax - zmin);
-                    double dz_old = dz;
-                    const double rtol = 1.0e-4;
+                    double z2, const double a2, const double b2) const {
+                    using boost::math::tools::brent_find_minima;
+                    uintmax_t iterations = 60;
+                    auto digits = 12;// accurate enough,std::numeric_limits<double>::digits;
+                    double Q1 = calc_q(a1, b1, z1);
+                    auto result = brent_find_minima(
+                        [Q1, a2, b2, this](const double&z)->double {
+                            double f = this->calc_q(a2, b2, z) - Q1;
+                            return f*f;
+                        },
+                        0.0, z1, digits, iterations);
+                    return result.first;
+                }
 
-                    const double Q1 = calc_q(a1, b1, z1);
-                    const double precision = Q1*rtol;
-                    double Q2 = calc_q(a2, b2, z2);
-                    double f = Q2 - Q1;
-
-                    double df = calc_df(a2, b2, z2);
-
-                    size_t i;
-                    size_t max_iter = 30;
-                    for (i=0; i < max_iter; ++i) {
-                        if (((z2 - zmax)*df - f)*((z2 - zmin)*df - f) > 0.0 || fabs(2.0*f) > fabs(dz_old*df)) {
-                            dz_old = dz;
-                            dz = (zmax - zmin)*0.5;
-                            z2 = zmin + dz;
-                        } else {
-                            dz_old = dz;
-                            dz = f/df;
-                            z2 -= dz;
-                        }
-                        if (fabs(dz) < precision)
-                            break;
-                        // Prepare next iteration
-                        Q2 = calc_q(a2, b2, z2);
-                        f = Q2 - Q1;
-                        df = calc_df(a2, b2, z2);
-                        if (f < 0.0) zmin = z2;
-                        else zmax = z2;
-                    }
-    #ifdef __UNIT_TEST__
-    #if VERBOSE>0
-                    std::cout << "Num iter in corr_lwc = " << i << std::endl;
-    #endif
-    #endif
-                    if (i < max_iter) return z2;
-                    else throw std::runtime_error("corr_lwc did not converge"); // No convergence in max_iter iterations!
-                  }
 
                   void calc_snow_state(const double shape, const double scale, const double y0, const double lambda,
                                        const double lwd, const double max_water_frac, const double temp_swe,
@@ -437,7 +408,9 @@ namespace shyft {
                                 double z1 = lwc/p.max_water;
                                 double z1_guess = z1*(1.0 - sdc_snow/sdc_melt_mean);
                                 //double z1_guess = z1*0.5; // Alternative, simple initial guess
-                                z1 = corr_lwc(z1, alpha_prev, sdc_scale_prev, z1_guess, alpha, sdc_scale);
+                                if (z1_guess < gamma_snow::tol)
+                                    z1_guess = z1*0.5;
+                                z1 = corr_lwc(z1, alpha_prev, sdc_scale_prev>0.0?sdc_scale_prev:sdc_scale, z1_guess, alpha, sdc_scale);
                                 lwc = z1*p.max_water;
                                 calc_snow_state(alpha, sdc_scale, p.initial_bare_ground_fraction,
                                                 acc_melt, lwc, p.max_water, temp_swe, storage, sca);

--- a/test/gamma_snow_test.cpp
+++ b/test/gamma_snow_test.cpp
@@ -88,7 +88,8 @@ void gamma_snow_test::test_correct_lwc() {
     const double result = gs.corr_lwc(z1, a1, b1, z2, a2, b2);
 // as a result of using lower resolution, less accuracy
     TS_ASSERT_DELTA(result, 3.8411,0.0001);
-    double r= gs.corr_lwc(1.0, 6.25, 0.005358, 0.5, 6.25, 0.005358);
+    // would throw in previous versions
+    gs.corr_lwc(1.0, 6.25, 0.005358, 0.5, 6.25, 0.005358);
 
     gs.corr_lwc(0.0, a1, b1, z2, a2, b2);
     gs.corr_lwc(z1, a1, b1, 0.0, a2, b2);

--- a/test/gamma_snow_test.cpp
+++ b/test/gamma_snow_test.cpp
@@ -87,7 +87,11 @@ void gamma_snow_test::test_correct_lwc() {
 
     const double result = gs.corr_lwc(z1, a1, b1, z2, a2, b2);
 // as a result of using lower resolution, less accuracy
-    TS_ASSERT_DELTA(result, 3.8417594715,10000* shyfttest::EPS);
+    TS_ASSERT_DELTA(result, 3.8411,0.0001);
+    double r= gs.corr_lwc(1.0, 6.25, 0.005358, 0.5, 6.25, 0.005358);
+
+    gs.corr_lwc(0.0, a1, b1, z2, a2, b2);
+    gs.corr_lwc(z1, a1, b1, 0.0, a2, b2);
 
 }
 

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>hbv_soil_test test_dry_soil_case</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>gamma_snow_test test_correct_lwc</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>hbv_soil_test test_dry_soil_case</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>gamma_snow_test test_correct_lwc</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
## Overview

The problem was related to gamma-snow, and the use of corr_lwc function. It caused the pt_gs_k stack to throw run-time error in some trivial cases.

It turned  out that in certain cases, the function was called with b1, or b2 zero, and sometimes z1 or z2 was zero.
In either cases, it did not find a solution, very reasonable for the case of b2 zero, as it gives nan, but failed to find a reasonable solution for other cases (ending up in exceeding number of iterations).

This PR try to fix this by adressing the root causes, - the parameters passed to the routine, and then using standard boost minimima finder to solve the problem.

We will check&verify this solution by doing some more real-life tests at Statkraft, ensuring that Ok solutions are found.
