### PR TITLE
fixed issue with rm.statistics.results when using calculation_filter 

### DIFF
--- a/core/cell_model.h
+++ b/core/cell_model.h
@@ -188,16 +188,18 @@ namespace shyft {
                 if (cells.size() == 0)
                     throw runtime_error("no cells to make statistics on");
 				verify_cids_exist(cells, catchment_indexes);
-				auto r = make_shared<pts_t>(cell_ts(cells[0]).ta, 0.0,point_interpretation_policy::POINT_AVERAGE_VALUE);
+                shared_ptr<pts_t> r;
 				double sum_area = 0.0;
 				bool match_all = catchment_indexes.size() == 0;
 				for (const auto& c : cells) {
                     if (match_all) {
+                        if(!r) r= make_shared<pts_t>(cell_ts(c).ta, 0.0, point_interpretation_policy::POINT_AVERAGE_VALUE);
                         r->add_scale(cell_ts(c), c.geo.area());  // c.env_ts.temperature, could be a feature(c) func return ref to ts
                         sum_area += c.geo.area();
                     } else {
                         for (auto cid : catchment_indexes) {
                             if ( c.geo.catchment_id() == (size_t) cid) { // criteria
+                                if (!r) r = make_shared<pts_t>(cell_ts(c).ta, 0.0, point_interpretation_policy::POINT_AVERAGE_VALUE);
                                 r->add_scale(cell_ts(c), c.geo.area());  // c.env_ts.temperature, could be a feature(c) func return ref to ts
                                 sum_area += c.geo.area();
                                 break;
@@ -264,15 +266,17 @@ namespace shyft {
                 if (cells.size() == 0)
                     throw runtime_error("no cells to make statistics on");
 				verify_cids_exist(cells, catchment_indexes);
-				auto r = make_shared<pts_t>(cell_ts(cells[0]).ta, 0.0, point_interpretation_policy::POINT_AVERAGE_VALUE);
+                shared_ptr<pts_t> r;
 				bool match_all = catchment_indexes.size() == 0;
 
 				for (const auto& c : cells) {
                     if (match_all) {
+                        if(!r) r= make_shared<pts_t>(cell_ts(c).ta, 0.0, point_interpretation_policy::POINT_AVERAGE_VALUE);
                         r->add(cell_ts(c));
                     } else {
                         for (auto cid : catchment_indexes) {
                             if (c.geo.catchment_id() == (size_t)cid) { //criteria
+                                if (!r) r = make_shared<pts_t>(cell_ts(c).ta, 0.0, point_interpretation_policy::POINT_AVERAGE_VALUE);
                                 r->add(cell_ts(c));  //c.env_ts.temperature, could be a feature(c) func return ref to ts
                                 break;
                             }

--- a/shyft/api/__init__.py
+++ b/shyft/api/__init__.py
@@ -182,11 +182,11 @@ TimeSeries.nash_sutcliffe.__doc__ = \
     Ref:  http://en.wikipedia.org/wiki/Nash%E2%80%93Sutcliffe_model_efficiency_coefficient
     Parameters
     ----------
-    observed_ts : Timeseries
+    observed_ts : TimeSeries
      the observed time-series
-    model_ts : Timeseries
+    model_ts : TimeSeries
      the time-series that is the model simulated / calculated ts
-    time_axis : Timeaxis2
+    time_axis : TimeAxis
      the time-axis that is used for the computation
     Return
     ------
@@ -198,6 +198,18 @@ TsFixed.time_axis = property(lambda self: self.get_time_axis(), doc="returns the
 TsPoint.values = property(lambda self: self.v, doc="returns the point values, .v of the timeseries")
 TsPoint.time_axis = property(lambda self: self.get_time_axis(), doc="returns the time_axis of the timeseries")
 
+# some minor fixup to ease work with core-time-series vs TimeSeries
+TsFixed.TimeSeries = property(lambda self: TimeSeries(self),doc="return a fully featured TimeSeries from the core TsFixed ")
+TsFixed.nash_sutcliffe = lambda self, other_ts: nash_sutcliffe(self.TimeSeries, other_ts, TimeAxis(self.get_time_axis()))
+TsFixed.kling_gupta = lambda self, other_ts, s_r=1.0, s_a=1.0, s_b=1.0: kling_gupta(self.TimeSeries, other_ts,
+                                                                                       TimeAxis(self.get_time_axis()), s_r, s_a,
+                                                                                       s_b)
+
+TsPoint.TimeSeries = property(lambda self: TimeSeries(self.get_time_axis(),self.v,self.point_interpretation()),doc="return a fully featured TimeSeries from the core TsPoint")
+TsPoint.nash_sutcliffe = lambda self, other_ts: nash_sutcliffe(self.TimeSeries, other_ts, TimeAxis(self.get_time_axis()))
+TsPoint.kling_gupta = lambda self, other_ts, s_r=1.0, s_a=1.0, s_b=1.0: kling_gupta(self.TimeSeries, other_ts,
+                                                                                       TimeAxis(self.get_time_axis()), s_r, s_a,
+                                                                                       s_b)
 
 
 

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -70,6 +70,17 @@ class TimeSeries(unittest.TestCase):
         ts_ta = tsfixed.time_axis  # a TsFixed do have .time_axis and .values
         self.assertEqual(len(ts_ta), len(self.ta))  # should have same length etc.
 
+        # verify some simple core-ts to TimeSeries interoperability
+        full_ts = tsfixed.TimeSeries  # returns a new TimeSeries as clone from tsfixed
+        self.assertEqual(full_ts.size(),tsfixed.size())
+        for i in range(tsfixed.size()):
+            self.assertEqual(full_ts.time(i),tsfixed.time(i))
+            self.assertAlmostEqual(full_ts.value(i),tsfixed.value(i),5)
+        ns = tsfixed.nash_sutcliffe(full_ts)
+        self.assertAlmostEqual(ns,1.0,4)
+        kg = tsfixed.kling_gupta(full_ts,1.0,1.0,1.0)
+        self.assertAlmostEqual(kg,1.0,4)
+
         # self.assertAlmostEqual(v,vv)
         # some reference testing:
         ref_v = tsfixed.v
@@ -92,6 +103,18 @@ class TimeSeries(unittest.TestCase):
         self.assertAlmostEqual(tspoint.get(0).v, v[0])
         self.assertAlmostEqual(tspoint.values[0], v[0])  # just to verfy compat .values works
         self.assertEqual(tspoint.get(0).t, ta(0).start)
+        # verify some simple core-ts to TimeSeries interoperability
+        full_ts = tspoint.TimeSeries  # returns a new TimeSeries as clone from tsfixed
+        self.assertEqual(full_ts.size(),tspoint.size())
+        for i in range(tspoint.size()):
+            self.assertEqual(full_ts.time(i),tspoint.time(i))
+            self.assertAlmostEqual(full_ts.value(i),tspoint.value(i),5)
+        ns = tspoint.nash_sutcliffe(full_ts)
+        self.assertAlmostEqual(ns,1.0,4)
+        kg = tspoint.kling_gupta(full_ts,1.0,1.0,1.0)
+        self.assertAlmostEqual(kg,1.0,4)
+
+
 
     def test_ts_factory(self):
         dv = np.arange(self.ta.size())

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>bayesian_kriging_test test_performance</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>cell_builder_test test_read_and_run_region_model</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
# Overview

region_model.statistics.sum/average cell_feature could return empty results in cases where the first cell of the cellvector was not part of the cell that was subject to simulation (calculation_filter), and the time-axis of that cell was empty (typical initial state).

This issue was experienced by Eli, ref. issue 109:

#109   where the same functions returned no values after calibration.

The issue was only related to extracting those time-series to python in that way, -any other method, including direct access would work.

In addition this PR also add some minor feature to ease working more seamlessly with the core-time-series (TsFixed and TsPoint in python) and the full feature TimeSeries class.

This is done by providing .TimeSeries property, that returns the core time-series (TsFixed/TsPoint) as a fully functional TimeSeries that can be added/compared etc.

We have also added most used/wanted  functions directly:

```python
TsFixed.nash_sutcliffe(other_TimeSeries) 
TsFixed.kling_gupta(other_TimeSeries,a,b,c)
```

Similar for the break-point type of ts, TsPoint that in some cases is used as input to the model.




