### PR TITLE
Improved handling of model state and storage

### DIFF
--- a/api/api.vcxproj
+++ b/api/api.vcxproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="api.h" />
+    <ClInclude Include="api_state.h" />
     <ClInclude Include="hbv_stack.h" />
     <ClInclude Include="pt_gs_k.h" />
     <ClInclude Include="pt_ss_k.h" />

--- a/api/api_serialization.cpp
+++ b/api/api_serialization.cpp
@@ -231,3 +231,35 @@ shyft::api::apoint_ts shyft::api::apoint_ts::deserialize(const std::string&str_b
     return ats;
 }
 
+namespace shyft {
+    namespace api {
+        //-serialization of state to byte-array in python support
+        template <class CS>
+        std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<CS>>& states) {
+            using namespace std;
+            std::ostringstream xmls;
+            boost::archive::binary_oarchive oa(xmls);
+            oa << BOOST_SERIALIZATION_NVP(states);
+            xmls.flush();
+            auto s = xmls.str();
+            return std::vector<char>(s.begin(), s.end());
+        }
+        template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::hbv_stack::state>>>& states);// { return serialize_to_bytes_impl(states); }
+        template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_gs_k::state>>>& states);// { return serialize_to_bytes_impl(states); }
+        template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_ss_k::state>>>& states);// { return serialize_to_bytes_impl(states); }
+        template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_hs_k::state>>>& states);// { return serialize_to_bytes_impl(states); }
+
+        template <class CS>
+        void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<CS>>&states) {
+            using namespace std;
+            string str_bin(bytes.begin(), bytes.end());
+            istringstream xmli(str_bin);
+            boost::archive::binary_iarchive ia(xmli);
+            ia >> BOOST_SERIALIZATION_NVP(states);
+        }
+        template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::hbv_stack::state>>>&states);// { deserialize_from_bytes_impl(bytes, states); }
+        template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_gs_k::state>>>&states);// { deserialize_from_bytes_impl(bytes, states); }
+        template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_hs_k::state>>>&states);// { deserialize_from_bytes_impl(bytes, states); }
+        template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_ss_k::state>>>&states);// { deserialize_from_bytes_impl(bytes, states); }
+    }
+}

--- a/api/api_serialization.cpp
+++ b/api/api_serialization.cpp
@@ -156,7 +156,14 @@ void shyft::api::cell_state_id::serialize(Archive & ar, const unsigned int file_
     & make_nvp("a", area)
     ;
 }
-
+template <class CS>
+template <class Archive>
+void shyft::api::cell_state_with_id<CS>::serialize(Archive&ar, const unsigned int file_version) {
+    ar
+    & make_nvp("id", id)
+    & make_nvp("state", state)
+    ;
+}
 //
 // 3. force impl. of pointers etc.
 //
@@ -174,6 +181,11 @@ x_serialize_implement(shyft::api::abin_op_ts);
 x_serialize_implement(shyft::api::abin_op_ts_scalar);
 x_serialize_implement(shyft::api::apoint_ts);
 x_serialize_implement(shyft::api::cell_state_id);
+x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::hbv_stack::state>);
+x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::pt_gs_k::state>);
+x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::pt_ss_k::state>);
+x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::pt_hs_k::state>);
+
 //
 // 4. Then include the archive supported
 //
@@ -197,6 +209,11 @@ x_arch(shyft::api::abin_op_ts);
 x_arch(shyft::api::abin_op_ts_scalar);
 x_arch(shyft::api::apoint_ts);
 x_arch(shyft::api::cell_state_id);
+x_arch(shyft::api::cell_state_with_id<shyft::core::hbv_stack::state>);
+x_arch(shyft::api::cell_state_with_id<shyft::core::pt_gs_k::state>);
+x_arch(shyft::api::cell_state_with_id<shyft::core::pt_ss_k::state>);
+x_arch(shyft::api::cell_state_with_id<shyft::core::pt_hs_k::state>);
+
 
 std::string shyft::api::apoint_ts::serialize() const {
     using namespace std;

--- a/api/api_serialization.cpp
+++ b/api/api_serialization.cpp
@@ -10,7 +10,7 @@
 #include "core/timeseries.h"
 
 #include "timeseries.h"
-
+#include "api_state.h"
 // then include stuff you need like vector,shared, base_obj,nvp etc.
 
 #include <boost/serialization/vector.hpp>
@@ -147,6 +147,16 @@ void shyft::api::apoint_ts::serialize(Archive & ar, const unsigned int version) 
     ;
 }
 
+template<class Archive>
+void shyft::api::cell_state_id::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+    & make_nvp("cid", cid)
+    & make_nvp("x", x)
+    & make_nvp("y", y)
+    & make_nvp("a", area)
+    ;
+}
+
 //
 // 3. force impl. of pointers etc.
 //
@@ -163,7 +173,7 @@ x_serialize_implement(shyft::api::abin_op_scalar_ts);
 x_serialize_implement(shyft::api::abin_op_ts);
 x_serialize_implement(shyft::api::abin_op_ts_scalar);
 x_serialize_implement(shyft::api::apoint_ts);
-
+x_serialize_implement(shyft::api::cell_state_id);
 //
 // 4. Then include the archive supported
 //
@@ -186,6 +196,7 @@ x_arch(shyft::api::abin_op_scalar_ts);
 x_arch(shyft::api::abin_op_ts);
 x_arch(shyft::api::abin_op_ts_scalar);
 x_arch(shyft::api::apoint_ts);
+x_arch(shyft::api::cell_state_id);
 
 std::string shyft::api::apoint_ts::serialize() const {
     using namespace std;

--- a/api/api_state.h
+++ b/api/api_state.h
@@ -64,6 +64,17 @@ namespace shyft {
             x_serialize_decl();
         };
 
+        template <class CS> std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<CS>>& states);
+          extern template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::hbv_stack::state>>>& states);
+          extern template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_gs_k::state>>>& states);
+          extern template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_ss_k::state>>>& states);
+          extern template std::vector<char> serialize_to_bytes(const std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_hs_k::state>>>& states);
+        
+        template <class CS> void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<CS>>&states);
+          extern  template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::hbv_stack::state>>>&states);
+          extern  template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_gs_k::state>>>&states);
+          extern  template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_hs_k::state>>>&states);
+          extern  template void deserialize_from_bytes(const std::vector<char>& bytes, std::shared_ptr<std::vector<cell_state_with_id<shyft::core::pt_ss_k::state>>>&states);
         /** \brief state_io_handler for efficient handling of cell-identified states
         *
         * This class provides functionality to extract/apply state based on a

--- a/api/api_state.h
+++ b/api/api_state.h
@@ -50,6 +50,10 @@ namespace shyft {
             typedef typename C::state_t cell_state_t;
             cell_state_id id;
             cell_state_t state;
+            cell_state_with_id() {};
+            bool operator==(const cell_state_with_id o) const {
+                return id == o.id; // only id equality, for vector support in boost python
+            }
             /** do the magic given a cell, create the id, stash away the id:state*/
             cell_state_with_id(const C& c) :id(cell_state_id_of(c)), state(c.state) {}
         };
