### PR TITLE
Added convert to full-model method and function

### DIFF
--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -326,18 +326,15 @@ namespace expose {
     }
 
     template <typename F, typename O>
-    void def_clone_to_opt_model(const char *func_name) {
-        //typedef typename F F_;
-        //typedef typename O O_;
-        //O(*pfi)(F_ const&) = &clone_to_opt_impl< F_, O_>;
+    void def_clone_to_similar_model(const char *func_name) {
         auto pfi = &clone_to_opt_impl< F, O>;
-        def(func_name, pfi, args("full_model"),
-            doc_intro("Clone a full model to a high speed opt model suitable for the optimizer")
+        def(func_name, pfi, args("src_model"),
+            doc_intro("Clone a model to a another similar type model, full to opt-model or vice-versa")
             doc_intro("The entire state except catchment-specific parameters, filter and result-series are cloned")
             doc_intro("The returned model is ready to run_cells(), state and interpolated enviroment is identical to the clone source")
             doc_parameters()
-            doc_parameter("full_model","XXXXModel","A full featured model, with state interpolation done, etc")
-            doc_returns("opt_model","XXXXOptModel","opt_model ready to run_cells, or to put into the calibrator/optimizer")
+            doc_parameter("src_model","XXXX?Model","The model to be cloned, with state interpolation done, etc")
+            doc_returns("new_model","XXXX?Model","new_model ready to run_cells, or to put into the calibrator/optimizer")
         );
     }
 

--- a/api/boostpython/hbv_stack.cpp
+++ b/api/boostpython/hbv_stack.cpp
@@ -132,7 +132,8 @@ namespace expose {
 			typedef shyft::core::region_model<hbv_stack::cell_complete_response_t, shyft::api::a_region_environment> HbvModel;
 			expose::model<HbvModel>("HbvModel", "Hbv_stack");
 			expose::model<HbvOptModel>("HbvOptModel", "Hbv_stack");
-            def_clone_to_opt_model<HbvModel, HbvOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<HbvModel, HbvOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<HbvOptModel, HbvModel>("create_full_model_clone");
 		}
 
 		static void

--- a/api/boostpython/pt_gs_k.cpp
+++ b/api/boostpython/pt_gs_k.cpp
@@ -138,7 +138,8 @@ namespace expose {
             typedef shyft::core::region_model<pt_gs_k::cell_complete_response_t, shyft::api::a_region_environment> PTGSKModel;
             expose::model<PTGSKModel>("PTGSKModel","PTGSK");
             expose::model<PTGSKOptModel>("PTGSKOptModel","PTGSK");
-            def_clone_to_opt_model<PTGSKModel, PTGSKOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<PTGSKModel, PTGSKOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<PTGSKOptModel,PTGSKModel>("create_full_model_clone");
         }
 
         static void

--- a/api/boostpython/pt_hs_k.cpp
+++ b/api/boostpython/pt_hs_k.cpp
@@ -127,7 +127,8 @@ namespace expose {
             typedef shyft::core::region_model<pt_hs_k::cell_complete_response_t, shyft::api::a_region_environment> PTHSKModel;
             expose::model<PTHSKModel>("PTHSKModel","PTHSK");
             expose::model<PTHSKOptModel>("PTHSKOptModel","PTHSK");
-            def_clone_to_opt_model<PTHSKModel, PTHSKOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<PTHSKModel, PTHSKOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<PTHSKOptModel, PTHSKModel>("create_full_model_clone");
         }
 
         static void

--- a/api/boostpython/pt_ss_k.cpp
+++ b/api/boostpython/pt_ss_k.cpp
@@ -135,7 +135,8 @@ namespace expose {
             typedef shyft::core::region_model<pt_ss_k::cell_complete_response_t, shyft::api::a_region_environment> PTSSKModel;
             expose::model<PTSSKModel>("PTSSKModel","PTSSK");
             expose::model<PTSSKOptModel>("PTSSKOptModel","PTSSK");
-            def_clone_to_opt_model<PTSSKModel, PTSSKOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<PTSSKModel, PTSSKOptModel>("create_opt_model_clone");
+            def_clone_to_similar_model<PTSSKOptModel, PTSSKModel>("create_full_model_clone");
         }
 
         static void

--- a/shyft/api/hbv_stack/__init__.py
+++ b/shyft/api/hbv_stack/__init__.py
@@ -18,6 +18,8 @@ HbvModel.soil_state = property(lambda self: HbvCellSoilStateStatistics(self.get_
 HbvModel.tank_state = property(lambda self: HbvCellTankStateStatistics(self.get_cells()))
 HbvModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
 HbvModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
+HbvOptModel.create_full_model_clone = lambda self: create_full_model_clone(self)
+HbvOptModel.create_full_model_clone.__doc__ = create_full_model_clone.__doc__
 
 HbvOptModel.cell_t = HbvCellOpt
 HbvOptModel.parameter_t = HbvParameter

--- a/shyft/api/pt_gs_k/__init__.py
+++ b/shyft/api/pt_gs_k/__init__.py
@@ -31,6 +31,8 @@ PTGSKOptModel.full_model_t =PTGSKModel
 PTGSKModel.opt_model_t =PTGSKOptModel
 PTGSKModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
 PTGSKModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
+PTGSKOptModel.create_full_model_clone = lambda self: create_full_model_clone(self)
+PTGSKOptModel.create_full_model_clone.__doc__ = create_full_model_clone.__doc__
 
 
 PTGSKCellAll.vector_t = PTGSKCellAllVector

--- a/shyft/api/pt_hs_k/__init__.py
+++ b/shyft/api/pt_hs_k/__init__.py
@@ -30,6 +30,8 @@ PTHSKOptModel.full_model_t =PTHSKModel
 PTHSKModel.opt_model_t =PTHSKOptModel
 PTHSKModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
 PTHSKModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
+PTHSKOptModel.create_full_model_clone = lambda self: create_full_model_clone(self)
+PTHSKOptModel.create_full_model_clone.__doc__ = create_full_model_clone.__doc__
 
 PTHSKCellAll.vector_t = PTHSKCellAllVector
 PTHSKCellOpt.vector_t = PTHSKCellOptVector

--- a/shyft/api/pt_ss_k/__init__.py
+++ b/shyft/api/pt_ss_k/__init__.py
@@ -30,6 +30,8 @@ PTSSKOptModel.full_model_t =PTSSKModel
 PTSSKModel.opt_model_t =PTSSKOptModel
 PTSSKModel.create_opt_model_clone = lambda self: create_opt_model_clone(self)
 PTSSKModel.create_opt_model_clone.__doc__ = create_opt_model_clone.__doc__
+PTSSKOptModel.create_full_model_clone = lambda self: create_full_model_clone(self)
+PTSSKOptModel.create_full_model_clone.__doc__ = create_full_model_clone.__doc__
 
 PTSSKCellAll.vector_t = PTSSKCellAllVector
 PTSSKCellOpt.vector_t = PTSSKCellOptVector


### PR DESCRIPTION
# Overview 

Added complementary functions for cloning an opt-model to a full-model.
Useful in the context of working with opt-models, then switch to full-model for inspecting details.
