### PR TITLE
Added compute_running_bias to kalman predictor

### DIFF
--- a/shyft/api/__init__.py
+++ b/shyft/api/__init__.py
@@ -1,6 +1,7 @@
 from ._api import *
 import numpy as np
 from math import sqrt
+
 # Fix up vector types
 
 DoubleVector.size = lambda self: len(self)
@@ -44,7 +45,8 @@ DoubleVector.push_back = lambda self, x: self.append(x)
 StringVector.push_back = lambda self, x: self.append(x)
 
 # FIx up YMDhms
-YMDhms.__str__ = lambda self: "YMDhms({0},{1},{2},{3},{4},{5})".format(self.year, self.month, self.day, self.hour, self.minute, self.second)
+YMDhms.__str__ = lambda self: "YMDhms({0},{1},{2},{3},{4},{5})".format(self.year, self.month, self.day, self.hour,
+                                                                       self.minute, self.second)
 
 # Fix up GeoPoint
 GeoPoint.__str__ = lambda self: "GeoPoint({0},{1},{2})".format(self.x, self.y, self.z)
@@ -53,13 +55,19 @@ GeoPoint_xy_distance = lambda a, b: GeoPoint.xy_distance(a, b)
 
 # Fix up LandTypeFractions
 
-LandTypeFractions.__str__ = lambda self: "LandTypeFractions(glacier={0},lake={1},reservoir={2},forest={3},unspecified={4})".format(self.glacier(), self.lake(), self.reservoir(),
-                                                                                                                                   self.forest(), self.unspecified())
+LandTypeFractions.__str__ = lambda \
+    self: "LandTypeFractions(glacier={0},lake={1},reservoir={2},forest={3},unspecified={4})".format(self.glacier(),
+                                                                                                    self.lake(),
+                                                                                                    self.reservoir(),
+                                                                                                    self.forest(),
+                                                                                                    self.unspecified())
 
 
 # Fix up GeoCellData
 def StrGeoCellData(gcd):
-    return "GeoCellData(mid_point={0},catchment_id={1},area={2},ltf={3})".format(str(gcd.mid_point()), gcd.catchment_id(), gcd.area(), str(gcd.land_type_fractions_info()))
+    return "GeoCellData(mid_point={0},catchment_id={1},area={2},ltf={3})".format(str(gcd.mid_point()),
+                                                                                 gcd.catchment_id(), gcd.area(),
+                                                                                 str(gcd.land_type_fractions_info()))
 
 
 GeoCellData.__str__ = lambda self: StrGeoCellData(self)
@@ -73,61 +81,66 @@ Timeaxis.__len__ = lambda self: self.size()
 Timeaxis.__call__ = lambda self, i: self.period(i)
 
 Timeaxis2.__len__ = lambda self: self.size()
-Timeaxis2.__str__ = lambda self: "GenericTimeaxis {0} {1} {2}".format(self.timeaxis_type, Calendar().to_string(self.total_period()), self.size())
+Timeaxis2.__str__ = lambda self: "GenericTimeaxis {0} {1} {2}".format(self.timeaxis_type,
+                                                                      Calendar().to_string(self.total_period()),
+                                                                      self.size())
 Timeaxis2.__call__ = lambda self, i: self.period(i)
 
 # fix up property on timeseries
 Timeseries.time_axis = property(lambda self: self.get_time_axis(), doc="returns the time_axis of the timeseries")
 
 Timeseries.__len__ = lambda self: self.size()
-Timeseries.v = property(lambda self: self.values,doc="returns the point-values of timeseries, alias for .values")
+Timeseries.v = property(lambda self: self.values, doc="returns the point-values of timeseries, alias for .values")
 
-Timeseries.kling_gupta = lambda self, other_ts, s_r=1.0, s_a=1.0, s_b=1.0: kling_gupta(self, other_ts, self.get_time_axis(), s_r, s_a, s_b)
+Timeseries.kling_gupta = lambda self, other_ts, s_r=1.0, s_a=1.0, s_b=1.0: kling_gupta(self, other_ts,
+                                                                                       self.get_time_axis(), s_r, s_a,
+                                                                                       s_b)
 Timeseries.kling_gupta.__doc__ = \
-"""
-computes the kling_gupta correlation using self as observation, and self.time_axis as
-the comparison time-axis
+    """
+    computes the kling_gupta correlation using self as observation, and self.time_axis as
+    the comparison time-axis
 