@@ -68,7 +72,7 @@ namespace shyft {
 
             state_io_handler() {}
             /** construct a handler for the cells provided*/
-            state_io_handler(std::shared_ptr<std::vector<C>>&cellx) :cells(cellx) {}
+            state_io_handler(std::shared_ptr<std::vector<C>> cellx) :cells(cellx) {}
 
             /** Extract cell identified state
             *\return the state for the cells, optionally filtered by the supplied catchment ids (cids)

--- a/api/api_state.h
+++ b/api/api_state.h
@@ -1,0 +1,114 @@
+#pragma once
+#include "core/core_pch.h"
+#include "core/geo_cell_data.h"
+#include "core/cell_model.h"
+
+namespace shyft {
+    namespace api {
+        /** \brief unique pseudo identifier of cell state
+        *
+        * A lot of Shyft models can appear in different geometries and
+        * resolutions. In a few rare cases we would like to store the *state* of
+        * a model. This would be typical for example for hydrological new-year 1-sept in Norway.
+        * To ensure that each cell-state have a unique identifier so that we never risk
+        * mixing state from different cells or different geometries, we create a pseudo unique
+        * id that helps identifying unique cell-states given this usage and context.
+        *
+        * The primary usage is to identify which cell a specific identified state belongs to.
+        *
+        */
+        struct cell_state_id {
+            int cid;///< the catchment id, if entirely different model, this might change
+            int x;///< the cell mid-point x (west-east), truncated to integer [meter]
+            int y;///< the cell mid-point y (south-north), truncated to integer [meter]
+            int area;///< the area in m[m2], - if different cell geometries, this changes
+            cell_state_id() = default; // python exposure
+            cell_state_id(int cid, int x, int y, int area) :cid(cid), x(x), y(y), area(area) {}
+            bool operator==(const cell_state_id & o) const {
+                return cid == o.cid && x == o.x && y == o.y && area == o.area;
+            }
+            bool operator<(const cell_state_id& o) const {
+                if (cid < o.cid) return true;
+                if (cid > o.cid) return false;
+                if (x < o.x)return true;
+                if (x > o.x)return false;
+                if (y < o.y) return true;
+                if (y > o.y) return false;
+                return area < o.area;
+            }
+            x_serialize_decl();
+        };
+        /** create the cell_state_id based on specified cell*/
+        template <class C>
+        inline cell_state_id cell_state_id_of(const C&c) {
+            return cell_state_id(c.geo.catchment_id(), (int)c.geo.mid_point().x, (int)c.geo.mid_point().y, (int)c.geo.area());
+        }
+
+        /** A cell state with a cell_state identifier */
+        template <class C>
+        struct cell_state_with_id {
+            typedef typename C::state_t cell_state_t;
+            cell_state_id id;
+            cell_state_t state;
+            /** do the magic given a cell, create the id, stash away the id:state*/
+            cell_state_with_id(const C& c) :id(cell_state_id_of(c)), state(c.state) {}
+        };
+
+        /** \brief state_io_handler for efficient handling of cell-identified states
+        *
+        * This class provides functionality to extract/apply state based on a
+        * pseudo unique id of each cell.
+        * A cell is identified by the integer portions of:
+        * catchment_id, mid_point.x,mid_point.y,area
+        */
+        template <class C>
+        struct state_io_handler {
+            typedef cell_state_with_id<C> cell_state_id_t;
+            std::shared_ptr<std::vector<C>> cells;// shared alias region model cells.
+
+            state_io_handler() {}
+            /** construct a handler for the cells provided*/
+            state_io_handler(std::shared_ptr<std::vector<C>>&cellx) :cells(cellx) {}
+
+            /** Extract cell identified state
+            *\return the state for the cells, optionally filtered by the supplied catchment ids (cids)
+            */
+            std::shared_ptr<std::vector<cell_state_id_t>> extract_state(const std::vector<int>& cids) const {
+                if (!cells)
+                    throw std::runtime_error("No cells to extract state from");
+                auto r = std::make_shared<std::vector<cell_state_id_t>>();
+                r->reserve(cells->size());
+                for (const auto &c : *cells)
+                    if (cids.size() == 0 || std::find(cids.begin(), cids.end(), c.geo.catchment_id()) != cids.end())
+                        r->emplace_back(c);// creates a a cell_state_with_id based on cell
+                return r;
+            }
+
+            /** Restore cell identified state, filtered by cids.
+            * \return a list identifying states that where not applied to cells(filtering out all that is related to non-matching cids)
+            */
+            std::vector<int> apply_state(std::shared_ptr < std::vector<cell_state_id_t> > s, const std::vector<int>& cids) {
+                if (!cells)
+                    throw std::runtime_error("No cells to apply state into");
+                std::map<cell_state_id, C*> cmap;// yes store pointers, we know the scope is this routine
+                for (auto& c : *cells) {
+                    if (cids.size() == 0 || std::find(cids.begin(), cids.end(), c.geo.catchment_id()) != cids.end())
+                        cmap[cell_state_id_of(c)] = &c;// fix the map
+                }
+                std::vector<int> missing;
+                for (size_t i = 0;i < s->size();++i) {
+                    if (cids.size() == 0 || std::find(cids.begin(), cids.end(), (*s)[i].id.cid) != cids.end()) {
+                        auto f = cmap.find((*s)[i].id);// log(n)
+                        if (f != cmap.end())
+                            f->second->state = (*s)[i].state;
+                        else
+                            missing.push_back(i);
+                    }
+                }
+                return missing;
+            }
+        };
+    }
+}
+//-- serialization support shyft
+x_serialize_export_key(shyft::api::cell_state_id);

