### PR TITLE
Make parameter optimisation easier

### DIFF
--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -307,6 +307,39 @@ namespace expose {
         .add_property("cells",&M::get_cells,"cells of the model")
          ;
     }
+
+    template <class F, class O>
+    O clone_to_opt_impl(F const& f) {
+        O o(f.extract_geo_cell_data(), f.get_region_parameter());
+        o.time_axis = f.time_axis;
+        o.ip_parameter = f.ip_parameter;
+        o.region_env = f.region_env;
+        o.initial_state = f.initial_state;
+        o.river_network = f.river_network;
+        auto fc = f.get_cells();
+        auto oc = o.get_cells();
+        for (size_t i = 0;i < f.size();++i) {
+            (*oc)[i].env_ts = (*fc)[i].env_ts;
+            (*oc)[i].state = (*fc)[i].state;
+        }
+        return o;
+    }
+
+    template <class F, class O>
+    void def_clone_to_opt_model(const char *func_name) {
+        O(*pfi)(typename F const&) = &clone_to_opt_impl< typename F, typename O>;
+        def(func_name, pfi, args("full_model"),
+            doc_intro("Clone a full model to a high speed opt model suitable for the optimizer")
+            doc_intro("The entire state except catchment-specific parameters, filter and result-series are cloned")
+            doc_intro("The returned model is ready to run_cells(), state and interpolated enviroment is identical to the clone source")
+            doc_parameters()
+            doc_parameter("full_model","XXXXModel","A full featured model, with state interpolation done, etc")
+            doc_returns("opt_model","XXXXOptModel","opt_model ready to run_cells, or to put into the calibrator/optimizer")
+        );
+    }
+
+
+
     template<class RegionModel>
     static void
     model_calibrator(const char *optimizer_name) {

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -38,7 +38,7 @@ namespace expose {
         }
         return move(r);
     }