-Parameters
-----------
-other_ts : Timeseries
- the predicted/calculated time-series to correlate
-s_r : float
- the kling gupta scale r factor(weight the correlation of goal function)
-s_a : float
- the kling gupta scale a factor(weight the relative average of the goal function)
-s_b : float
- the kling gupta scale b factor(weight the relative standard deviation of the goal function)
+    Parameters
+    ----------
+    other_ts : Timeseries
+     the predicted/calculated time-series to correlate
+    s_r : float
+     the kling gupta scale r factor(weight the correlation of goal function)
+    s_a : float
+     the kling gupta scale a factor(weight the relative average of the goal function)
+    s_b : float
+     the kling gupta scale b factor(weight the relative standard deviation of the goal function)
 
-Return
-------
-KGEs : float
+    Return
+    ------
+    KGEs : float
 
-"""
+    """
 
-Timeseries.nash_sutcliffe = lambda self,other_ts: nash_sutcliffe(self, other_ts, self.get_time_axis())
+Timeseries.nash_sutcliffe = lambda self, other_ts: nash_sutcliffe(self, other_ts, self.get_time_axis())
 Timeseries.nash_sutcliffe.__doc__ = \
-"""
-Computes the Nash-Sutcliffe model effiency coefficient (n.s)
-for the two time-series over the specified time_axis
-Ref:  http://en.wikipedia.org/wiki/Nash%E2%80%93Sutcliffe_model_efficiency_coefficient
-Parameters
-----------
-observed_ts : Timeseries
- the observed time-series
-model_ts : Timeseries
- the time-series that is the model simulated / calculated ts
-time_axis : Timeaxis2
- the time-axis that is used for the computation
-Return
-------
- float: The n.s performance, that have a maximum at 1.0
-"""
+    """
+    Computes the Nash-Sutcliffe model effiency coefficient (n.s)
+    for the two time-series over the specified time_axis
+    Ref:  http://en.wikipedia.org/wiki/Nash%E2%80%93Sutcliffe_model_efficiency_coefficient
+    Parameters
+    ----------
+    observed_ts : Timeseries
+     the observed time-series
+    model_ts : Timeseries
+     the time-series that is the model simulated / calculated ts
+    time_axis : Timeaxis2
+     the time-axis that is used for the computation
+    Return
+    ------
+     float: The n.s performance, that have a maximum at 1.0
+    """
 
-TsFixed.values = property(lambda self:self.v,doc="returns the point values, .v of the timeseries")
+TsFixed.values = property(lambda self: self.v, doc="returns the point values, .v of the timeseries")
 TsFixed.time_axis = property(lambda self: self.get_time_axis(), doc="returns the time_axis of the timeseries")
-TsPoint.values = property(lambda self:self.v,doc="returns the point values, .v of the timeseries")
+TsPoint.values = property(lambda self: self.v, doc="returns the point values, .v of the timeseries")
 TsPoint.time_axis = property(lambda self: self.get_time_axis(), doc="returns the time_axis of the timeseries")
+
 
 def ta_iter(x):
     x.counter = 0
@@ -149,7 +162,8 @@ Timeaxis2.__iter__ = lambda self: ta_iter(self)
 Timeaxis2.__next__ = lambda self: ta_next(self)
 
 # Fix up PointTimeaxis
-PointTimeaxis.__str__ = lambda self: "PointTimeaxis(total_period={0}, n={1} )".format(str(self.total_period()), len(self))
+PointTimeaxis.__str__ = lambda self: "PointTimeaxis(total_period={0}, n={1} )".format(str(self.total_period()),
+                                                                                      len(self))
 PointTimeaxis.__len__ = lambda self: self.size()
 PointTimeaxis.__call__ = lambda self, i: self.period(i)
 PointTimeaxis.__iter__ = lambda self: ta_iter(self)
@@ -161,6 +175,7 @@ PrecipitationSource.vector_t = PrecipitationSourceVector
 RadiationSource.vector_t = RadiationSourceVector
 RelHumSource.vector_t = RelHumSourceVector
 WindSpeedSource.vector_t = WindSpeedSourceVector