--- a/api/boostpython/api.cpp
+++ b/api/boostpython/api.cpp
@@ -28,6 +28,7 @@ namespace expose {
 	extern void hbv_actual_evapotranspiration();
 	extern void glacier_melt();
 	extern void routing();
+    extern void api_cell_state_id();
 
     void api() {
         calendar_and_time();
@@ -53,6 +54,7 @@ namespace expose {
 		hbv_actual_evapotranspiration();
 		glacier_melt();
 		routing();
+        api_cell_state_id();
     }
 }
 

--- a/api/boostpython/api.cpp
+++ b/api/boostpython/api.cpp
@@ -29,6 +29,32 @@ namespace expose {
 	extern void glacier_melt();
 	extern void routing();
     extern void api_cell_state_id();
+    
+    static std::vector<char> byte_vector_from_file(std::string path) {
+        using namespace std;
+        ostringstream buf;
+        ifstream input;
+        input.open(path.c_str(),ios::in|ios::binary);
+        if (input.is_open()) {
+            buf << input.rdbuf();
+            auto s = buf.str();
+            return std::vector<char>(begin(s), end(s));
+        } else
+            throw runtime_error(string("failed to open file for read:") + path);
+    }
+
+    static void byte_vector_to_file(std::string path, const std::vector<char>&bytes) {
+        using namespace std;
+        ofstream out;
+        out.open(path, ios::out | ios::binary | ios::trunc);
+        if (out.is_open()) {
+            out.write(bytes.data(), bytes.size());
+            out.flush();
+            out.close();
+        } else {
+            throw runtime_error(string("failed to open file for write:") + path);
+        }
+    }
 
     void api() {
         calendar_and_time();
@@ -55,6 +81,9 @@ namespace expose {
 		glacier_melt();
 		routing();
         api_cell_state_id();
+        using namespace boost::python;
+        def("byte_vector_from_file", byte_vector_from_file, (arg("path")), "reads specified file and returns its contents as a ByteVector");
+        def("byte_vector_to_file", byte_vector_to_file, (arg("path"), arg("byte_vector")), "write the supplied ByteVector to file as specified by path");
     }
 }
 

--- a/api/boostpython/api_state.cpp
+++ b/api/boostpython/api_state.cpp
@@ -25,6 +25,7 @@ namespace expose {
             .def_readwrite("x", &cell_state_id::x, "x position in [m]")
             .def_readwrite("y", &cell_state_id::y, "y position in [m]")
             .def_readwrite("area", &cell_state_id::area, "area in [m^2]")
+            .def(self==self)
             ;
 
     }

--- a/api/boostpython/api_state.cpp
+++ b/api/boostpython/api_state.cpp
@@ -1,6 +1,6 @@
 #include "boostpython_pch.h"
 
-#include "api_state.h"
+#include "api/api_state.h"
 namespace expose {
     using namespace shyft::api;
     using namespace boost::python;

--- a/api/boostpython/api_state.cpp
+++ b/api/boostpython/api_state.cpp
@@ -1,0 +1,31 @@
+#include "boostpython_pch.h"
+
+#include "api_state.h"
+namespace expose {
+    using namespace shyft::api;
+    using namespace boost::python;
+    using namespace std;
+
+    void api_cell_state_id() {
+        class_<cell_state_id>("CellStateId",
+            "Unique cell pseudo identifier of  a state\n"
+            "\n"
+            "A lot of Shyft models can appear in different geometries and\n"
+            "resolutions.In a few rare cases we would like to store the *state* of\n"
+            "a model.This would be typical for example for hydrological new - year 1 - sept in Norway.\n"
+            "To ensure that each cell - state have a unique identifier so that we never risk\n"
+            "mixing state from different cells or different geometries, we create a pseudo unique\n"
+            "id that helps identifying unique cell - states given this usage and context.\n"
+            "\n"
+            "The primary usage is to identify which cell a specific identified state belongs to.\n"
+
+            )
+            .def(init<int, int, int, int>(args("cid", "x", "y", "area"), "construct CellStateId with specified parameters"))
+            .def_readwrite("cid", &cell_state_id::cid, "catchment identifier")
+            .def_readwrite("x", &cell_state_id::x, "x position in [m]")
+            .def_readwrite("y", &cell_state_id::y, "y position in [m]")
+            .def_readwrite("area", &cell_state_id::area, "area in [m^2]")
+            ;
+
+    }
+}

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -41,12 +41,13 @@ namespace expose {
     
     template<class C>
     static void cell_state_etc(const char *stack_name) {
-        typedef shyft::api::cell_state_with_id<C> CellState;
+        typedef typename C::state_t cstate_t;
+        typedef typename shyft::api::cell_state_with_id<cstate_t> CellState;
         char cs_name[200];sprintf(cs_name, "%sStateWithId", stack_name);
         class_<CellState>(cs_name, "Keep the cell id and cell state")
-            .def_readwrite("id", &CellState::id, "the cell identifer for the state")
+            .def_readwrite("id", &CellState::id, "the cell identifier for the state")
             .def_readwrite("state", &CellState::state, "the cell state")
-            .def("cell_state", &shyft::api::cell_state_id_of<C>, args("cell"), "create a cell state with id for the supplied cell")
+            .def("cell_state", &shyft::api::cell_state_id_of, args("geo_cell_data"), "create a cell state with id for the supplied cell.geo")
             .staticmethod("cell_state")
             ;
         char csv_name[200];sprintf(csv_name, "%sVector", cs_name);

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -53,7 +53,10 @@ namespace expose {
         char csv_name[200];sprintf(csv_name, "%sVector", cs_name);
         class_<std::vector<CellState>, bases<>, std::shared_ptr<std::vector<CellState>> >(csv_name, "vector of cell state")
             .def(vector_indexing_suite<std::vector<CellState>>())
+            
             ;
+        def("serialize", shyft::api::serialize_to_bytes<CellState>, args("states"), "make a blob out of the states");
+        def("deserialize", shyft::api::deserialize_from_bytes<CellState>, args("bytes", "states"), "from a blob, fill in states");
     }
 
     template <class C>

--- a/api/boostpython/hbv_stack.cpp
+++ b/api/boostpython/hbv_stack.cpp
@@ -123,6 +123,7 @@ namespace expose {
 			expose::statistics::hbv_actual_evapotranspiration<HbvCellAll>("HbvCell");
 			expose::statistics::hbv_soil<HbvCellAll>("HbvCell");
 			expose::statistics::hbv_tank<HbvCellAll>("HbvCell");
+            expose::cell_state_etc<HbvCellAll>("Hbv");// just one expose of state
 		}
 
 		static void

--- a/api/boostpython/pt_gs_k.cpp
+++ b/api/boostpython/pt_gs_k.cpp
@@ -150,11 +150,6 @@ namespace expose {
         model_calibrator() {
             expose::model_calibrator<shyft::core::region_model<pt_gs_k::cell_discharge_response_t,shyft::api::a_region_environment>>("PTGSKOptimizer");
         }
-        static void
-            state_with_id() {
-            //todo
-        }
-
     }
 }
 

--- a/api/boostpython/pt_gs_k.cpp
+++ b/api/boostpython/pt_gs_k.cpp
@@ -128,6 +128,8 @@ namespace expose {
               expose::statistics::actual_evapotranspiration<PTGSKCellAll>("PTGSKCell");
               expose::statistics::priestley_taylor<PTGSKCellAll>("PTGSKCell");
               expose::statistics::kirchner<PTGSKCellAll>("PTGSKCell");
+              expose::cell_state_etc<PTGSKCellAll>("PTGSK");// just one expose of state
+
         }
 
         static void
@@ -147,6 +149,10 @@ namespace expose {
         static void
         model_calibrator() {
             expose::model_calibrator<shyft::core::region_model<pt_gs_k::cell_discharge_response_t,shyft::api::a_region_environment>>("PTGSKOptimizer");
+        }
+        static void
+            state_with_id() {
+            //todo
         }
 
     }

--- a/api/boostpython/pt_hs_k.cpp
+++ b/api/boostpython/pt_hs_k.cpp
@@ -118,6 +118,7 @@ namespace expose {
               expose::statistics::actual_evapotranspiration<PTHSKCellAll>("PTHSKCell");
               expose::statistics::priestley_taylor<PTHSKCellAll>("PTHSKCell");
               expose::statistics::kirchner<PTHSKCellAll>("PTHSKCell");
+              expose::cell_state_etc<PTHSKCellAll>("PTHSK");// just one expose of state
         }
 
         static void

--- a/api/boostpython/pt_ss_k.cpp
+++ b/api/boostpython/pt_ss_k.cpp
@@ -126,6 +126,7 @@ namespace expose {
               expose::statistics::actual_evapotranspiration<PTSSKCellAll>("PTSSKCell");
               expose::statistics::priestley_taylor<PTSSKCellAll>("PTSSKCell");
               expose::statistics::kirchner<PTSSKCellAll>("PTSSKCell");
+              expose::cell_state_etc<PTSSKCellAll>("PTSSK");// just one expose of state
         }
 
         static void

--- a/api/python/api.python.vcxproj
+++ b/api/python/api.python.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\boostpython\api_region_environment.cpp" />
     <ClCompile Include="..\boostpython\api_routing.cpp" />
     <ClCompile Include="..\boostpython\api_skaugen.cpp" />
+    <ClCompile Include="..\boostpython\api_state.cpp" />
     <ClCompile Include="..\boostpython\api_target_specification.cpp" />
     <ClCompile Include="..\boostpython\api_time_axis.cpp" />
     <ClCompile Include="..\boostpython\api_time_series.cpp" />

--- a/core/core_serialization.cpp
+++ b/core/core_serialization.cpp
@@ -9,6 +9,16 @@
 #include "time_axis.h"
 #include "timeseries.h"
 #include "geo_cell_data.h"
+#include "hbv_snow.h"
+#include "hbv_soil.h"
+#include "hbv_tank.h"
+#include "gamma_snow.h"
+#include "kirchner.h"
+#include "skaugen.h"
+#include "hbv_stack.h"
+#include "pt_gs_k.h"
+#include "pt_ss_k.h"
+#include "pt_hs_k.h"
 
 // then include stuff you need like vector,shared, base_obj,nvp etc.
 
@@ -250,6 +260,87 @@ void shyft::core::geo_cell_data::serialize(Archive& ar, const unsigned int versi
     & make_nvp("routing",routing)
     ;
 }
+//-- state serialization
+template <class Archive>
+void shyft::core::hbv_snow::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+    & make_nvp("swe",swe)
+    & make_nvp("sca",sca)
+    ;
+}
+template <class Archive>
+void shyft::core::hbv_soil::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+    & make_nvp("sm",sm)
+    ;
+}
+template <class Archive>
+void shyft::core::hbv_tank::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+    & make_nvp("uz",uz)
+    & make_nvp("lz",lz)
+    ;
+}
+template <class Archive>
+void shyft::core::kirchner::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("q",q)
+        ;
+}
+template <class Archive>
+void shyft::core::gamma_snow::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("albedo", albedo)
+        & make_nvp("lwc", lwc)
+        & make_nvp("surface_heat",surface_heat )
+        & make_nvp("alpha", alpha)
+        & make_nvp("sdc_melt_mean",sdc_melt_mean )
+        & make_nvp("acc_melt",acc_melt )
+        & make_nvp("iso_pot_energy", iso_pot_energy)
+        & make_nvp("temp_swe",temp_swe )
+        ;
+}
+template <class Archive>
+void shyft::core::skaugen::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("nu",nu)
+        & make_nvp("alpha",alpha)
+        & make_nvp("sca",sca)
+        & make_nvp("swe",swe)
+        & make_nvp("free_water",free_water)
+        & make_nvp("residual",residual)
+        & make_nvp("num_units",num_units)
+        ;
+}
+template <class Archive>
+void shyft::core::hbv_stack::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("snow",snow)
+        & make_nvp("soil",soil)
+        & make_nvp("tank",tank)
+        ;
+}
+template <class Archive>
+void shyft::core::pt_gs_k::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("gs",gs)
+        & make_nvp("kirchner",kirchner)
+        ;
+}
+template <class Archive>
+void shyft::core::pt_ss_k::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("snow",snow)
+        & make_nvp("kirchner", kirchner)
+        ;
+}
+template <class Archive>
+void shyft::core::pt_hs_k::state::serialize(Archive & ar, const unsigned int file_version) {
+    ar
+        & make_nvp("snow",snow)
+        & make_nvp("kirchner", kirchner)
+        ;
+}
 
 //-- export geo stuff
 x_serialize_implement(shyft::core::geo_point);
