### PR TITLE
Cell charge_m3s speed and calibration supporting hydrological yearly balance

### DIFF
--- a/api/api.h
+++ b/api/api.h
@@ -249,6 +249,21 @@ namespace shyft {
 				sum_catchment_feature_value(*cells, catchment_indexes,
 					[](const cell& c) { return c.rc.avg_discharge; }, ith_timestep);
 		}
+        apoint_ts charge(const vector<int>& catchment_indexes) const {
+            return apoint_ts(*shyft::core::cell_statistics::
+                sum_catchment_feature(*cells, catchment_indexes,
+                    [](const cell& c) { return c.rc.charge_m3s; }));
+        }
+        vector<double> charge(const vector<int>& catchment_indexes, size_t ith_timestep) const {
+            return shyft::core::cell_statistics::
+                catchment_feature(*cells, catchment_indexes,
+                    [](const cell& c) { return c.rc.charge_m3s; }, ith_timestep);
+        }
+        double charge_value(const vector<int>& catchment_indexes, size_t ith_timestep) const {
+            return shyft::core::cell_statistics::
+                sum_catchment_feature_value(*cells, catchment_indexes,
+                    [](const cell& c) { return c.rc.charge_m3s; }, ith_timestep);
+        }
 
 		apoint_ts temperature(const vector<int>& catchment_indexes) const {
             return apoint_ts(*shyft::core::cell_statistics::

--- a/api/boostpython/api_target_specification.cpp
+++ b/api/boostpython/api_target_specification.cpp
@@ -34,6 +34,7 @@ namespace expose {
         enum_<model_calibration::target_spec_calc_type>("TargetSpecCalcType")
             .value("NASH_SUTCLIFFE",model_calibration::NASH_SUTCLIFFE)
             .value("KLING_GUPTA",model_calibration::KLING_GUPTA)
+            .value("ABS_DIFF",model_calibration::ABS_DIFF)
             .export_values()
             ;
         enum_<model_calibration::target_property_type>("CatchmentPropertyType")
@@ -41,6 +42,7 @@ namespace expose {
             .value("SNOW_COVERED_AREA", model_calibration::SNOW_COVERED_AREA)
             .value("SNOW_WATER_EQUIVALENT", model_calibration::SNOW_WATER_EQUIVALENT)
             .value("ROUTED_DISCHARGE",model_calibration::ROUTED_DISCHARGE)
+            .value("CELL_CHARGE",model_calibration::CELL_CHARGE)
             .export_values()
             ;
         typedef shyft::core::pts_t target_ts_t;

--- a/api/boostpython/expose_statistics.h
+++ b/api/boostpython/expose_statistics.h
@@ -300,6 +300,9 @@ namespace expose {
             rts_ (bc_stat::*discharge_ts)(cids_) const = &bc_stat::discharge;
             vd_  (bc_stat::*discharge_vd)(cids_,ix_) const =&bc_stat::discharge;
 
+            rts_(bc_stat::*charge_ts)(cids_) const = &bc_stat::charge;
+            vd_(bc_stat::*charge_vd)(cids_, ix_) const = &bc_stat::charge;
+
             rts_ (bc_stat::*temperature_ts)(cids_) const = &bc_stat::temperature;
             vd_  (bc_stat::*temperature_vd)(cids_,ix_) const =&bc_stat::temperature;
 
@@ -322,6 +325,9 @@ namespace expose {
                 .def("discharge",discharge_ts,args("catchment_indexes"), "returns sum  for catcment_ids")
                 .def("discharge",discharge_vd,args("catchment_indexes","i"),"returns  for cells matching catchments_ids at the i'th timestep")
 				.def("discharge_value", &bc_stat::discharge_value, args("catchment_indexes", "i"), "returns  for cells matching catchments_ids at the i'th timestep")
+                .def("charge", charge_ts, args("catchment_indexes"), "returns sum charge[m^3/s] for catcment_ids")
+                .def("charge", charge_vd, args("catchment_indexes", "i"), "returns charge[m^3/s]  for cells matching catchments_ids at the i'th timestep")
+                .def("charge_value", &bc_stat::charge_value, args("catchment_indexes", "i"), "returns charge[m^3/s] for cells matching catchments_ids at the i'th timestep")
                 .def("temperature",temperature_ts,args("catchment_indexes"), "returns sum  for catcment_ids")
                 .def("temperature",temperature_vd,args("catchment_indexes","i"),"returns  for cells matching catchments_ids at the i'th timestep")
 				.def("temperature_value", &bc_stat::temperature_value, args("catchment_indexes", "i"), "returns  for cells matching catchments_ids at the i'th timestep")

--- a/core/hbv_stack_cell_model.h
+++ b/core/hbv_stack_cell_model.h
@@ -34,13 +34,14 @@ namespace shyft {
 				pts_t ae_output;///< actual evap mm/h
 				pts_t soil_outflow; ///< Tank outflow given in [m^3/s] for the timestep
 				pts_t avg_discharge; ///< Tank outflow given in [m^3/s] for the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
 				response_t end_reponse;///<< end_response, at the end of collected
 
 				all_response_collector() : destination_area(0.0) {}
 				all_response_collector(const double destination_area) : destination_area(destination_area) {}
 				all_response_collector(const double destination_area, const timeaxis_t& time_axis)
 					: destination_area(destination_area), pe_output(time_axis, 0.0), snow_outflow(time_axis, 0.0),glacier_melt(time_axis,0.0),snow_sca(time_axis,0.0),snow_swe(time_axis,0), ae_output(time_axis, 0.0),
-						soil_outflow(time_axis, 0.0), avg_discharge(time_axis, 0.0) {}
+						soil_outflow(time_axis, 0.0), avg_discharge(time_axis, 0.0),charge_m3s(time_axis, 0.0) {}
 
 				/**\brief called before run to allocate space for results */
 				void initialize(const timeaxis_t& time_axis,int start_step,int n_steps, double area) {
@@ -53,6 +54,7 @@ namespace shyft {
                     ts_init(ae_output, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(soil_outflow, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
 				}
 
 				/**\brief Call for each time step, to collect needed information from R
@@ -73,7 +75,8 @@ namespace shyft {
 					ae_output.set(idx, response.ae.ae);
 					soil_outflow.set(idx, response.soil.outflow);//mm ?? //TODO: current mm/h. Want m3/s, but we get mm/h from soil output
 					avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, destination_area)); // wants m3/s, outflow is given in mm/h, so compute the totals in  mm/s
-				}
+                    charge_m3s.set(idx, response.charge_m3s);
+                }
 				void set_end_response(const response_t& r) { end_reponse = r; }
 			};
 
@@ -81,6 +84,7 @@ namespace shyft {
 			struct discharge_collector {
 				double destination_area;
 				pts_t avg_discharge; ///< Discharge given in [m^3/s] as the average of the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
 				response_t end_response;///<< end_response, at the end of collected
 				bool collect_snow;
 				pts_t snow_sca;
@@ -89,13 +93,14 @@ namespace shyft {
 				discharge_collector() : destination_area(0.0), collect_snow(false) {}
 				discharge_collector(const double destination_area) : destination_area(destination_area), collect_snow(false) {}
 				discharge_collector(const double destination_area, const timeaxis_t& time_axis)
-					: destination_area(destination_area), avg_discharge(time_axis, 0.0), collect_snow(false),
+					: destination_area(destination_area), avg_discharge(time_axis, 0.0),charge_m3s(time_axis, 0.0), collect_snow(false),
 					snow_sca(timeaxis_t(time_axis.start(), time_axis.delta(), 0), 0.0),
 					snow_swe(timeaxis_t(time_axis.start(), time_axis.delta(), 0), 0.0) {}
 
 				void initialize(const timeaxis_t& time_axis, int start_step, int n_steps, double area) {
 					destination_area = area;
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
 					auto ta = collect_snow ? time_axis : timeaxis_t(time_axis.start(), time_axis.delta(), 0);
                     ts_init(snow_swe, ta, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_sca, ta, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
@@ -104,6 +109,7 @@ namespace shyft {
 
 				void collect(size_t idx, const response_t& response) {
 					avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, destination_area)); // outflow is given in mm, so compute the totals
+                    charge_m3s.set(idx, response.charge_m3s);
 					if (collect_snow) {
 						snow_sca.set(idx, response.snow.snow_state.sca);
 						snow_swe.set(idx, response.snow.snow_state.swe);

--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -204,6 +204,7 @@ namespace shyft {
             double gm_melt_m3s;
             // Stack response
             double total_discharge;
+            double charge_m3s;
         };
 
         /** \brief Calculation Model using assembly of PriestleyTaylor, GammaSnow and Kirchner
@@ -300,6 +301,7 @@ namespace shyft {
             const double total_lake_fraction = geo_cell_data.land_type_fractions_info().lake() + geo_cell_data.land_type_fractions_info().reservoir(); // both give direct response for now
             const double glacier_fraction = geo_cell_data.land_type_fractions_info().glacier();
             const double kirchner_fraction = 1 - total_lake_fraction - glacier_fraction;
+            const double cell_area_m2 = geo_cell_data.area();
             const double glacier_area_m2 = geo_cell_data.area()*glacier_fraction;
             const double altitude= geo_cell_data.mid_point().z;
             // Step through times in axis
@@ -323,10 +325,14 @@ namespace shyft {
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.gs.outflow, response.ae.ae); // all units mm/h over 'same' area
 
                 response.total_discharge =
-                      prec*total_lake_fraction
-                    + shyft::m3s_to_mmh(response.gm_melt_m3s,geo_cell_data.area())
+                      std::max(0.0,prec - response.ae.ae)*total_lake_fraction // when it rains, remove ae. from direct response
+                    + shyft::m3s_to_mmh(response.gm_melt_m3s,cell_area_m2)
                     + response.kirchner.q_avg*kirchner_fraction;
-
+                response.charge_m3s =
+                    + shyft::mmh_to_m3s(prec, cell_area_m2)
+                    - shyft::mmh_to_m3s(response.ae.ae, cell_area_m2)
+                    + response.gm_melt_m3s
+                    - shyft::mmh_to_m3s(response.total_discharge, cell_area_m2);
                 // Possibly save the calculated values using the collector callbacks.
                 response_collector.collect(i, response);///< \note collect the response valid for the i'th period (current state is now at the end of period)
                 if(i+1==i_end)

--- a/core/pt_gs_k_cell_model.h
+++ b/core/pt_gs_k_cell_model.h
@@ -30,6 +30,7 @@ namespace shyft {
                 double destination_area;///< in [m^2]
                 // these are the one that we collects from the response, to better understand the model::
                 pts_t avg_discharge; ///< Kirchner Discharge given in [m^3/s] for the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
                 pts_t snow_sca; ///< gamma snow covered area fraction, sca.. 0..1 - at the end of timestep (state)
                 pts_t snow_swe;///< gamma snow swe, [mm] over the cell sca.. area, - at the end of timestep ?
                 pts_t snow_outflow;///< gamma snow output [m^3/s] for the timestep
@@ -41,12 +42,13 @@ namespace shyft {
                 all_response_collector() : destination_area(0.0) {}
                 all_response_collector(const double destination_area) : destination_area(destination_area) {}
                 all_response_collector(const double destination_area, const timeaxis_t& time_axis)
-                    : destination_area(destination_area), avg_discharge(time_axis, 0.0), snow_sca(time_axis, 0.0), snow_swe(time_axis, 0.0), snow_outflow(time_axis, 0.0), glacier_melt(time_axis, 0.0), ae_output(time_axis, 0.0), pe_output(time_axis, 0.0) {}
+                    : destination_area(destination_area), avg_discharge(time_axis, 0.0),charge_m3s(time_axis,0.0), snow_sca(time_axis, 0.0), snow_swe(time_axis, 0.0), snow_outflow(time_axis, 0.0), glacier_melt(time_axis, 0.0), ae_output(time_axis, 0.0), pe_output(time_axis, 0.0) {}
 
                 /**\brief called before run to allocate space for results */
                 void initialize(const timeaxis_t& time_axis,int start_step,int n_steps, double area) {
                     destination_area = area;
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_sca, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_swe, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_outflow, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
@@ -67,6 +69,7 @@ namespace shyft {
                 //template<class R>
                 void collect(size_t idx, const response_t& response) {
                     avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, destination_area)); // wants m3/s, q_avg is given in mm/h, so compute the totals in  mm/s
+                    charge_m3s.set(idx, response.charge_m3s);
                     snow_sca.set(idx, response.gs.sca);
                     snow_outflow.set(idx, response.gs.outflow); //TODO: current mm/h.. but  want m3/s, but we get mm/h from snow output
                     glacier_melt.set(idx, response.gm_melt_m3s);
@@ -82,6 +85,7 @@ namespace shyft {
             struct discharge_collector {
                 double cell_area;///< in [m^2]
                 pts_t avg_discharge; ///< Discharge given in [m^3/s] as the average of the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
                 response_t end_response;///<< end_response, at the end of collected
                 bool collect_snow;
                 pts_t snow_sca;
@@ -90,13 +94,14 @@ namespace shyft {
                 discharge_collector(const double cell_area) : cell_area(cell_area),collect_snow(false) {}
                 discharge_collector(const double cell_area, const timeaxis_t& time_axis)
                     : cell_area(cell_area),
-                      avg_discharge(time_axis, 0.0),collect_snow(false),
+                      avg_discharge(time_axis, 0.0), charge_m3s(time_axis, 0.0), collect_snow(false),
                       snow_sca(timeaxis_t(time_axis.start(),time_axis.delta(),0),0.0),
                       snow_swe(timeaxis_t(time_axis.start(),time_axis.delta(),0),0.0) {}
 
                 void initialize(const timeaxis_t& time_axis,int start_step,int n_steps, double area) {
                     cell_area = area;
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     auto ta = collect_snow ? time_axis : timeaxis_t(time_axis.start(), time_axis.delta(), 0);
                     ts_init(snow_sca, ta, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_swe, ta, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
@@ -104,6 +109,7 @@ namespace shyft {
 
                 void collect(size_t idx, const response_t& response) {
                     avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, cell_area)); // q_avg is given in mm, so compute the totals
+                    charge_m3s.set(idx, response.charge_m3s);
                     if(collect_snow) {
                         snow_sca.set(idx,response.gs.sca);
                         snow_swe.set(idx,response.gs.storage);

--- a/core/pt_hs_k.h
+++ b/core/pt_hs_k.h
@@ -150,6 +150,7 @@ namespace shyft {
             double gm_melt_m3s;
             // Stack response
             double total_discharge;
+            double charge_m3s;
         };
 
 
@@ -190,6 +191,7 @@ namespace shyft {
             const double total_lake_fraction = geo_cell_data.land_type_fractions_info().lake() + geo_cell_data.land_type_fractions_info().reservoir();
             const double glacier_fraction = geo_cell_data.land_type_fractions_info().glacier();
             const double kirchner_fraction = 1 - total_lake_fraction - glacier_fraction;
+            const double cell_area_m2 = geo_cell_data.area();
             const double glacier_area_m2 = geo_cell_data.area()*glacier_fraction;
 
             size_t i_begin = n_steps > 0 ? start_step : 0;
@@ -213,9 +215,15 @@ namespace shyft {
 
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.snow.outflow, response.ae.ae); //all units mm/h over 'same' area
 
-                response.total_discharge = prec*total_lake_fraction
-                    + m3s_to_mmh(response.gm_melt_m3s, geo_cell_data.area())
+                response.total_discharge =
+                      std::max(0.0, prec - response.ae.ae)*total_lake_fraction // when it rains, remove ae. from direct response
+                    + m3s_to_mmh(response.gm_melt_m3s, cell_area_m2)
                     + response.kirchner.q_avg * kirchner_fraction;
+                response.charge_m3s =
+                    + shyft::mmh_to_m3s(prec, cell_area_m2)
+                    - shyft::mmh_to_m3s(response.ae.ae, cell_area_m2)
+                    + response.gm_melt_m3s
+                    - shyft::mmh_to_m3s(response.total_discharge, cell_area_m2);
                 response.snow.snow_state=state.snow;//< note/sih: we need snow in the response due to calibration
 
                 // Possibly save the calculated values using the collector callbacks.

--- a/core/pt_hs_k_cell_model.h
+++ b/core/pt_hs_k_cell_model.h
@@ -31,6 +31,7 @@ namespace shyft {
                 double destination_area;///< in [m^2]
                 // these are the one that we collects from the response, to better understand the model::
                 pts_t avg_discharge; ///< Kirchner Discharge given in [m^3/s] for the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
                 pts_t snow_outflow;///<  snow output [mm/h] for the timestep TODO: want to have m3 s-1
                 pts_t snow_sca;
                 pts_t snow_swe;
@@ -42,13 +43,14 @@ namespace shyft {
                 all_response_collector() : destination_area(0.0) {}
                 all_response_collector(const double destination_area) : destination_area(destination_area) {}
                 all_response_collector(const double destination_area, const timeaxis_t& time_axis)
-                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),
+                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),charge_m3s(time_axis,0.0),
                    snow_outflow(time_axis, 0.0), snow_sca(time_axis,0.0),snow_swe(time_axis,0.0),glacier_melt(time_axis, 0.0), ae_output(time_axis, 0.0), pe_output(time_axis, 0.0) {}
 
                 /**\brief called before run to allocate space for results */
                 void initialize(const timeaxis_t& time_axis, int start_step, int n_steps, double area) {
                     destination_area = area;
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s   , time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_outflow,  time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_sca,      time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_swe,      time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
@@ -68,6 +70,7 @@ namespace shyft {
                  */
                 void collect(size_t idx, const response_t& response) {
                     avg_discharge.set(idx, mmh_to_m3s(response.total_discharge,destination_area)); // wants m3/s, q_avg is given in mm/h, so compute the totals in  mm/s
+                    charge_m3s.set(idx, response.charge_m3s);
                     snow_outflow.set(idx, response.snow.outflow);//mm/h ?? //TODO: current mm/h. Want m3/s, but we get mm/h from snow output
                     snow_sca.set(idx,response.snow.snow_state.sca);
                     snow_swe.set(idx,response.snow.snow_state.swe);
@@ -82,6 +85,7 @@ namespace shyft {
             struct discharge_collector {
                 double destination_area;
                 pts_t avg_discharge; ///< Discharge given in [m^3/s] as the average of the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
                 response_t end_response;///<< end_response, at the end of collected
                 bool collect_snow;
                 pts_t snow_sca;
@@ -90,7 +94,7 @@ namespace shyft {
                 discharge_collector() : destination_area(0.0),collect_snow(false) {}
                 discharge_collector(const double destination_area) : destination_area(destination_area),collect_snow(false) {}
                 discharge_collector(const double destination_area, const timeaxis_t& time_axis)
-                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),collect_snow(false),
+                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),charge_m3s(time_axis,0.0),collect_snow(false),
                     snow_sca(timeaxis_t(time_axis.start(),time_axis.delta(),0),0.0),
                     snow_swe(timeaxis_t(time_axis.start(),time_axis.delta(),0),0.0) {}
 
@@ -98,6 +102,7 @@ namespace shyft {
                     destination_area = area;
                     auto ta = collect_snow ? time_axis : timeaxis_t(time_axis.start(), time_axis.delta(), 0);
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_sca, ta, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_swe, ta, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                 }
@@ -105,6 +110,7 @@ namespace shyft {
 
                 void collect(size_t idx, const response_t& response) {
                     avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, destination_area)); // q_avg is given in mm, so compute the totals
+                    charge_m3s.set(idx, response.charge_m3s);
                     if(collect_snow) {
                         snow_sca.set(idx,response.snow.snow_state.sca);
                         snow_swe.set(idx,response.snow.snow_state.swe);

--- a/core/pt_ss_k.h
+++ b/core/pt_ss_k.h
@@ -155,6 +155,7 @@ namespace shyft {
             double gm_melt_m3s;
             // PTSSK response
             double total_discharge;
+            double charge_m3s;
         };
 
 
@@ -190,6 +191,7 @@ namespace shyft {
             const double total_lake_fraction = geo_cell_data.land_type_fractions_info().lake() + geo_cell_data.land_type_fractions_info().reservoir();
             const double glacier_fraction = geo_cell_data.land_type_fractions_info().glacier();
             const double kirchner_fraction = 1 - total_lake_fraction - glacier_fraction;
+            const double cell_area_m2 = geo_cell_data.area();
             const double glacier_area_m2 = geo_cell_data.area()*glacier_fraction;
             // Initialize the method stack
             precipitation_correction::calculator p_corr(parameter.p_corr.scale_factor);
@@ -216,10 +218,15 @@ namespace shyft {
                     period.timespan());
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.snow.outflow, response.ae.ae); //all units mm/h over 'same' area
 
-                response.total_discharge = prec*total_lake_fraction
-                    + m3s_to_mmh(response.gm_melt_m3s, geo_cell_data.area())
+                response.total_discharge = 
+                      std::max(0.0, prec - response.ae.ae)*total_lake_fraction // when it rains, remove ae. from direct response
+                    + m3s_to_mmh(response.gm_melt_m3s, cell_area_m2)
                     + response.kirchner.q_avg * kirchner_fraction;
-
+                response.charge_m3s =
+                    + shyft::mmh_to_m3s(prec, cell_area_m2)
+                    - shyft::mmh_to_m3s(response.ae.ae, cell_area_m2)
+                    + response.gm_melt_m3s
+                    - shyft::mmh_to_m3s(response.total_discharge, cell_area_m2);
                 // Possibly save the calculated values using the collector callbacks.
                 response_collector.collect(i, response);
 

--- a/core/pt_ss_k_cell_model.h
+++ b/core/pt_ss_k_cell_model.h
@@ -29,6 +29,7 @@ namespace shyft {
                 double destination_area;  ///< in [m^2]
                 // Collect responses as time series
                 pts_t avg_discharge;  ///< Kirchner Discharge given in [m^3/s] for the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
                 pts_t snow_total_stored_water;  ///< aka sca*(swe + lwc) in [mm]
                 pts_t snow_outflow;  ///< gamma snow output [m^3/s] for the timestep
                 pts_t glacier_melt;///< [m3/s] for the timestep
@@ -39,13 +40,14 @@ namespace shyft {
                 all_response_collector() : destination_area(0.0) {}
                 all_response_collector(const double destination_area) : destination_area(destination_area) {}
                 all_response_collector(const double destination_area, const timeaxis_t& time_axis)
-                 : destination_area(destination_area), avg_discharge(time_axis, 0.0), snow_total_stored_water(time_axis, 0.0),
+                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),charge_m3s(time_axis,0.0), snow_total_stored_water(time_axis, 0.0),
                    snow_outflow(time_axis, 0.0), glacier_melt(time_axis,0.0),ae_output(time_axis, 0.0), pe_output(time_axis, 0.0) {}
 
                 /**\brief Called before run to allocate space for results */
                 void initialize(const timeaxis_t& time_axis,int start_step,int n_steps, double area) {
                     destination_area = area;
                     ts_init(avg_discharge           ,time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s              ,time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_total_stored_water ,time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_outflow            ,time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(glacier_melt            ,time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
@@ -65,6 +67,7 @@ namespace shyft {
                 void collect(size_t idx, const response_t& response) {
                     // Convert discharge to volume per time unit (m^3/s) instead of mm per time step
                     avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, destination_area));
+                    charge_m3s.set(idx, response.charge_m3s);
                     snow_total_stored_water.set(idx, mmh_to_m3s(response.snow.total_stored_water, destination_area));
                     // Convert snow outflow to volume per time unit (m^3/s) instead of mm per time step
                     snow_outflow.set(idx, mmh_to_m3s(response.snow.outflow, destination_area));
@@ -79,6 +82,7 @@ namespace shyft {
             struct discharge_collector {
                 double destination_area;
                 pts_t avg_discharge; ///< Discharge given in [m^3/s] as the average of the timestep
+                pts_t charge_m3s; ///< = precip + glacier - act_evap - avg_discharge [m^3/s] for the timestep
                 response_t end_response;///<< end_response, at the end of collected
                 bool collect_snow;
                 pts_t snow_sca;
@@ -87,7 +91,7 @@ namespace shyft {
                 discharge_collector() : destination_area(0.0),collect_snow(false) {}
                 discharge_collector(const double destination_area) : destination_area(destination_area),collect_snow(false) {}
                 discharge_collector(const double destination_area, const timeaxis_t& time_axis)
-                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),collect_snow(false),
+                 : destination_area(destination_area), avg_discharge(time_axis, 0.0),charge_m3s(time_axis,0.0),collect_snow(false),
                     snow_sca(timeaxis_t(time_axis.start(),time_axis.delta(),0),0.0),
                     snow_swe(timeaxis_t(time_axis.start(),time_axis.delta(),0),0.0)  {}
 
@@ -95,6 +99,7 @@ namespace shyft {
                     destination_area = area;
                     auto ta = collect_snow ? time_axis : timeaxis_t(time_axis.start(), time_axis.delta(), 0);
                     ts_init(avg_discharge, time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
+                    ts_init(charge_m3s   , time_axis, start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_sca, ta,start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                     ts_init(snow_swe, ta,start_step, n_steps, fx_policy_t::POINT_AVERAGE_VALUE);
                 }
@@ -102,6 +107,7 @@ namespace shyft {
 
                 void collect(size_t idx, const response_t& response) {
                     avg_discharge.set(idx, mmh_to_m3s(response.total_discharge, destination_area)); // q_avg is given in mm, so compute the totals
+                    charge_m3s.set(idx, response.charge_m3s);
                     if(collect_snow) {
                         snow_sca.set(idx,response.snow.sca);
                         snow_swe.set(idx,response.snow.swe);

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -747,6 +747,23 @@ namespace shyft {
                         cr[c.geo.catchment_ix].add(c.rc.avg_discharge);
                 }
             }
+            template <class TSV>
+            void catchment_charges(TSV& cr) const {
+                typedef typename TSV::value_type ts_t;
+                cr.clear();
+                cr.reserve(n_catchments);
+                for (size_t i = 0;i < n_catchments;++i) {
+                    cr.emplace_back(ts_t(time_axis, 0.0));
+                }
+                for (const auto& c : *cells) {
+                    if (is_calculated_by_catchment_ix(c.geo.catchment_ix)) {
+                        cr[c.geo.catchment_ix].add_scale(c.env_ts.precipitation, c.geo.area() / (double(deltahours(1))*1000.0));
+                        //+TODO glacier + actual evap, e.g. replace with rc.cell_charge_m3s
+                        cr[c.geo.catchment_ix].add_scale(c.rc.avg_discharge,-1.0);
+
+                    }
+                }
+            }
 
             /**\brief return all discharges at the output of the routing points
              *

--- a/core/region_model.h
+++ b/core/region_model.h
@@ -747,6 +747,7 @@ namespace shyft {
                         cr[c.geo.catchment_ix].add(c.rc.avg_discharge);
                 }
             }
+
             template <class TSV>
             void catchment_charges(TSV& cr) const {
                 typedef typename TSV::value_type ts_t;
@@ -757,10 +758,7 @@ namespace shyft {
                 }
                 for (const auto& c : *cells) {
                     if (is_calculated_by_catchment_ix(c.geo.catchment_ix)) {
-                        cr[c.geo.catchment_ix].add_scale(c.env_ts.precipitation, c.geo.area() / (double(deltahours(1))*1000.0));
-                        //+TODO glacier + actual evap, e.g. replace with rc.cell_charge_m3s
-                        cr[c.geo.catchment_ix].add_scale(c.rc.avg_discharge,-1.0);
-
+                        cr[c.geo.catchment_ix].add(c.rc.charge_m3s);
                     }
                 }
             }

--- a/core/timeseries.h
+++ b/core/timeseries.h
@@ -1651,9 +1651,20 @@ namespace shyft{
             if(!isfinite(a)) a = 1.0;//could happen in theory if qo is zero
             if(!isfinite(b)) b = 1.0;// could happen if uo is zero
             // We use EDs to scale, and KGEs = (1-EDs) with max at 1.0, we use 1-KGEs to get minimum as 0 for minbobyqa
-            return /*EDs=*/ sqrt(std::pow(s_r*(r - 1), 2) + std::pow(s_a*(a - 1), 2) + std::pow(s_b*(b - 1), 2));
+            double eds2 = (s_r != 0.0 ? std::pow(s_r*(r - 1), 2) : 0.0) + (s_a != 0.0 ? std::pow(s_a*(a - 1), 2) : 0.0) + (s_b != 0.0 ? std::pow(s_b*(b - 1), 2) : 0.0);
+            return /*EDs=*/ sqrt( eds2);
 		}
-
+        template<class TSA1, class TSA2>
+        double abs_diff_sum_goal_function(const TSA1& observed_ts, const TSA2& model_ts) {
+            double abs_diff_sum = 0.0;
+            for (size_t i = 0; i < observed_ts.size(); ++i) {
+                double tv = observed_ts.value(i);
+                double dv = model_ts.value(i);
+                if (isfinite(tv) && isfinite(dv))
+                    abs_diff_sum +=fabs(tv-dv);
+            }
+            return abs_diff_sum;
+        }
         /// http://en.wikipedia.org/wiki/Percentile NIST definitions, we use R7, R and excel seems more natural..
         /// http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm
         /// calculate percentile using full sort.. works nice for a larger set of percentiles.

--- a/shyft/tests/api/test_calibration_types.py
+++ b/shyft/tests/api/test_calibration_types.py
@@ -235,6 +235,7 @@ class ShyftApi(unittest.TestCase):
         t.scale_factor = 1.0
         t.calc_mode = api.NASH_SUTCLIFFE
         t.calc_mode = api.KLING_GUPTA
+        t.calc_mode = api.ABS_DIFF
         t.s_r = 1.0  # KGEs scale-factors
         t.s_a = 2.0
         t.s_b = 3.0
@@ -270,6 +271,8 @@ class ShyftApi(unittest.TestCase):
         self.assertEqual(t2.uid,'test_uid')
         t2.catchment_property = api.SNOW_WATER_EQUIVALENT
         self.assertEqual(t2.catchment_property, api.SNOW_WATER_EQUIVALENT)
+        t2.catchment_property = api.CELL_CHARGE
+        self.assertEqual(t2.catchment_property, api.CELL_CHARGE)
         self.assertIsNotNone(t2.catchment_indexes)
         for i in range(len(cids)):
             self.assertEqual(cids[i], t2.catchment_indexes[i])

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -205,6 +205,8 @@ class RegionModel(unittest.TestCase):
         cids = api.IntVector()  # optional, we can add selective catchment_ids here
         sum_discharge = model.statistics.discharge(cids)
         sum_discharge_value = model.statistics.discharge_value(cids, 0)  # at the first timestep
+        sum_charge = model.statistics.charge(cids)
+        sum_charge_value=model.statistics.charge_value(cids, 0)
         opt_model.run_cells()  # starting out with the same state, same interpolated values, and region-parameters, we should get same results
         sum_discharge_opt_value= opt_model.statistics.discharge_value(cids, 0)
         self.assertAlmostEqual(sum_discharge_opt_value,sum_discharge_value,3)  # verify the opt_model clone gives same value

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -172,21 +172,21 @@ TEST_CASE("test_state_with_id_functionality") {
         TS_ASSERT_DELTA( (*s0_x)[i].state.kirchner.q, (*s0)[i].state.kirchner.q, 0.01);
     }
     auto s1 = xh.extract_state(vector<int>{2}); // ok, now specify cids, 2, only two cells match
-    TS_ASSERT_EQUALS(s1->size(), 2);
+    TS_ASSERT_EQUALS(s1->size(), size_t( 2));
     for (size_t i = 0;i < s1->size();++i)
         TS_ASSERT_EQUALS((*s1)[i].id, cell_state_id_of((*cv)[i+2].geo));// ensure we got correct id's out.
 
     auto s_missing = xh.extract_state(vector<int>{3});
-    TS_ASSERT_EQUALS(s_missing->size(), 0);
+    TS_ASSERT_EQUALS(s_missing->size(), 0u);
 
     auto m0 = xh.apply_state(s0, vector<int>());
-    TS_ASSERT_EQUALS(m0.size(), 0);
+    TS_ASSERT_EQUALS(m0.size(), 0u);
 
     auto m0_x = xh.apply_state(s0, vector<int>{4});
-    TS_ASSERT_EQUALS(m0_x.size(), 0); // because we passed in states not containing 4
+    TS_ASSERT_EQUALS(m0_x.size(), 0u); // because we passed in states not containing 4
     (*s0)[0].id.cid = 4; //stuff in a 4, and get one missing below
     auto m0_y = xh.apply_state(s0, vector<int>{4});
-    TS_ASSERT_EQUALS(m0_y.size(), 1);
+    TS_ASSERT_EQUALS(m0_y.size(), 1u);
     TS_ASSERT_EQUALS(m0_y[0], 0);
 }
 TEST_SUITE_END();

--- a/test/calibration_test.cpp
+++ b/test/calibration_test.cpp
@@ -492,5 +492,28 @@ TEST_CASE("test_kling_gupta_goal_function") {
 	double nsg1 = kling_gupta_goal_function<dlib::running_scalar_covariance<double>>(o1, s1,1.0,1.0,1.0);
 
 	TS_ASSERT_DELTA(nsg1,1.5666, 0.0001);
+    SUBCASE("avg ratio") {
+        o1.set(1, 1.0);
+        s1.set(2, 2.0);
+        double a = kling_gupta_goal_function<dlib::running_scalar_covariance<double>>(o1, s1, 0.0, 1.0, 0.0);
+        FAST_CHECK_LE( fabs(a - 1.0) , 1e-12);
+    }
 }
+TEST_CASE("test_abs_diff_sum_goal_function") {
+    calendar utc;
+    utctime start = utc.time(YMDhms(2000, 1, 1, 0, 0, 0));
+    utctimespan dt = deltahours(1);
+    timeaxis ta1(start, dt, 3);
+    pts_t o1(ta1, 1.0); o1.set(1, 10.0);
+    pts_t s1(ta1, 2.0); s1.set(2, 7.0);
+    double ads1 = abs_diff_sum_goal_function(o1, s1);
+
+    TS_ASSERT_DELTA(fabs(1.0-2.0)+fabs(10.0-2.0)+fabs(1.0-7.0), ads1, 0.0001);
+    SUBCASE("with-nan") {
+        o1.set(1, shyft::nan);
+        double ads2 = abs_diff_sum_goal_function(o1, s1);
+        TS_ASSERT_DELTA(fabs(1.0 - 2.0) + fabs(0) + fabs(1.0 - 7.0), ads2, 0.0001);
+    }
+}
+
 TEST_SUITE_END();

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE("cell_builder_test::test_read_geo_point_map") {
 	wkt_reader wio;
 	map<int, observation_location> obs;
 	obs = wio.read_geo_point_map("met_stations", slurp(test_path("neanidelv/geo_point_map.txt")));
-	TS_ASSERT_DIFFERS(obs.size(), 0);
+	TS_ASSERT_DIFFERS(obs.size(), 0u);
 	for (const auto& kv : obs) {
 		TS_ASSERT_DIFFERS(kv.first, 0);
 		TS_ASSERT_DIFFERS(kv.second.point.x, 0.0);
@@ -141,10 +141,10 @@ TEST_CASE("cell_builder_test::test_io_performance") {
 	auto prec = shyfttest::find("neanidelv", "precipitation");
 	auto disc = shyfttest::find("neanidelv", "discharge");
 	auto rad = shyfttest::find("neanidelv", "radiation");
-	TS_ASSERT_EQUALS(temp.size(), 10);
-	TS_ASSERT_DIFFERS(prec.size(), 0);
-	TS_ASSERT_DIFFERS(disc.size(), 0);
-	TS_ASSERT_EQUALS(rad.size(), 1);
+	TS_ASSERT_EQUALS(temp.size(), 10u);
+	TS_ASSERT_DIFFERS(prec.size(), 0u);
+	TS_ASSERT_DIFFERS(disc.size(), 0u);
+	TS_ASSERT_EQUALS(rad.size(), 1u);
 	auto dt = shyft::core::utctime_now() - t0;
 	TS_ASSERT_LESS_THAN(dt, 10);
 }

--- a/test/region_model_test.cpp
+++ b/test/region_model_test.cpp
@@ -184,7 +184,7 @@ TEST_CASE("test_region_vs_catchment_parameters") {
     cells->push_back(c1);
     cells->push_back(c2);
     region_model_t rm(cells,gp);
-    TS_ASSERT_EQUALS(rm.number_of_catchments(),2);
+    TS_ASSERT_EQUALS(rm.number_of_catchments(),2u);
     TS_ASSERT(rm.has_catchment_parameter(0)==false);
     TS_ASSERT(rm.has_catchment_parameter(1)==false); // by default, all should share the global rm parameter
     parameter_t c1p;                                 // now, put a specific parameter to catchment 0

--- a/test/routing_test.cpp
+++ b/test/routing_test.cpp
@@ -64,23 +64,23 @@ TEST_CASE("test_build_valid_river_network") {
     routing::river c0{5,routing_info(5)};//
     TS_ASSERT_THROWS(rn.add(c0),std::runtime_error);// self circle  detect.
     TS_ASSERT_THROWS(rn.set_downstream_by_id(4,1),std::runtime_error);// attempt to establish circle
-    TS_ASSERT_EQUALS(rn.upstreams_by_id(a_id).size(),0);// verify we still got the correct network
-    TS_ASSERT_EQUALS(rn.upstreams_by_id(b_id).size(),1);// verify we still got the correct network
-    TS_ASSERT_EQUALS(rn.upstreams_by_id(c_id).size(),0);// verify we still got the correct network
-    TS_ASSERT_EQUALS(rn.upstreams_by_id(d_id).size(),2);// verify we still got the correct network
+    TS_ASSERT_EQUALS(rn.upstreams_by_id(a_id).size(),0u);// verify we still got the correct network
+    TS_ASSERT_EQUALS(rn.upstreams_by_id(b_id).size(),1u);// verify we still got the correct network
+    TS_ASSERT_EQUALS(rn.upstreams_by_id(c_id).size(),0u);// verify we still got the correct network
+    TS_ASSERT_EQUALS(rn.upstreams_by_id(d_id).size(),2u);// verify we still got the correct network
     TS_ASSERT_EQUALS(rn.downstream_by_id(a_id),b_id);
     TS_ASSERT_EQUALS(rn.downstream_by_id(b_id),d_id);
     TS_ASSERT_EQUALS(rn.downstream_by_id(c_id),d_id);
     TS_ASSERT_EQUALS(rn.downstream_by_id(d_id),0);
     TS_ASSERT_DELTA(rn.river_by_id(a_id).downstream.distance,a.downstream.distance,0.01);
     auto all_ups = rn.all_upstreams_by_id(d_id);
-    TS_ASSERT_EQUALS(all_ups.size(), 3);
+    TS_ASSERT_EQUALS(all_ups.size(), 3u);
     // remove stuff:
     rn.remove_by_id(c_id);
     TS_ASSERT_THROWS(rn.check_rid(c_id),std::runtime_error);
-    TS_ASSERT_EQUALS(rn.upstreams_by_id(d_id).size(),1);
+    TS_ASSERT_EQUALS(rn.upstreams_by_id(d_id).size(),1u);
     rn.remove_by_id(b_id);
-    TS_ASSERT_EQUALS(rn.upstreams_by_id(d_id).size(),0);
+    TS_ASSERT_EQUALS(rn.upstreams_by_id(d_id).size(),0u);
     TS_ASSERT_EQUALS(rn.downstream_by_id(a_id),0);
     rn.remove_by_id(a_id);
     TS_ASSERT_THROWS(rn.remove_by_id(b_id),std::runtime_error);

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -232,7 +232,7 @@ TEST_CASE("test_api_ts_ref_binding") {
 
     auto xmls_unbound = f.serialize();
 
-    TS_ASSERT_EQUALS(tsr.size(),2);
+    TS_ASSERT_EQUALS(tsr.size(),2u);
     CHECK_THROWS_AS(f.value(0), runtime_error);
     // -now bind the variables
     api::apoint_ts b_c(ta,5.0);

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>cell_builder_test test_read_and_run_region_model</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-tc=test_abs_diff_sum_goal_function</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>

--- a/test/time_axis_test.cpp
+++ b/test/time_axis_test.cpp
@@ -58,19 +58,19 @@ TEST_CASE("test_all") {
     //
     // STEP 0: verify that the expected time-axis is correct
     //
-    TS_ASSERT_EQUALS( n, expected.size() );
+    TS_ASSERT_EQUALS( n, (int)expected.size() );
     TS_ASSERT_EQUALS( utcperiod( start, start + n * dt ), expected.total_period() );
     TS_ASSERT_EQUALS( string::npos, expected.index_of( start - 1 ) );
     TS_ASSERT_EQUALS( string::npos, expected.open_range_index_of( start - 1 ) );
     TS_ASSERT_EQUALS( string::npos, expected.index_of( start + n * dt ) );
-    TS_ASSERT_EQUALS( n - 1, expected.open_range_index_of( start + n * dt ) );
+    TS_ASSERT_EQUALS( n - 1,(int) expected.open_range_index_of( start + n * dt ) );
     for( int i = 0; i < n; ++i ) {
         TS_ASSERT_EQUALS( start + i * dt, expected.time( i ) );
         TS_ASSERT_EQUALS( utcperiod( start + i * dt, start + ( i + 1 )*dt ), expected.period( i ) );
-        TS_ASSERT_EQUALS( i, expected.index_of( start + i * dt ) );
-        TS_ASSERT_EQUALS( i, expected.index_of( start + i * dt + dt - 1 ) );
-        TS_ASSERT_EQUALS( i, expected.open_range_index_of( start + i * dt ) );
-        TS_ASSERT_EQUALS( i, expected.open_range_index_of( start + i * dt + dt - 1 ) );
+        TS_ASSERT_EQUALS( i,(int) expected.index_of( start + i * dt ) );
+        TS_ASSERT_EQUALS( i,(int) expected.index_of( start + i * dt + dt - 1 ) );
+        TS_ASSERT_EQUALS( i, (int)expected.open_range_index_of( start + i * dt ) );
+        TS_ASSERT_EQUALS( i,(int) expected.open_range_index_of( start + i * dt + dt - 1 ) );
     }
     //
     // STEP 1: construct all the other types of time-axis, with equal content, but represented differently

--- a/test/timeseries_test.cpp
+++ b/test/timeseries_test.cpp
@@ -73,7 +73,7 @@ typedef point_ts<point_timeaxis> xts_t;
 TEST_SUITE("time_series");
 TEST_CASE("test_point_timeaxis") {
     point_timeaxis ts0; //zero points
-    TS_ASSERT_EQUALS(ts0.size(),0);
+    TS_ASSERT_EQUALS(ts0.size(),0u);
     TS_ASSERT_EQUALS(ts0.index_of(12),std::string::npos);
     vector<utctime> t2={3600*1};//just one point
     try {
@@ -86,14 +86,14 @@ TEST_CASE("test_point_timeaxis") {
     }
     vector<utctime> t={3600*1,3600*2,3600*3};
     point_timeaxis tx(t);
-    TS_ASSERT_EQUALS(tx.size(),2);// number of periods, - two .. (unless we redefined the last to be last point .. +oo)
+    TS_ASSERT_EQUALS(tx.size(),2u);// number of periods, - two .. (unless we redefined the last to be last point .. +oo)
     TS_ASSERT_EQUALS(tx.period(0),utcperiod(t[0],t[1]));
     TS_ASSERT_EQUALS(tx.period(1),utcperiod(t[1],t[2]));
     TS_ASSERT_EQUALS(tx.index_of(-3600),std::string::npos);//(1),utcperiod(t[1],t[2]);
-    TS_ASSERT_EQUALS(tx.index_of(t[0]),0);
-    TS_ASSERT_EQUALS(tx.index_of(t[1]-1),0);
+    TS_ASSERT_EQUALS(tx.index_of(t[0]),0u);
+    TS_ASSERT_EQUALS(tx.index_of(t[1]-1),0u);
     TS_ASSERT_EQUALS(tx.index_of(t[2]+1),std::string::npos);
-    TS_ASSERT_EQUALS(tx.open_range_index_of(t[2]+1),1);
+    TS_ASSERT_EQUALS(tx.open_range_index_of(t[2]+1),1u);
 
 
 }
@@ -106,7 +106,7 @@ TEST_CASE("test_timeaxis") {
     TS_ASSERT_EQUALS(tx.size(),n);
     for(size_t i=0;i<n;++i) {
         TS_ASSERT_EQUALS(tx.period(i), utcperiod(t0+i*dt,t0+(i+1)*dt));
-        TS_ASSERT_EQUALS(tx.time(i), t0+i*dt );
+        TS_ASSERT_EQUALS(tx.time(i),utctime( t0+i*dt) );
         TS_ASSERT_EQUALS(tx.index_of(tx.time(i)),i);
         TS_ASSERT_EQUALS(tx.index_of(tx.time(i)+dt/2),i);
     }
@@ -224,40 +224,40 @@ TEST_CASE("test_hint_based_bsearch") {
     shyfttest::ts_source ta_null(t,d,0);
     TS_ASSERT_EQUALS(hint_based_search(ta_null,ta.total_period(),-1),string::npos);//trivial.
     size_t ix;
-    TS_ASSERT_EQUALS(ix=hint_based_search(ta,utcperiod(t+d,t+2*d),-1),1);
+    TS_ASSERT_EQUALS(ix=hint_based_search(ta,utcperiod(t+d,t+2*d),-1),1u);
 
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,1);ta.reset_call_count();
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+d,t+2*d),ix),1);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,0);
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+2*d,t+3*d),ix),2);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,0);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,1u);ta.reset_call_count();
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+d,t+2*d),ix),1u);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,0u);
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+2*d,t+3*d),ix),2u);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,0u);
 
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+7*d,t+8*d),4),7);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,0);// great using linear approach to find near solution upward.
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+7*d,t+8*d),4),7u);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,0u);// great using linear approach to find near solution upward.
 
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+0*d,t+1*d),4),0);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,0);// great using linear approach to find near solution upward.
-
-    ta.reset_call_count();
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+1*d,t+2*d),0),1);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,0);// great using linear approach to find near solution upward.
-    TS_ASSERT_EQUALS(ta.n_get_calls,2);// great using linear approach to find near solution upward.
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+0*d,t+1*d),4),0u);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,0u);// great using linear approach to find near solution upward.
 
     ta.reset_call_count();
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+1*d,t+2*d),0),1u);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,0u);// great using linear approach to find near solution upward.
+    TS_ASSERT_EQUALS(ta.n_get_calls,2u);// great using linear approach to find near solution upward.
 
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t-1*d,t-0*d),5),string::npos);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,0);// in this case, local search ends up with conclusive npos
+    ta.reset_call_count();
+
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t-1*d,t-0*d),5u),string::npos);
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,0u);// in this case, local search ends up with conclusive npos
 
     ta.reset_call_count();
 
 
     TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+20*d,t+21*d),5),ta.size()-1);
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,1);// great using linear approach to find near solution upward.
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,1u);// great using linear approach to find near solution upward.
 
     ta.reset_call_count();
 