+
 
 def np_array(dv):
     """
@@ -178,14 +193,20 @@ def np_array(dv):
     m = f.reshape(n, n)
     return m
 
-# fixup kalman state
-KalmanState.x = property(lambda self: KalmanState.get_x(self).to_numpy(),doc="represents the current bias estimate, kalman.state.x")
-KalmanState.k = property(lambda self: KalmanState.get_k(self).to_numpy(),doc="represents the current kalman gain factors, kalman.state.k")
-KalmanState.P = property(lambda self: np_array(KalmanState.get_P(self)),doc="returns numpy array of kalman.state.P, the nxn covariance matrix")
-KalmanState.W = property(lambda self: np_array(KalmanState.get_W(self)),doc="returns numpy array of kalman.state.W, the nxn noise matrix")
 
-#fixup KalmanBiasPredictor
-def KalmanBiasPredictor_update_with_forecast(bp,fc_set,obs,time_axis):
+# fixup kalman state
+KalmanState.x = property(lambda self: KalmanState.get_x(self).to_numpy(),
+                         doc="represents the current bias estimate, kalman.state.x")
+KalmanState.k = property(lambda self: KalmanState.get_k(self).to_numpy(),
+                         doc="represents the current kalman gain factors, kalman.state.k")
+KalmanState.P = property(lambda self: np_array(KalmanState.get_P(self)),
+                         doc="returns numpy array of kalman.state.P, the nxn covariance matrix")
+KalmanState.W = property(lambda self: np_array(KalmanState.get_W(self)),
+                         doc="returns numpy array of kalman.state.W, the nxn noise matrix")
+
+
+# fixup KalmanBiasPredictor
+def KalmanBiasPredictor_update_with_forecast(bp, fc_set, obs, time_axis):
     """
 
     Parameters