@@ -296,6 +387,19 @@ x_serialize_implement(shyft::timeseries::periodic_ts<shyft::time_axis::calendar_
 x_serialize_implement(shyft::timeseries::periodic_ts<shyft::time_axis::point_dt>);
 x_serialize_implement(shyft::timeseries::periodic_ts<shyft::time_axis::generic_dt>);
 
+//-- export method and method-stack state
+x_serialize_implement(shyft::core::hbv_snow::state);
+x_serialize_implement(shyft::core::hbv_soil::state);
+x_serialize_implement(shyft::core::hbv_tank::state);
+x_serialize_implement(shyft::core::gamma_snow::state);
+x_serialize_implement(shyft::core::skaugen::state);
+x_serialize_implement(shyft::core::kirchner::state);
+
+x_serialize_implement(shyft::core::pt_gs_k::state);
+x_serialize_implement(shyft::core::pt_hs_k::state);
+x_serialize_implement(shyft::core::pt_ss_k::state);
+x_serialize_implement(shyft::core::hbv_stack::state);
+
 //
 // 4. Then include the archive supported
 //
@@ -341,3 +445,15 @@ x_arch(shyft::core::geo_point);
 x_arch(shyft::core::land_type_fractions);
 x_arch(shyft::core::routing_info);
 x_arch(shyft::core::geo_cell_data);
+
+x_arch(shyft::core::hbv_snow::state);
+x_arch(shyft::core::hbv_soil::state);
+x_arch(shyft::core::hbv_tank::state);
+x_arch(shyft::core::gamma_snow::state);
+x_arch(shyft::core::skaugen::state);
+x_arch(shyft::core::kirchner::state);
+
+x_arch(shyft::core::pt_gs_k::state);
+x_arch(shyft::core::pt_hs_k::state);
+x_arch(shyft::core::pt_ss_k::state);
+x_arch(shyft::core::hbv_stack::state);

--- a/core/gamma_snow.h
+++ b/core/gamma_snow.h
@@ -110,6 +110,7 @@ namespace shyft {
                         && fabs(temp_swe - x.temp_swe)<eps;
 
                 }
+                x_serialize_decl();
             };
 
 
@@ -477,3 +478,5 @@ namespace shyft {
         }
     } // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::gamma_snow::state);

--- a/core/hbv_snow.h
+++ b/core/hbv_snow.h
@@ -102,6 +102,7 @@ namespace shyft {
                     const double eps=1e-6;
                     return fabs(swe-x.swe)<eps && fabs(sca-x.sca)<eps;
                 }