-    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+2*d,t+3*d),ta.size()+5),2);//shall survive bad usage..
-    TS_ASSERT_EQUALS(ta.n_index_of_calls,1);// great using linear approach to find near solution upward.
+    TS_ASSERT_EQUALS(hint_based_search(ta,utcperiod(t+2*d,t+3*d),ta.size()+5),2u);//shall survive bad usage..
+    TS_ASSERT_EQUALS(ta.n_index_of_calls,1u);// great using linear approach to find near solution upward.
 
 }
 
@@ -270,11 +270,11 @@ TEST_CASE("test_average_value_staircase") {
 
 
     shyfttest::test_timeseries ps(begin(points),end(points));
-    TS_ASSERT_EQUALS(-1,ps.index_of(t0-deltahours(1)));
-    TS_ASSERT_EQUALS(0,ps.index_of(t0+deltahours(0)));
-    TS_ASSERT_EQUALS(1,ps.index_of(t0+deltahours(1)));
-    TS_ASSERT_EQUALS(2,ps.index_of(t0+deltahours(2)));
-    TS_ASSERT_EQUALS(2,ps.index_of(t0+deltahours(3)));
+    TS_ASSERT_EQUALS(string::npos,ps.index_of(t0-deltahours(1)));
+    TS_ASSERT_EQUALS(0u,ps.index_of(t0+deltahours(0)));
+    TS_ASSERT_EQUALS(1u,ps.index_of(t0+deltahours(1)));
+    TS_ASSERT_EQUALS(2u,ps.index_of(t0+deltahours(2)));
+    TS_ASSERT_EQUALS(2u,ps.index_of(t0+deltahours(3)));
 
     // case 1: just check it can compute true average..
     size_t ix=0;
@@ -285,21 +285,21 @@ TEST_CASE("test_average_value_staircase") {
     ix=-1;
     ps.index_of_count=0;
     TS_ASSERT_DELTA(1.0,average_value(ps,utcperiod(t0+deltaminutes(10),t0+ deltaminutes(11)),ix,false),0.0000001);
-    TS_ASSERT_EQUALS(1,ps.index_of_count);
-    TS_ASSERT_EQUALS(ix,1);
+    TS_ASSERT_EQUALS(1u,ps.index_of_count);
+    TS_ASSERT_EQUALS(ix,1u);
     // case 3: check that it deliver/keep average value after last value observed
     ps.index_of_count=0;
     ix=2;
     TS_ASSERT_DELTA(3.0,average_value(ps,utcperiod(t0+5*dt,t0+ 60*dt),ix,false),0.0000001);
-    TS_ASSERT_EQUALS(0,ps.index_of_count);
-    TS_ASSERT_EQUALS(ix,2);
+    TS_ASSERT_EQUALS(0u,ps.index_of_count);
+    TS_ASSERT_EQUALS(ix,2u);
     // case 4: ask for data before first point -> nan
     ix=2;
     ps.index_of_count=0;
     double v=average_value(ps,utcperiod(t0-5*dt,t0- 4*dt),ix,false);
     TS_ASSERT(!std::isfinite(v));
-    TS_ASSERT_EQUALS(ps.index_of_count,0);
-    TS_ASSERT_EQUALS(ix,0);
+    TS_ASSERT_EQUALS(ps.index_of_count,0u);
+    TS_ASSERT_EQUALS(ix,0u);
 
     // case 5: check it eats nans (nan-0)
     vector<point> points_with_nan0={point(t0,shyft::nan),point(t0+dt/2,2.0),point(t0+dt,shyft::nan),point(t0+2*dt,3)};
@@ -333,22 +333,22 @@ TEST_CASE("test_average_value_staircase") {
 
     ix=7;// ensure negative direction search ends up in doing a binary -search
     v=average_value(ps6,full_period,ix,false);
-    TS_ASSERT_EQUALS(ps6.index_of_count,1);
+    TS_ASSERT_EQUALS(ps6.index_of_count,1u);
     TS_ASSERT_DELTA((0*1+1*1+2*1.0)/3.0,v,0.00001);
     v=average_value(ps6,utcperiod(t0+3*dt,t0+4*dt),ix,false);
-    TS_ASSERT_EQUALS(ps6.index_of_count,1);
+    TS_ASSERT_EQUALS(ps6.index_of_count,1u);
     TS_ASSERT_DELTA((3)/1.0,v,0.00001);
-    TS_ASSERT_EQUALS(ix,4);
+    TS_ASSERT_EQUALS(ix,4u);
     ix=0;ps6.index_of_count=0;
     v=average_value(ps6,utcperiod(t0+7*dt,t0+8*dt),ix,false);
-    TS_ASSERT_EQUALS(ps6.index_of_count,1);
+    TS_ASSERT_EQUALS(ps6.index_of_count,1u);
     TS_ASSERT_DELTA((7)/1.0,v,0.00001);
     ps.index_of_count=0;
     average_accessor<shyfttest::test_timeseries,timeaxis> avg_a(ps,tx);
     TS_ASSERT_DELTA(avg_a.value(0),(1*0.5+2*0.5)/1.0,0.000001);//(1*0.5+2*1.5+3*1.0)/3.0
     TS_ASSERT_DELTA(avg_a.value(1),(2*1.0)/1.0,0.000001);//(1*0.5+2*1.5+3*1.0)/3.0
     TS_ASSERT_DELTA(avg_a.value(2),(3*1.0)/1.0,0.000001);//(1*0.5+2*1.5+3*1.0)/3.0
-    TS_ASSERT_EQUALS(ps.index_of_count,0);
+    TS_ASSERT_EQUALS(ps.index_of_count,0u);
 }
 
 TEST_CASE("test_average_value_linear_between_points") {
@@ -360,11 +360,11 @@ TEST_CASE("test_average_value_linear_between_points") {
 
 
 	shyfttest::test_timeseries ps(begin(points), end(points));
-	TS_ASSERT_EQUALS(-1, ps.index_of(t0 - deltahours(1)));
-	TS_ASSERT_EQUALS(0, ps.index_of(t0 + deltahours(0)));
-	TS_ASSERT_EQUALS(1, ps.index_of(t0 + deltahours(1)));
-	TS_ASSERT_EQUALS(2, ps.index_of(t0 + deltahours(2)));
-	TS_ASSERT_EQUALS(2, ps.index_of(t0 + deltahours(3)));
+	TS_ASSERT_EQUALS(string::npos, ps.index_of(t0 - deltahours(1)));
+	TS_ASSERT_EQUALS(0u, ps.index_of(t0 + deltahours(0)));
+	TS_ASSERT_EQUALS(1u, ps.index_of(t0 + deltahours(1)));
+	TS_ASSERT_EQUALS(2u, ps.index_of(t0 + deltahours(2)));
+	TS_ASSERT_EQUALS(2u, ps.index_of(t0 + deltahours(3)));
 
 	// case 1: just check it can compute true average..
 	size_t ix = 0;
@@ -375,21 +375,21 @@ TEST_CASE("test_average_value_linear_between_points") {
 	ix = -1;
 	ps.index_of_count = 0;
 	TS_ASSERT_DELTA(1.0+ 2*10.5/60, average_value(ps, utcperiod(t0 + deltaminutes(10), t0 + deltaminutes(11)), ix), 0.0000001);
-	TS_ASSERT_EQUALS(1, ps.index_of_count);
-	TS_ASSERT_EQUALS(ix, 1);
+	TS_ASSERT_EQUALS(1u, ps.index_of_count);
+	TS_ASSERT_EQUALS(ix, 1u);
 	// case 3: check that it deliver/keep average value after last value observed
 	ps.index_of_count = 0;
 	ix = 2;
 	TS_ASSERT_DELTA(3.0, average_value(ps, utcperiod(t0 + 5 * dt, t0 + 60 * dt), ix), 0.0000001);
-	TS_ASSERT_EQUALS(0, ps.index_of_count);
-	TS_ASSERT_EQUALS(ix, 2);
+	TS_ASSERT_EQUALS(0u, ps.index_of_count);
+	TS_ASSERT_EQUALS(ix, 2u);
 	// case 4: ask for data before first point -> nan
 	ix = 2;
 	ps.index_of_count = 0;
 	double v = average_value(ps, utcperiod(t0 - 5 * dt, t0 - 4 * dt), ix);
 	TS_ASSERT(!std::isfinite(v));
-	TS_ASSERT_EQUALS(ps.index_of_count, 0);
-	TS_ASSERT_EQUALS(ix, 0);
+	TS_ASSERT_EQUALS(ps.index_of_count, 0u);
+	TS_ASSERT_EQUALS(ix, 0u);
 
 	// case 5: check it eats nans (nan-0)
 	vector<point> points_with_nan0 = { point(t0, shyft::nan), point(t0 + dt / 2, 2.0), point(t0 + dt, shyft::nan), point(t0 + 2 * dt, 3) };
@@ -423,15 +423,15 @@ TEST_CASE("test_average_value_linear_between_points") {
 
 	ix = 7;// ensure negative direction search ends up in doing a binary -search
 	v = average_value(ps6, full_period, ix);
-	TS_ASSERT_EQUALS(ps6.index_of_count, 1);
+	TS_ASSERT_EQUALS(ps6.index_of_count, 1u);
 	TS_ASSERT_DELTA(1.5, v, 0.00001);
 	v = average_value(ps6, utcperiod(t0 + 3 * dt, t0 + 4 * dt), ix);
-	TS_ASSERT_EQUALS(ps6.index_of_count, 1);
+	TS_ASSERT_EQUALS(ps6.index_of_count, 1u);
 	TS_ASSERT_DELTA(3.5, v, 0.00001);
-	TS_ASSERT_EQUALS(ix, 4);
+	TS_ASSERT_EQUALS(ix, 4u);
 	ix = 0; ps6.index_of_count = 0;
 	v = average_value(ps6, utcperiod(t0 + 7 * dt, t0 + 8 * dt), ix);
-	TS_ASSERT_EQUALS(ps6.index_of_count, 1);
+	TS_ASSERT_EQUALS(ps6.index_of_count, 1u);
 	TS_ASSERT_DELTA(7.5, v, 0.00001);
 	ps.index_of_count = 0;
 	ps.set_point_interpretation(POINT_INSTANT_VALUE);
@@ -439,7 +439,7 @@ TEST_CASE("test_average_value_linear_between_points") {
 	TS_ASSERT_DELTA(avg_a.value(0), 1.83333333333, 0.000001);//(1*0.5+2*1.5+3*1.0)/3.0
 	TS_ASSERT_DELTA(avg_a.value(1), 2.6666666666, 0.000001);//(1*0.5+2*1.5+3*1.0)/3.0
 	TS_ASSERT_DELTA(avg_a.value(2), (3 * 1.0) / 1.0, 0.000001);//(1*0.5+2*1.5+3*1.0)/3.0
-	TS_ASSERT_EQUALS(ps.index_of_count, 0);
+	TS_ASSERT_EQUALS(ps.index_of_count, 0u);
 }
 
 
@@ -555,7 +555,7 @@ TEST_CASE("test_point_timeseries_with_point_timeaxis") {
     vector<utctime> times={3600*1,3600*2,3600*3,3600*4};
     vector<double> points={1.0,2.0,3.0};
     point_ts<point_timeaxis> ps(point_timeaxis(times),points);
-    TS_ASSERT_EQUALS(ps.size(),3);
+    TS_ASSERT_EQUALS(ps.size(),3u);
     for(size_t i=0;i<ps.size();++i) {
         TS_ASSERT_EQUALS(ps.get(i).v,points[i]);
     }
@@ -864,8 +864,8 @@ TEST_CASE("test_periodic_ts_t") {
 	typedef periodic_ts<timeaxis> periodic_ts_t;
 	periodic_ts_t pts(v, deltahours(3), ta);
 
-	TS_ASSERT_EQUALS(pts.size(), 1000);
-	TS_ASSERT_EQUALS(pts.index_of(t0), 0);
+	TS_ASSERT_EQUALS(pts.size(), 1000u);
+	TS_ASSERT_EQUALS(pts.index_of(t0), 0u);
 }
 
 TEST_CASE("test_periodic_ts_over_sampled") {
@@ -877,8 +877,8 @@ TEST_CASE("test_periodic_ts_over_sampled") {
 	typedef periodic_ts<timeaxis> periodic_ts_t;
 	periodic_ts_t pts(v, deltahours(3), ta);
 
-	TS_ASSERT_EQUALS(pts.size(), 1000);
-	TS_ASSERT_EQUALS(pts.index_of(t0), 0);
+	TS_ASSERT_EQUALS(pts.size(), 1000u);
+	TS_ASSERT_EQUALS(pts.index_of(t0), 0u);
 	TS_ASSERT_EQUALS(pts.value(0), v[0]);
 	TS_ASSERT_EQUALS(pts.value(1), v[0]);
 	TS_ASSERT_EQUALS(pts.value(2), v[0]);
@@ -945,8 +945,8 @@ TEST_CASE("test_periodic_template_ts") {
 
 	periodic_ts< timeaxis> fun(pd, ta, point_interpretation_policy::POINT_AVERAGE_VALUE);
 	// case 0: time-axis delta t covers several steps/values of the pattern
-	TS_ASSERT_EQUALS(fun.size(), 1000);
-	TS_ASSERT_EQUALS(fun.index_of(t0), 0);
+	TS_ASSERT_EQUALS(fun.size(), 1000u);
+	TS_ASSERT_EQUALS(fun.index_of(t0), 0u);
 	TS_ASSERT_EQUALS(fun.value(0), 2.2);
 	TS_ASSERT_EQUALS(fun.value(1), 5.5);
 	TS_ASSERT_EQUALS(fun.value(2), 4.0);
@@ -1083,7 +1083,7 @@ TEST_CASE("test_partition_by") {
 		auto v_common_t0 = ts.value(ts_ix);
 		auto v_year_start = src_a.value(src_ix);
 		TS_ASSERT_EQUALS(ts.size(), ta_y2015.size());
-		TS_ASSERT_EQUALS(ts_ix, 0);// because we make a separate one 365 day time-axis, so the first value should be at 0'th index
+		TS_ASSERT_EQUALS(ts_ix, 0u);// because we make a separate one 365 day time-axis, so the first value should be at 0'th index
 		TS_ASSERT_DELTA(v_common_t0, v_year_start, 0.01);// verify from source exactly equal to the partition value
 		TS_ASSERT_DELTA(v_year_start, double(src_ix), 0.01); // verify we did get the right value
 		ty = utc.add(ty, calendar::YEAR, 1);

--- a/test/utctime_utilities_test.cpp
+++ b/test/utctime_utilities_test.cpp
@@ -83,9 +83,9 @@ TEST_CASE("test_calendar_to_string") {
 
 TEST_CASE("test_calendar_day_of_year") {
     calendar cet(deltahours(1));
-    TS_ASSERT_EQUALS(1,cet.day_of_year(cet.time(YMDhms(2012,1,1,10,11,12))));
-    TS_ASSERT_EQUALS(2,cet.day_of_year(cet.time(YMDhms(2012,1,2,0,0,0))));
-    TS_ASSERT_EQUALS(366,cet.day_of_year(cet.time(YMDhms(2012,12,31,12,0,0))));
+    TS_ASSERT_EQUALS(1u,cet.day_of_year(cet.time(YMDhms(2012,1,1,10,11,12))));
+    TS_ASSERT_EQUALS(2u,cet.day_of_year(cet.time(YMDhms(2012,1,2,0,0,0))));
+    TS_ASSERT_EQUALS(366u,cet.day_of_year(cet.time(YMDhms(2012,12,31,12,0,0))));
 
 
 }


### PR DESCRIPTION
# Overview

This PR adds cell charge speed [m^3/s] to the standard response of all model stacks.
The purpose is to ease study how a cell charges water, in snow-layer, or any other vertical layer of the cell.

This also enable calibration to take the yearly(or other period) hydrological balance, the accumulated cell charge should then typically be close to target-timeseries, typically set to zero.
Timeaxis in these cases would typically be 1 (one) step for a year.

For calibration a new goal-function is introduced,
ABS_DIFF - that computes the accumulated sum of fabs(target-simulated) over the time-axis specified
and to specify cell charge
```python
from shyft import api as s
# setting target specification to use the new criteria
t = s.TargetSpecificationPts()
t.calc_mode = s.ABS_DIFF
t.catchment_property = s.CELL_CHARGE

# accessing the new charge[m3s] basic cell statistics property
sum_charge = model.statistics.charge(cids)
sum_charge_value=model.statistics.charge_value(cids, 0)
```

## Other changes

Actual evapotranspiration is now subtracted from direct precipitation on lake and reservoirs.
This is done to improve mass-balance for lake/reservoir dominated cell-types.

Given a cell with lake/reservoirs only, then actual-evapotranspiration is a positive value when there is no rain. If there is rain, direct runoff from the cell is equal to the precipitation minus the actual-evapotranspiration.

We assume that later we will add specialized cells for dealing with reservoirs and lakes, and deal with this issues more easiliy.