-    
+
     template<class C>
     static void cell_state_etc(const char *stack_name) {
         typedef typename C::state_t cstate_t;
@@ -53,7 +53,7 @@ namespace expose {
         char csv_name[200];sprintf(csv_name, "%sVector", cs_name);
         class_<std::vector<CellState>, bases<>, std::shared_ptr<std::vector<CellState>> >(csv_name, "vector of cell state")
             .def(vector_indexing_suite<std::vector<CellState>>())
-            
+
             ;
         def("serialize", shyft::api::serialize_to_bytes<CellState>, args("states"), "make a blob out of the states");
         def("deserialize", shyft::api::deserialize_from_bytes<CellState>, args("bytes", "states"), "from a blob, fill in states");
@@ -61,7 +61,7 @@ namespace expose {
 
     template <class C>
     static void cell_state_io(const char *cell_name) {
-        
+
         char csh_name[200];sprintf(csh_name, "%sStateHandler", cell_name);
         typedef shyft::api::state_io_handler<C> CellStateHandler;
         class_<CellStateHandler>(csh_name, "Provides functionality to extract and restore state from cells")
@@ -325,9 +325,12 @@ namespace expose {
         return o;
     }
 
-    template <class F, class O>
+    template <typename F, typename O>
     void def_clone_to_opt_model(const char *func_name) {
-        O(*pfi)(typename F const&) = &clone_to_opt_impl< typename F, typename O>;
+        //typedef typename F F_;
+        //typedef typename O O_;
+        //O(*pfi)(F_ const&) = &clone_to_opt_impl< F_, O_>;
+        auto pfi = &clone_to_opt_impl< F, O>;
         def(func_name, pfi, args("full_model"),
             doc_intro("Clone a full model to a high speed opt model suitable for the optimizer")
             doc_intro("The entire state except catchment-specific parameters, filter and result-series are cloned")

--- a/api/boostpython/hbv_stack.cpp
+++ b/api/boostpython/hbv_stack.cpp
@@ -132,6 +132,7 @@ namespace expose {
 			typedef shyft::core::region_model<hbv_stack::cell_complete_response_t, shyft::api::a_region_environment> HbvModel;
 			expose::model<HbvModel>("HbvModel", "Hbv_stack");
 			expose::model<HbvOptModel>("HbvOptModel", "Hbv_stack");
+            def_clone_to_opt_model<HbvModel, HbvOptModel>("create_opt_model_clone");
 		}
 
 		static void

--- a/api/boostpython/pt_gs_k.cpp
+++ b/api/boostpython/pt_gs_k.cpp
@@ -138,6 +138,7 @@ namespace expose {
             typedef shyft::core::region_model<pt_gs_k::cell_complete_response_t, shyft::api::a_region_environment> PTGSKModel;
             expose::model<PTGSKModel>("PTGSKModel","PTGSK");
             expose::model<PTGSKOptModel>("PTGSKOptModel","PTGSK");
+            def_clone_to_opt_model<PTGSKModel, PTGSKOptModel>("create_opt_model_clone");
         }
 
         static void

--- a/api/boostpython/pt_hs_k.cpp
+++ b/api/boostpython/pt_hs_k.cpp
@@ -127,6 +127,7 @@ namespace expose {
             typedef shyft::core::region_model<pt_hs_k::cell_complete_response_t, shyft::api::a_region_environment> PTHSKModel;
             expose::model<PTHSKModel>("PTHSKModel","PTHSK");
             expose::model<PTHSKOptModel>("PTHSKOptModel","PTHSK");
+            def_clone_to_opt_model<PTHSKModel, PTHSKOptModel>("create_opt_model_clone");
         }
 
         static void

--- a/api/boostpython/pt_ss_k.cpp
+++ b/api/boostpython/pt_ss_k.cpp
@@ -135,6 +135,7 @@ namespace expose {
             typedef shyft::core::region_model<pt_ss_k::cell_complete_response_t, shyft::api::a_region_environment> PTSSKModel;
             expose::model<PTSSKModel>("PTSSKModel","PTSSK");
             expose::model<PTSSKOptModel>("PTSSKOptModel","PTSSK");
+            def_clone_to_opt_model<PTSSKModel, PTSSKOptModel>("create_opt_model_clone");
         }
 
         static void

--- a/shyft/api/hbv_stack/__init__.py
+++ b/shyft/api/hbv_stack/__init__.py
@@ -16,6 +16,8 @@ HbvModel.priestley_taylor_response = property(lambda self: HbvCellPriestleyTaylo
 HbvModel.hbv_actual_evaptranspiration_response=property(lambda self: HbvCellHbvActualEvapotranspirationResponseStatistics(self.get_cells()))
 HbvModel.soil_state = property(lambda self: HbvCellSoilStateStatistics(self.get_cells()))
 HbvModel.tank_state = property(lambda self: HbvCellTankStateStatistics(self.get_cells()))
+HbvModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
+HbvModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
 
 HbvOptModel.cell_t = HbvCellOpt
 HbvOptModel.parameter_t = HbvParameter

--- a/shyft/api/pt_gs_k/__init__.py
+++ b/shyft/api/pt_gs_k/__init__.py
@@ -29,6 +29,8 @@ PTGSKOptModel.statistics = property(lambda self:PTGSKCellOptStatistics(self.get_
 PTGSKOptModel.optimizer_t = PTGSKOptimizer
 PTGSKOptModel.full_model_t =PTGSKModel
 PTGSKModel.opt_model_t =PTGSKOptModel
+PTGSKModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
+PTGSKModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
 
 
 PTGSKCellAll.vector_t = PTGSKCellAllVector

--- a/shyft/api/pt_hs_k/__init__.py
+++ b/shyft/api/pt_hs_k/__init__.py
@@ -28,6 +28,8 @@ PTHSKOptModel.optimizer_t = PTHSKOptimizer
 
 PTHSKOptModel.full_model_t =PTHSKModel
 PTHSKModel.opt_model_t =PTHSKOptModel
+PTHSKModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
+PTHSKModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
 
 PTHSKCellAll.vector_t = PTHSKCellAllVector
 PTHSKCellOpt.vector_t = PTHSKCellOptVector

--- a/shyft/api/pt_ss_k/__init__.py
+++ b/shyft/api/pt_ss_k/__init__.py
@@ -28,6 +28,8 @@ PTSSKOptModel.statistics = property(lambda self:PTSSKCellOptStatistics(self.get_
 PTSSKOptModel.optimizer_t = PTSSKOptimizer
 PTSSKOptModel.full_model_t =PTSSKModel
 PTSSKModel.opt_model_t =PTSSKOptModel
+PTSSKModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
+PTSSKModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
 
 PTSSKCellAll.vector_t = PTSSKCellAllVector
 PTSSKCellOpt.vector_t = PTSSKCellOptVector


### PR DESCRIPTION
# Overview

When working and calibrating models, it's nice to work with the fully instrumented models that allows the end user to inspect all possible aspects of the model.
During calibration/optimization, Shyft have template specialized model that optimize away both waste of memory and computational efforts. This way we get the highest possible speed during calibration.

To ease switchiing from a full model and a tuned optimized model, there is now a special clone method on the full-model that creates a tuned model clone.

The tuned opt-model clone is exactly equal to its full model, except:
* results (they are not needed, soon to be overwritten during calibration)
* catchment-specific parameters are omitted ( calibration require only one region-parameter, applied to the catchment-ids of interest)
* catchment calculation filter (cleared, the optimizer will set new one based on calibration targets)

So, state, initial state, the cell-interpolated region_environment etc. are in place, so if the source model was ready to run cells, the new opt-model are also ready to run.

Ref. test_region_model_stacks.py for example how to use.

```python
        model.initialize_cell_environment(time_axis)  #
        model.interpolate( model_interpolation_parameter, region_env)
        opt_model = model.create_opt_model_clone(model)  # this is how to make a model suitable for optimizer
        # opt_model now have a copy of region_env, interpolation_params, initial_state etc.
        # but is of type PTGSKOptModel, if model was a PTGSKModel. 

```

Changes are incremental added functionality and backward compatible.