+                x_serialize_decl();
             };
             struct response {
                 double outflow = 0.0;
@@ -293,3 +294,5 @@ namespace shyft {
         }
     } // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::hbv_snow::state);

--- a/core/hbv_soil.h
+++ b/core/hbv_soil.h
@@ -22,6 +22,7 @@ namespace shyft {
 					const double eps = 1e-6;
 					return fabs(sm - x.sm)<eps;
 				}
+                x_serialize_decl();
 			};
 
 			struct response {
@@ -52,3 +53,5 @@ namespace shyft {
 		}
 	} // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::hbv_soil::state);

--- a/core/hbv_stack.h
+++ b/core/hbv_stack.h
@@ -165,7 +165,8 @@ namespace shyft {
 				soil_state_t soil;
 				tank_state_t tank;
 				bool operator==(const state& x) const { return snow == x.snow && tank == x.tank && soil == x.soil; }
-			};
+                x_serialize_decl();
+            };
 
 
 			/** \brief Simple response struct for the hbv_stack method stack
@@ -322,3 +323,5 @@ namespace shyft {
 		} // hbv_stack
 	} // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::hbv_stack::state);

--- a/core/hbv_tank.h
+++ b/core/hbv_tank.h
@@ -31,6 +31,7 @@ namespace shyft {
 					else
 						return false;
 				}
+                x_serialize_decl();
 			};
 
 			struct response {
@@ -66,3 +67,5 @@ namespace shyft {
 		}
 	} // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::hbv_tank::state);

--- a/core/kirchner.h
+++ b/core/kirchner.h
@@ -126,6 +126,7 @@ namespace shyft {
                     const double eps=1e-6;
                     return fabs(q-x.q)<eps;
                 }
+                x_serialize_decl();
             };
 
 
@@ -227,5 +228,6 @@ namespace shyft {
         } // End namespace kirchner
     };
 };
-
+//-- serialization support shyft
+x_serialize_export_key(shyft::core::kirchner::state);
 /* vim: set filetype=cpp: */

--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -183,6 +183,7 @@ namespace shyft {
             gs_state_t gs;
             kirchner_state_t kirchner;
             bool operator==(const state& x) const {return gs==x.gs && kirchner==x.kirchner;}
+            x_serialize_decl();
         };
 
 
@@ -336,3 +337,5 @@ namespace shyft {
     } // pt_gs_k
   } // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::pt_gs_k::state);

--- a/core/pt_hs_k.h
+++ b/core/pt_hs_k.h
@@ -135,6 +135,7 @@ namespace shyft {
              : snow(snow), kirchner(kirchner) { /* Do nothing */ }
             state(const state& state) : snow(state.snow), kirchner(state.kirchner) {}
             bool operator==(const state& x) const {return snow==x.snow && kirchner==x.kirchner;}
+            x_serialize_decl();
         };
 
         struct response {
@@ -228,3 +229,5 @@ namespace shyft {
     }
   } // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::pt_hs_k::state);

--- a/core/pt_ss_k.h
+++ b/core/pt_ss_k.h
@@ -138,6 +138,7 @@ namespace shyft {
              : snow(snow), kirchner(kirchner) { /* Do nothing */ }
             state(const state& state) : snow(state.snow), kirchner(state.kirchner) {}
             bool operator==(const state& x) const {return kirchner==x.kirchner && snow==x.snow;}
+            x_serialize_decl();
         };
 
 
@@ -230,3 +231,5 @@ namespace shyft {
     }
   }
 }
+//-- serialization support shyft
+x_serialize_export_key(shyft::core::pt_ss_k::state);

--- a/core/skaugen.h
+++ b/core/skaugen.h
@@ -120,6 +120,7 @@ namespace shyft {
 
 
                 }
+                x_serialize_decl();
             };
 
 
@@ -378,3 +379,5 @@ namespace shyft {
        } // skaugen
     } // core
 } // shyft
+  //-- serialization support shyft
+x_serialize_export_key(shyft::core::skaugen::state);

--- a/shyft/api/hbv_stack/__init__.py
+++ b/shyft/api/hbv_stack/__init__.py
@@ -7,6 +7,8 @@ HbvModel.cell_t = HbvCellAll
 HbvParameter.map_t = HbvParameterMap
 HbvModel.parameter_t = HbvParameter
 HbvModel.state_t = HbvState
+HbvModel.state_with_id_t = HbvStateWithId
+HbvModel.state = property(lambda self:HbvCellAllStateHandler(self.get_cells()))
 HbvModel.statistics = property(lambda self: HbvCellAllStatistics(self.get_cells()))
 HbvModel.hbv_snow_state = property(lambda self: HbvCellHBVSnowStateStatistics(self.get_cells()))
 HbvModel.hbv_snow_response = property(lambda self: HbvCellHBVSnowResponseStatistics(self.get_cells()))