@@ -200,8 +221,43 @@ def KalmanBiasPredictor_update_with_forecast(bp,fc_set,obs,time_axis):
     nothing
     """
     if isinstance(fc_set, TemperatureSourceVector):
-        KalmanBiasPredictor.update_with_geo_forecast(bp,fc_set,obs,time_axis)
+        KalmanBiasPredictor.update_with_geo_forecast(bp, fc_set, obs, time_axis)
     else:
-        KalmanBiasPredictor.update_with_forecast_vector(bp,fc_set,obs,time_axis)
+        KalmanBiasPredictor.update_with_forecast_vector(bp, fc_set, obs, time_axis)
+
+
+def KalmanBiasPredictor_compute_running_bias(bp, fc_ts, obs_ts, time_axis):
+    """
+    compute the running bias timeseries,
+    using one 'merged' - forecasts and one observation time - series.
+
+    Before each day - period, the bias - values are copied out to form
+    a continuous bias prediction time-series.
+
+    Parameters
+    ----------
+
+    bias_predictor : KalmanBiasPredictor
+        The bias predictor object it self
+
+    forecast_ts : Timeseries
+        a merged forecast ts
+        with period covering the observation_ts and time_axis supplied
+
+    observation ts: Timeseries
+        the observation time-series
+
+    time_axis : Timeaxis
+        covering the period/timesteps to be updated
+        e.g. yesterday, 3h resolution steps, according to the points in the filter
+
+    Returns
+    -------
+    bias_ts : Timeseries(time_axis,bias_vector,POINT_AVERAGE)
+        computed running bias-ts
+    """
+    return KalmanBiasPredictor.compute_running_bias_ts(bp, fc_ts, obs_ts, time_axis)
+
 
 KalmanBiasPredictor.update_with_forecast = KalmanBiasPredictor_update_with_forecast
+KalmanBiasPredictor.compute_running_bias = KalmanBiasPredictor_compute_running_bias

--- a/test/kalman_test.cpp
+++ b/test/kalman_test.cpp
@@ -129,3 +129,37 @@ void kalman_test::test_bias_predictor() {
         TS_ASSERT_DELTA(fx.bias_offset(t),bias_estimate,0.2);
     }
 }
+
+void kalman_test::test_running_predictor() {
+    using namespace shyfttest;
+    using namespace std;
+    using pts_t=shyft::timeseries::point_ts<timeaxis_t>;
+    // prepare the time-dimension, using time-axis
+    calendar utc;
+    utctimespan dt=deltahours(1);
+    size_t n=24*10;
+    auto t0=utc.time(2000,1,1);
+    timeaxis_t ta(t0,dt,n); /// for the test,this is the governing time-axis (corresponding to region_model.time_axis during run/interpolation)
+    temperature fx(0.1);
+
+    pts_t observation(ta,0.0);
+    pts_t merged_forecast(ta,0.0);
+    for(size_t i=0;i<ta.size();++i) {
+        observation.set(i,fx.observation(ta.time(i)));
+        merged_forecast.set(i,fx.forecast(ta.time(i)));
+    }
+
+    kalman::parameter p;
+    kalman::filter f(p);
+    kalman::bias_predictor bias_predictor(f);
+    timeaxis_t pred_ta(t0,deltahours(3),n/3);// the predictor time-axis that covers the observation time-series ta
+    auto bias_ts = bias_predictor.compute_running_bias<pts_t>(merged_forecast,observation,pred_ta);
+    TS_ASSERT_EQUALS(bias_ts.size(),pred_ta.size());
+    for(size_t i=0;i<8;++i) {
+        TS_ASSERT_DELTA(bias_ts.value(i),0.0,0.0001);// assume first values are 0.0 since there is no learning.
+    }
+    for(size_t i=bias_ts.size()-8;i<bias_ts.size();++i) {
+        auto t= bias_ts.time(i);
+        TS_ASSERT_DELTA(fx.bias_offset(t),bias_ts.value(i),0.2);// at the end it should have a quite correct pattern
+    }
+}

--- a/test/kalman_test.h
+++ b/test/kalman_test.h
@@ -5,4 +5,5 @@ class kalman_test : public CxxTest::TestSuite {
 public:
 	void test_filter();
 	void test_bias_predictor();
+	void test_running_predictor();
 };


### PR DESCRIPTION
# Overview


## running bias computation
To support grid pre-prosessing utlizing grid-forecasts and observations in historical time,
we have added another function that computes the running-bias prediction,
given 
1. merged-forecast-ts (typically projected from surrounding grid-point to observation-point)
2. observation-ts, like temperature observed for the same historical period
3. the wanted time-axis for the bias-ts (typically the historical period, 3h resolution from 1.9...)
4. the usual kalman parameters, as well as initial state if it exists.
returns
bias_ts, as forecasted at the beginning of each day through the complete period.

note: the first day uses current state of the bias-predictor, so if not set, the bias-predicted will contains 0.0 the first day.

After some days, the bias-ts will resemble the kalman bias predictions based on the observed difference between the merged forecast- time-series and the observation time-series.

## time-axis of the forecast-timeseries limits kalman learning scope.
A minor fix to ensure that if a forecast have a time-axis, let's say for 2 days,
only those two days are used for kalman-update.
This makes it easy to pick out certain part of forecasts to feed into the kalman-filter.
E.g. only use portions of the forecasts from +24h until the end.


## Compatibility
There is no breaking changes in any interfaces, only added functionality.
The time-axis scope fix just make it more convenient to use existing functions.

## Example how to use

The python test_kalman.py is updated with a verification of the api as well as 
expected value-check for a simple constant-bias case.

```python
    def test_compute_running_bias(self):
        """
        Verify that if we feed forecast and observation into the bias-predictor
        it will create the estimated bias offsets, and
        that compute_running_bias returns a time-series.
        """
        f = api.KalmanFilter()
        bp = api.KalmanBiasPredictor(f)
        self.assertIsNotNone(bp)
        self.assertEqual(bp.filter.parameter.n_daily_observations, 8)

        n_fc = 1
        utc = api.Calendar()
        t0 = utc.time(2016, 1, 1)
        dt = api.deltahours(1)
        n_fc_steps = 24 * 10  # 10 days history
        fc_dt = api.deltahours(6)
        fc_fx = lambda time_axis: self._create_fc_values(time_axis, 2.0)  # just return a constant 2.0 deg C for now

        n_obs = n_fc_steps
        obs_ta = api.Timeaxis2(t0, dt, n_obs)
        obs_ts = api.Timeseries(obs_ta, fill_value=0.0)
        kalman_dt = api.deltahours(3)  # suitable average for prediction temperature
        kalman_ta = api.Timeaxis2(t0, kalman_dt, n_obs // 3)
        fc_ts = self._create_forecast_set(n_fc, t0, dt, n_fc_steps, fc_dt, fc_fx)[0]
        bias_ts = bp.compute_running_bias(fc_ts, obs_ts, kalman_ta)  # also verify we can feed in a pure TsVector
        bias_pattern = bp.state.x  # the bp.state.x is now the best estimates fo the bias between fc and observation
        self.assertEqual(len(bias_pattern), 8)
        for i in range(len(bias_pattern)):
            self.assertLess(abs(bias_pattern[i] - 2.0), 0.2)  # bias should iterate to approx 2.0 degC now.
        # and...:
        for i in range(8):
            self.assertAlmostEqual(bias_ts.value(i), 0.0)  # expect 0.0 for the first day

        for i in range(8):
            self.assertLess(abs(bias_ts.value(bias_ts.size() - i-1) - 2.0), 0.2)  # last part should be 2.0 deg.C


```