@@ -14,11 +16,15 @@ HbvModel.priestley_taylor_response = property(lambda self: HbvCellPriestleyTaylo
 HbvModel.hbv_actual_evaptranspiration_response=property(lambda self: HbvCellHbvActualEvapotranspirationResponseStatistics(self.get_cells()))
 HbvModel.soil_state = property(lambda self: HbvCellSoilStateStatistics(self.get_cells()))
 HbvModel.tank_state = property(lambda self: HbvCellTankStateStatistics(self.get_cells()))
+
 HbvOptModel.cell_t = HbvCellOpt
 HbvOptModel.parameter_t = HbvParameter
 HbvOptModel.state_t = HbvState
+HbvOptModel.state_with_id_t=HbvStateWithId
+HbvOptModel.state = property(lambda self:HbvCellOptStateHandler(self.get_cells()))
 HbvOptModel.statistics = property(lambda self:HbvCellOptStatistics(self.get_cells()))
 HbvOptModel.optimizer_t = HbvOptimizer
+
 HbvCellAll.vector_t = HbvCellAllVector
 HbvCellOpt.vector_t = HbvCellOptVector
 HbvState.vector_t = HbvStateVector

--- a/shyft/api/hbv_stack/__init__.py
+++ b/shyft/api/hbv_stack/__init__.py
@@ -30,3 +30,17 @@ HbvCellOpt.vector_t = HbvCellOptVector
 HbvState.vector_t = HbvStateVector
 HbvState.serializer_t= HbvStateIo
 
+#decorate StateWithId for serialization support
+def serialize_to_bytes(state_with_id_vector):
+    if not isinstance(state_with_id_vector,HbvStateWithIdVector):
+        raise RuntimeError("supplied argument must be of type HbvStateWithIdVector")
+    return serialize(state_with_id_vector)
+
+HbvStateWithIdVector.serialize_to_bytes = lambda self: serialize_to_bytes(self)
+
+def deserialize_from_bytes(bytes):
+    if not isinstance(bytes,ByteVector):
+        raise RuntimeError("Supplied type must be a ByteVector, as created from serialize_to_bytes")
+    states=HbvStateWithIdVector()
+    deserialize(bytes,states)
+    return states

--- a/shyft/api/pt_gs_k/__init__.py
+++ b/shyft/api/pt_gs_k/__init__.py
@@ -1,4 +1,5 @@
 from ._pt_gs_k import *
+from .. import ByteVector
 # Fix up types that we need attached to the model
 PTGSKStateVector.push_back = lambda self, x: self.append(x)
 PTGSKStateVector.size = lambda self: len(self)
@@ -31,3 +32,18 @@ PTGSKCellAll.vector_t = PTGSKCellAllVector
 PTGSKCellOpt.vector_t = PTGSKCellOptVector
 PTGSKState.vector_t = PTGSKStateVector
 PTGSKState.serializer_t= PTGSKStateIo
+
+#decorate StateWithId for serialization support
+def serialize_to_bytes(state_with_id_vector):
+    if not isinstance(state_with_id_vector,PTGSKStateWithIdVector):
+        raise RuntimeError("supplied argument must be of type PTGSKStateWithIdVector")
+    return serialize(state_with_id_vector)
+
+PTGSKStateWithIdVector.serialize_to_bytes = lambda self: serialize_to_bytes(self)
+
+def deserialize_from_bytes(bytes):
+    if not isinstance(bytes,ByteVector):
+        raise RuntimeError("Supplied type must be a ByteVector, as created from serialize_to_bytes")
+    states=PTGSKStateWithIdVector()
+    deserialize(bytes,states)
+    return states

--- a/shyft/api/pt_gs_k/__init__.py
+++ b/shyft/api/pt_gs_k/__init__.py
@@ -8,17 +8,25 @@ PTGSKModel.cell_t = PTGSKCellAll
 PTGSKParameter.map_t = PTGSKParameterMap
 PTGSKModel.parameter_t = PTGSKParameter
 PTGSKModel.state_t = PTGSKState
+PTGSKModel.state_with_id_t = PTGSKStateWithId
+PTGSKModel.state = property(lambda self:PTGSKCellAllStateHandler(self.get_cells()))
 PTGSKModel.statistics = property(lambda self: PTGSKCellAllStatistics(self.get_cells()))
+
 PTGSKModel.gamma_snow_state = property(lambda self: PTGSKCellGammaSnowStateStatistics(self.get_cells()))
 PTGSKModel.gamma_snow_response = property(lambda self: PTGSKCellGammaSnowResponseStatistics(self.get_cells()))
 PTGSKModel.priestley_taylor_response = property(lambda self: PTGSKCellPriestleyTaylorResponseStatistics(self.get_cells()))
 PTGSKModel.actual_evaptranspiration_response=property(lambda self: PTGSKCellActualEvapotranspirationResponseStatistics(self.get_cells()))
 PTGSKModel.kirchner_state = property(lambda self: PTGSKCellKirchnerStateStatistics(self.get_cells()))
+
 PTGSKOptModel.cell_t = PTGSKCellOpt
 PTGSKOptModel.parameter_t = PTGSKParameter
 PTGSKOptModel.state_t = PTGSKState
+PTGSKOptModel.state_with_id_t = PTGSKStateWithId
+PTGSKOptModel.state = property(lambda self:PTGSKCellOptStateHandler(self.get_cells()))
 PTGSKOptModel.statistics = property(lambda self:PTGSKCellOptStatistics(self.get_cells()))
+
 PTGSKOptModel.optimizer_t = PTGSKOptimizer
+
 PTGSKCellAll.vector_t = PTGSKCellAllVector
 PTGSKCellOpt.vector_t = PTGSKCellOptVector
 PTGSKState.vector_t = PTGSKStateVector

--- a/shyft/api/pt_hs_k/__init__.py
+++ b/shyft/api/pt_hs_k/__init__.py
@@ -7,16 +7,23 @@ PTHSKModel.cell_t = PTHSKCellAll
 PTHSKParameter.map_t = PTHSKParameterMap
 PTHSKModel.parameter_t = PTHSKParameter
 PTHSKModel.state_t = PTHSKState
+PTHSKModel.state_with_id_t = PTHSKStateWithId
+PTHSKModel.state = property(lambda self:PTHSKCellAllStateHandler(self.get_cells()))
 PTHSKModel.statistics = property(lambda self: PTHSKCellAllStatistics(self.get_cells()))
+
 PTHSKModel.hbv_snow_state = property(lambda self: PTHSKCellHBVSnowStateStatistics(self.get_cells()))
 PTHSKModel.hbv_snow_response = property(lambda self: PTHSKCellHBVSnowResponseStatistics(self.get_cells()))
 PTHSKModel.priestley_taylor_response = property(lambda self: PTHSKCellPriestleyTaylorResponseStatistics(self.get_cells()))
 PTHSKModel.actual_evaptranspiration_response=property(lambda self: PTHSKCellActualEvapotranspirationResponseStatistics(self.get_cells()))
 PTHSKModel.kirchner_state = property(lambda self: PTHSKCellKirchnerStateStatistics(self.get_cells()))
+
 PTHSKOptModel.cell_t = PTHSKCellOpt
 PTHSKOptModel.parameter_t = PTHSKParameter
 PTHSKOptModel.state_t = PTHSKState
+PTHSKOptModel.state_with_id_t = PTHSKStateWithId
+PTHSKOptModel.state = property(lambda self:PTHSKCellOptStateHandler(self.get_cells()))
 PTHSKOptModel.statistics = property(lambda self:PTHSKCellOptStatistics(self.get_cells()))
+
 PTHSKOptModel.optimizer_t = PTHSKOptimizer
 PTHSKCellAll.vector_t = PTHSKCellAllVector
 PTHSKCellOpt.vector_t = PTHSKCellOptVector

--- a/shyft/api/pt_hs_k/__init__.py
+++ b/shyft/api/pt_hs_k/__init__.py
@@ -30,3 +30,17 @@ PTHSKCellOpt.vector_t = PTHSKCellOptVector
 PTHSKState.vector_t = PTHSKStateVector
 PTHSKState.serializer_t= PTHSKStateIo
 
+#decorate StateWithId for serialization support
+def serialize_to_bytes(state_with_id_vector):
+    if not isinstance(state_with_id_vector,PTHSKStateWithIdVector):
+        raise RuntimeError("supplied argument must be of type PTHSKStateWithIdVector")
+    return serialize(state_with_id_vector)
+
+PTHSKStateWithIdVector.serialize_to_bytes = lambda self: serialize_to_bytes(self)
+
+def deserialize_from_bytes(bytes):
+    if not isinstance(bytes,ByteVector):
+        raise RuntimeError("Supplied type must be a ByteVector, as created from serialize_to_bytes")
+    states=PTHSKStateWithIdVector()
+    deserialize(bytes,states)
+    return states

--- a/shyft/api/pt_ss_k/__init__.py
+++ b/shyft/api/pt_ss_k/__init__.py
@@ -31,3 +31,18 @@ PTSSKCellOpt.vector_t = PTSSKCellOptVector
 PTSSKState.vector_t = PTSSKStateVector
 PTSSKState.serializer_t= PTSSKStateIo
 PTSSKStateVector.push_back = lambda self, x: self.append(x)
+
+#decorate StateWithId for serialization support
+def serialize_to_bytes(state_with_id_vector):
+    if not isinstance(state_with_id_vector,PTSSKStateWithIdVector):
+        raise RuntimeError("supplied argument must be of type PTSSKStateWithIdVector")
+    return serialize(state_with_id_vector)
+
+PTSSKStateWithIdVector.serialize_to_bytes = lambda self: serialize_to_bytes(self)
+
+def deserialize_from_bytes(bytes):
+    if not isinstance(bytes,ByteVector):
+        raise RuntimeError("Supplied type must be a ByteVector, as created from serialize_to_bytes")
+    states=PTSSKStateWithIdVector()
+    deserialize(bytes,states)
+    return states

--- a/shyft/api/pt_ss_k/__init__.py
+++ b/shyft/api/pt_ss_k/__init__.py
@@ -8,16 +8,23 @@ PTSSKModel.cell_t = PTSSKCellAll
 PTSSKParameter.map_t = PTSSKParameterMap
 PTSSKModel.parameter_t = PTSSKParameter
 PTSSKModel.state_t = PTSSKState
+PTSSKModel.state_with_id_t = PTSSKStateWithId
+PTSSKModel.state = property(lambda self:PTSSKCellAllStateHandler(self.get_cells()))
 PTSSKModel.statistics = property(lambda self: PTSSKCellAllStatistics(self.get_cells()))
+
 PTSSKModel.gamma_snow_state = property(lambda self: PTSSKCellGammaSnowStateStatistics(self.get_cells()))
 PTSSKModel.gamma_snow_response = property(lambda self: PTSSKCellGammaSnowResponseStatistics(self.get_cells()))
 PTSSKModel.priestley_taylor_response = property(lambda self: PTSSKCellPriestleyTaylorResponseStatistics(self.get_cells()))
 PTSSKModel.actual_evaptranspiration_response=property(lambda self: PTSSKCellActualEvapotranspirationResponseStatistics(self.get_cells()))
 PTSSKModel.kirchner_state = property(lambda self: PTSSKCellKirchnerStateStatistics(self.get_cells()))
+
 PTSSKOptModel.cell_t = PTSSKCellOpt
 PTSSKOptModel.parameter_t = PTSSKParameter
 PTSSKOptModel.state_t = PTSSKState
+PTSSKOptModel.state_with_id_t = PTSSKStateWithId
+PTSSKOptModel.state = property(lambda self:PTSSKCellOptStateHandler(self.get_cells()))
 PTSSKOptModel.statistics = property(lambda self:PTSSKCellOptStatistics(self.get_cells()))
+
 PTSSKOptModel.optimizer_t = PTSSKOptimizer
 PTSSKCellAll.vector_t = PTSSKCellAllVector
 PTSSKCellOpt.vector_t = PTSSKCellOptVector

--- a/shyft/tests/api/test_api_cell_state_id.py
+++ b/shyft/tests/api/test_api_cell_state_id.py
@@ -1,0 +1,12 @@
+from shyft.api import CellStateId
+import unittest
+
+
+class VerifyCellStateId(unittest.TestCase):
+
+    def test_cell_state_id(self):
+        a=CellStateId()
+        self.assertEqual(a.cid,0)
+        self.assertEqual(a.x,0)
+        self.assertEqual(a.y,0)
+        self.assertEqual(a.area,0)

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -11,6 +11,7 @@
 #include "api/pt_gs_k.h"
 #include "api/pt_ss_k.h"
 #include "api/pt_hs_k.h"
+#include "api/api_state.h"
 
 using namespace std;
 using namespace shyft::core;
@@ -130,4 +131,53 @@ void api_test::test_geo_cell_data_io() {
     TS_ASSERT_DELTA(gcd2.land_type_fractions_info().reservoir(),gcd.land_type_fractions_info().reservoir(),eps);
     TS_ASSERT_DELTA(gcd2.land_type_fractions_info().forest(),gcd.land_type_fractions_info().forest(),eps);
     TS_ASSERT_DELTA(gcd2.land_type_fractions_info().unspecified(),gcd.land_type_fractions_info().unspecified(),eps);
+}
+
+
+
+/** Here we try to build a test-story from start to end that covers state-io-extract-restore*/
+void api_test::test_state_with_id_functionality() {
+    typedef shyft::core::pt_gs_k::cell_discharge_response_t xcell_t;
+    cell_state_id a{ 1,2,3,10 };
+    cell_state_id b{ 1,2,4,20 };
+    cell_state_id c{ 2,2,4,20 };
+    TS_ASSERT_DIFFERS(a, b);
+    std::map<cell_state_id, int> smap;
+    smap[a] = a.area;
+    smap[b] = b.area;
+    TS_ASSERT_EQUALS(smap.find(c), smap.end());
+    TS_ASSERT_DIFFERS(smap.find(a), smap.end());
+    // ------------------------------- (x,y,z),area,cid)
+    xcell_t c1{ geo_cell_data(geo_point(1,1,1),  10,  1) };c1.state.kirchner.q = 1.1;
+    xcell_t c2{ geo_cell_data(geo_point(1,2,1),  10,  1) };c2.state.kirchner.q = 1.2;
+    xcell_t c3{ geo_cell_data(geo_point(2,1,1),  10,  2) };c3.state.kirchner.q = 2.1;
+    xcell_t c4{ geo_cell_data(geo_point(2,2,1),  10,  2) };c4.state.kirchner.q = 2.2;
+    auto cv = make_shared<vector<xcell_t>>();
+    cv->push_back(c1);
+    cv->push_back(c2);
+    cv->push_back(c3);
+    cv->push_back(c4);
+    state_io_handler<xcell_t> xh(cv);
+    auto s0 = xh.extract_state(vector<int>());
+    TS_ASSERT_EQUALS(s0->size(), cv->size());
+    for (size_t i = 0;i < cv->size();++i)
+        TS_ASSERT_EQUALS((*s0)[i].id, cell_state_id_of((*cv)[i]));// ensure we got correct id's out.
+
+    auto s1 = xh.extract_state(vector<int>{2}); // ok, now specify cids, 2, only two cells match
+    TS_ASSERT_EQUALS(s1->size(), 2);
+    for (size_t i = 0;i < s1->size();++i)
+        TS_ASSERT_EQUALS((*s1)[i].id, cell_state_id_of((*cv)[i+2]));// ensure we got correct id's out.
+
+    auto s_missing = xh.extract_state(vector<int>{3});
+    TS_ASSERT_EQUALS(s_missing->size(), 0);
+
+    auto m0 = xh.apply_state(s0, vector<int>());
+    TS_ASSERT_EQUALS(m0.size(), 0);
+
+    auto m0_x = xh.apply_state(s0, vector<int>{4});
+    TS_ASSERT_EQUALS(m0_x.size(), 0); // because we passed in states not containing 4
+    (*s0)[0].id.cid = 4; //stuff in a 4, and get one missing below
+    auto m0_y = xh.apply_state(s0, vector<int>{4});
+    TS_ASSERT_EQUALS(m0_y.size(), 1);
+    TS_ASSERT_EQUALS(m0_y[0], 0);
 }

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -161,12 +161,12 @@ void api_test::test_state_with_id_functionality() {
     auto s0 = xh.extract_state(vector<int>());
     TS_ASSERT_EQUALS(s0->size(), cv->size());
     for (size_t i = 0;i < cv->size();++i)
-        TS_ASSERT_EQUALS((*s0)[i].id, cell_state_id_of((*cv)[i]));// ensure we got correct id's out.
+        TS_ASSERT_EQUALS((*s0)[i].id, cell_state_id_of((*cv)[i].geo));// ensure we got correct id's out.
 
     auto s1 = xh.extract_state(vector<int>{2}); // ok, now specify cids, 2, only two cells match
     TS_ASSERT_EQUALS(s1->size(), 2);
     for (size_t i = 0;i < s1->size();++i)
-        TS_ASSERT_EQUALS((*s1)[i].id, cell_state_id_of((*cv)[i+2]));// ensure we got correct id's out.
+        TS_ASSERT_EQUALS((*s1)[i].id, cell_state_id_of((*cv)[i+2].geo));// ensure we got correct id's out.
 
     auto s_missing = xh.extract_state(vector<int>{3});
     TS_ASSERT_EQUALS(s_missing->size(), 0);

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -162,7 +162,16 @@ void api_test::test_state_with_id_functionality() {
     TS_ASSERT_EQUALS(s0->size(), cv->size());
     for (size_t i = 0;i < cv->size();++i)
         TS_ASSERT_EQUALS((*s0)[i].id, cell_state_id_of((*cv)[i].geo));// ensure we got correct id's out.
-
+    //-- while at it, also verify serialization support
+    auto bytes = serialize_to_bytes(s0);
+    TS_ASSERT(bytes.size()> 10);
+    shared_ptr<vector<cell_state_with_id<xcell_t::state_t>>> s0_x;
+    deserialize_from_bytes(bytes, s0_x);
+    TS_ASSERT_EQUALS(s0_x->size(), s0->size());
+    for (size_t i = 0;i < s0->size();++i) {
+        TS_ASSERT_EQUALS((*s0_x)[i].id, (*s0)[i].id);//equality by identity only check
+        TS_ASSERT_DELTA( (*s0_x)[i].state.kirchner.q, (*s0)[i].state.kirchner.q, 0.01);
+    }
     auto s1 = xh.extract_state(vector<int>{2}); // ok, now specify cids, 2, only two cells match
     TS_ASSERT_EQUALS(s1->size(), 2);
     for (size_t i = 0;i < s1->size();++i)

--- a/test/api_test.h
+++ b/test/api_test.h
@@ -11,5 +11,6 @@ class api_test : public CxxTest::TestSuite {
 	void test_ptssk_state_io(void);
 	void test_pthsk_state_io(void);
 	void test_geo_cell_data_io(void);
+    void test_state_with_id_functionality(void);
 
 };

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>gamma_snow_test test_correct_lwc</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>api_test test_state_with_id_functionality</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
# Overview

The previous implementation supported serialization of state into 'readable' strings, that could be stored into files and retrieved later.
It did however require the user to use the exact same model regarding cells.

Use-cases have emerged where we use larger models with catchments, where we would like to ensure that regardless of model-composition, states that are equivalent in model-stack and cell-geometry can be applied.

## Details

This PR provies all types of **region models** with the 

    
**.state** property, that provide functions
     
     .extract_state(cids) --> state with id vector
     .apply_state(state_with_id_vector, cids)

where cids is an api.IntVector containing catchment id's in scope. If cids is an empty IntVector, it applies to all catchments in the scope.

In order to store/retrieve the state vector to/from **file**, - the model-stack specific state-vector provides methods to **.serialize_to_bytes** and **.deserialize_from_bytes**.

Combined with the new  functions:

**shyft.api.byte_vector_to_file(path,bytes)**,
 and 
**shyft.api.byte_vector_from_file(path)** --> state with id vector


Example and test code is provided in the shyft/tests/test_region_model_stacks.py, example code is added below for simplicity

```python
   def test_state_with_id_handler(self):
        num_cells = 20
        model_type = pt_gs_k.PTGSKModel
        model = self.build_model(model_type, pt_gs_k.PTGSKParameter, num_cells, 2)
        cids_unspecified = api.IntVector()
        cids_1 = api.IntVector([1])
        cids_2 = api.IntVector([2])

        model_state_12 = model.state.extract_state(cids_unspecified)  # this is how to get all states from model
        model_state_1 = model.state.extract_state(cids_1)  # this is how to get only specified states from model
        model_state_2 = model.state.extract_state(cids_2)
        self.assertEqual(len(model_state_1) + len(model_state_2), len(model_state_12))
        self.assertGreater(len(model_state_1), 0)
        self.assertGreater(len(model_state_2), 0)
        for i in range(len(model_state_1)):  # verify selective extract catchment 1
            self.assertEqual(model_state_1[i].id.cid, 1)
        for i in range(len(model_state_2)):  # verify selective extract catchment 2
            self.assertEqual(model_state_2[i].id.cid, 2)
        for i in range(len(model_state_12)):
            model_state_12[i].state.kirchner.q = 100 + i
        model.state.apply_state(model_state_12, cids_unspecified)  # this is how to put all states into  model
        ms_12 = model.state.extract_state(cids_unspecified)
        for i in range(len(ms_12)):
            self.assertAlmostEqual(ms_12[i].state.kirchner.q, 100 + i)
        for i in range(len(model_state_2)):
            model_state_2[i].state.kirchner.q = 200 + i
        unapplied = model.state.apply_state(model_state_2, cids_2)  # this is how to put a limited set of state into model
        self.assertEqual(len(unapplied), 0)
        ms_12 = model.state.extract_state(cids_unspecified)
        for i in range(len(ms_12)):
            if ms_12[i].id.cid == 1:
                self.assertAlmostEqual(ms_12[i].state.kirchner.q, 100 + i)

        ms_2 = model.state.extract_state(cids_2)
        for i in range(len(ms_2)):
            self.assertAlmostEqual(ms_2[i].state.kirchner.q, 200 + i)

        # serialization support, to and from bytes

        bytes = ms_2.serialize_to_bytes()  # first make some bytes out of the state
        with tempfile.TemporaryDirectory() as tmpdirname:
            file_path = str(path.join(tmpdirname, "pt_gs_k_state_test.bin"))
            api.byte_vector_to_file(file_path, bytes)  # stash it into a file
            bytes = api.byte_vector_from_file(file_path)  # get it back from the file and into ByteVector
        ms_2x = pt_gs_k.deserialize_from_bytes(bytes)  # then restore it from bytes to a StateWithIdVector

        self.assertIsNotNone(ms_2x)
        for i in range(len(ms_2x)):
            self.assertAlmostEqual(ms_2x[i].state.kirchner.q, 200 + i)

```