### PR TITLE
Iso week

### DIFF
--- a/api/boostpython/api_utctime.cpp
+++ b/api/boostpython/api_utctime.cpp
@@ -23,36 +23,114 @@ namespace expose {
         utctime (calendar::*time_6)(int,int,int,int,int,int) const = &calendar::time;
         utctime (calendar::*time_from_week_6)(int, int, int, int, int, int) const = &calendar::time_from_week;
         class_<calendar, shared_ptr<calendar>>("Calendar",
-            "Calendar deals with the concept of human calendar\n"
-            " In SHyFT we practice the 'utctime-perimeter' principle,\n"
-            "  * so the core is utc-time only \n"
-            "  * we deal with time-zone and calendars at the interfaces/perimeters\n"
-            "\n"
-            " Please notice that although the calendar concept is complete\n"
-            " we only implement features as needed in the core and interfaces\n"
-            " Currently this includes most options, including olson time-zone handling\n"
-            "Calendar functionality:\n"
-            " -# Conversion between the calendar coordinates YMDhms or iso week YWdhms and utctime, taking  any timezone and DST into account\n"
-            " -# Calendar constants, utctimespan like values for Year,Month,Week,Day,Hour,Minute,Second\n"
-            " -# Calendar arithmetic, like adding calendar units, e.g. day,month,year etc.\n"
-            " -# Calendar arithmetic, like trim/truncate a utctime down to nearest timespan/calendar unit. eg. day\n"
-            " -# Calendar arithmetic, like calculate difference in calendar units(e.g days) between two utctime points\n"
-            " -# Calendar Timezone and DST handling\n"
-            " -# Converting utctime to string and vice-versa\n"
-            "\n"
+            doc_intro("Calendar deals with the concept of human calendar")
+            doc_intro(" In SHyFT we practice the 'utctime-perimeter' principle,")
+            doc_intro("  * so the core is utc-time only ")
+            doc_intro("  * we deal with time-zone and calendars at the interfaces/perimeters")
+            doc_intro(" in python, this corresponds to timestamp[64], or as the integer version of the time package representation")
+            doc_intro(" e.g. the difference between time.time()- utctime_now() is in split-seconds")
+            doc_intro("\n")
+            doc_intro("Calendar functionality:")
+            doc_intro(" -# Conversion between the calendar coordinates YMDhms or iso week YWdhms and utctime, taking  any timezone and DST into account\n")
+            doc_intro(" -# Calendar constants, utctimespan like values for Year,Month,Week,Day,Hour,Minute,Second\n")
+            doc_intro(" -# Calendar arithmetic, like adding calendar units, e.g. day,month,year etc.\n")
+            doc_intro(" -# Calendar arithmetic, like trim/truncate a utctime down to nearest timespan/calendar unit. eg. day\n")
+            doc_intro(" -# Calendar arithmetic, like calculate difference in calendar units(e.g days) between two utctime points\n")
+            doc_intro(" -# Calendar Timezone and DST handling\n")
+            doc_intro(" -# Converting utctime to string and vice-versa\n")
+            doc_intro("\n")
+            doc_notes()
+            doc_note(" Please notice that although the calendar concept is complete")
+            doc_note(" we only implement features as needed in the core and interfaces")
+            doc_note(" Currently this includes most options, including olson time-zone handling")
+            doc_note(" The time-zone support is currently a snapshot of rules ~2014")
+            doc_note(" but we plan to use standard packages like Howard Hinnant's online approach for this later.")
             )
-            .def(init<utctimespan>(args("tz-offset"), "creates a calendar with constant tz-offset"))
-            .def(init<string>(args("olson tz-id"), "create a Calendar from Olson timezone id, eg. 'Europe/Oslo'"))
-            .def("to_string", to_string_t, args("utctime"), "convert time t to readable string taking current calendar properties, including timezone into account")
-            .def("to_string", to_string_p, args("utcperiod"), "convert utcperiod p to readable string taking current calendar properties, including timezone into account")
-            .def("region_id_list", &calendar::region_id_list, "Returns a list over predefined olson time-zone identifiers").staticmethod("region_id_list")
-            .def("calendar_units", &calendar::calendar_units, args("t"), "returns YMDhms for specified t, in the time-zone as given by the calendar")
-            .def("calendar_week_units", &calendar::calendar_week_units, args("t"), "returns iso YWdhms for specified t, in the time-zone as given by the calendar")
-            .def("time", time_YMDhms, args("YMDhms"), "convert calendar coordinates into time using the calendar time-zone")
-            .def("time", time_YWdhms, args("YWdhms"), "convert calendar coordinates into time using the calendar time-zone")
+            .def(init<utctimespan>(args("tz_offset"), 
+                doc_intro("creates a calendar with constant tz-offset")
+                doc_parameters()
+                doc_parameter("tz_offset","int","seconds utc offset, 3600 gives UTC+01 zone")
 
-            .def("time", time_6, calendar_time_overloads("returns time according to calendar", args("Y,M,D,h,m,s")))
-            .def("time_from_week", time_from_week_6, calendar_time_overloads_week("returns time according to calendar iso year,week ..", args("Y,W,w,h,m,s")))
+              )
+            )
+            .def(init<string>(args("olson_tz_id"),
+                doc_intro("create a Calendar from Olson timezone id, eg. 'Europe/Oslo'")
+                doc_parameters()
+                doc_parameter("olson_tz_id","str","Olson time-zone id, e.g. 'Europe/Oslo'")
+                )
+            )
+            .def("to_string", to_string_t, args("utctime"),
+                doc_intro("convert time t to readable iso standard string taking ")
+                doc_intro(" the current calendar properties, including timezone into account")
+                doc_parameters()
+                doc_parameter("utctime","int","seconds utc since epoch")
+                doc_returns("iso time string","str","iso standard formatted string,including tz info")
+            )
+            .def("to_string", to_string_p, args("utcperiod"),
+                doc_intro("convert utcperiod p to readable string taking current calendar properties, including timezone into account")
+                doc_parameters()
+                doc_parameter("utcperiod", "UtcPeriod", "An UtcPeriod object")
+                doc_returns("period-string", "str", "[start..end>, iso standard formatted string,including tz info")
+            )
+            .def("region_id_list", &calendar::region_id_list,
+                doc_intro("Returns a list over predefined Olson time-zone identifiers")
+                doc_notes()
+                doc_note("the list is currently static and reflects tz-rules approx as of 2014")
+            ).staticmethod("region_id_list")
+            .def("calendar_units", &calendar::calendar_units, args("t"),
+                doc_intro("returns YMDhms for specified t, in the time-zone as given by the calendar")
+                doc_parameters()
+                doc_parameter("t", "int", "timestamp utc seconds since epoch")
+                doc_returns("calendar_units","YMDhms","calendar units as in year-month-day hour-minute-second")
+            )
+            .def("calendar_week_units", &calendar::calendar_week_units, args("t"), 
+                doc_intro("returns iso YWdhms for specified t, in the time-zone as given by the calendar")
+                doc_parameters()
+                doc_parameter("t", "int", "timestamp utc seconds since epoch")
+                doc_returns("calendar_week_units", "YWdms", "calendar units as in iso year-week-week_day hour-minute-second")
+            )
+            .def("time", time_YMDhms, args("YMDhms"), 
+                doc_intro("convert calendar coordinates into time using the calendar time-zone")
+                doc_parameters()
+                doc_parameter("YMDhms","YMDhms","calendar cooordinate structure containg year,month,day, hour,minute,second")
+                doc_returns("timestamp","int","timestamp as in seconds utc since epoch")                
+            )
+            .def("time", time_YWdhms, args("YWdhms"),
+                doc_intro("convert calendar iso week coordinates structure into time using the calendar time-zone")
+                doc_parameters()
+                doc_parameter("YWdhms", "YWdhms", "structure containg iso specification calendar coordinates")
+                doc_returns("timestamp", "int", "timestamp as in seconds utc since epoch")
+            )
+
+            .def("time", time_6, calendar_time_overloads(
+                doc_intro("convert calendar coordinates into time using the calendar time-zone")
+                doc_parameters()
+                doc_parameter("Y", "int", "Year")
+                doc_parameter("M", "int", "Month  [1..12], default=1")
+                doc_parameter("D", "int", "Day    [1..31], default=1")
+                doc_parameter("h", "int", "hour   [0..23], default=0")
+                doc_parameter("m", "int", "minute [0..59], default=0")
+                doc_parameter("s", "int", "second [0..59], default=0")
+                doc_returns("timestamp", "int", "timestamp as in seconds utc since epoch")
+                , 
+                args("Y", "M", "D", "h", "m", "s")
+            )
+            )
+            .def("time_from_week", time_from_week_6, 
+                calendar_time_overloads_week(
+                    doc_intro("convert calendar iso week coordinates into time using the calendar time-zone")
+                    doc_parameters()
+                    doc_parameter("Y", "int", "ISO Year")
+                    doc_parameter("W", "int", "ISO Week  [1..54], default=1")
+                    doc_parameter("wd","int", "week_day  [1..7]=[mo..su], default=1")
+                    doc_parameter("h", "int", "hour   [0..23], default=0")
+                    doc_parameter("m", "int", "minute [0..59], default=0")
+                    doc_parameter("s", "int", "second [0..59], default=0")
+                    doc_returns("timestamp", "int", "timestamp as in seconds utc since epoch")
+                    ,
+                    args("Y","W","wd","h","m","s")
+                )
+            )
 
             .def("add", &calendar::add, args("t", "delta_t", "n"),
                 doc_intro("calendar semantic add")
@@ -63,28 +141,42 @@ namespace expose {
                 doc_intro(" e.g. add one day, and calendar have dst, could give 23,24 or 25 hours due to dst.")
                 doc_intro(" similar for week or any other time steps.")
                 doc_parameters()
-                doc_parameter("t","int","timestamp utc since epoch")
+                doc_parameter("t","int","timestamp utc seconds since epoch")
                 doc_parameter("delta_t","int","timestep in seconds, with semantic interpretation of DAY,WEEK,MONTH,YEAR")
                 doc_parameter("n","int","number of timesteps to add")
                 doc_returns("t","int","new timestamp with the added time-steps, seconds utc since epoch")
-                doc_see_also("diff_units,trim")  
+                doc_see_also("diff_units(t1,t2,delta_t),trim(t,delta_t)")  
             )
-        .def("diff_units",diff_units,args("t,delta_t,n"),
-             "calculate the distance t1..t2 in specified units\n"
-             " The function takes calendar semantics when deltaT is calendar::DAY,WEEK,MONTH,YEAR,\n"
-             " and in addition also dst.\n"
-             "e.g. the diff_units of calendar::DAY over summer->winter shift is 1, remainder is 0,\n"
-             "even if the number of hours during those days are 23 and 25 summer and winter transition respectively\n"
-             "returns: calendar semantics of (t2-t1)/deltaT, where deltaT could be calendar units DAY,WEEK,MONTH,YEAR"
+        .def("diff_units",diff_units,args("t1","t2","delta_t"),
+             doc_intro("calculate the distance t1..t2 in specified units, taking dst into account if observed")
+             doc_intro("The function takes calendar semantics when delta_t is calendar::DAY,WEEK,MONTH,YEAR,")
+             doc_intro("and in addition also dst if observed.")
+             doc_intro("e.g. the diff_units of calendar::DAY over summer->winter shift is 1,")
+             doc_intro("even if the number of hours during those days are 23 and 25 summer and winter transition respectively")
+             doc_intro("returns: calendar semantics of (t2-t1)/deltaT, where deltaT could be calendar units DAY,WEEK,MONTH,YEAR")
+             doc_parameters()
+             doc_parameter("t", "int", "timestamp utc seconds since epoch")
+             doc_parameter("delta_t", "int", "timestep in seconds, with semantic interpretation of DAY,WEEK,MONTH,YEAR")
+             doc_parameter("n", "int", "number of timesteps to add")
+             doc_returns("n_units", "int", "number of units, so that t2 = c.add(t1,delta_t,n) + remainder(discarded)")
+             doc_see_also("add(t,delta_t,n),trim(t,delta_t)")
+
              )
-        .def("trim",&calendar::trim,args("t,delta_t"),"round down t to nearest calendar time-unit delta_t")
-        .def_readonly("YEAR",&calendar::YEAR)
-        .def_readonly("MONTH",&calendar::MONTH)
-        .def_readonly("DAY",&calendar::DAY)
-        .def_readonly("WEEK",&calendar::WEEK)
-        .def_readonly("HOUR",&calendar::HOUR)
-        .def_readonly("MINUTE",&calendar::MINUTE)
-        .def_readonly("SECOND",&calendar::SECOND)
+        .def("trim",&calendar::trim,args("t","delta_t"),
+            doc_intro("round time t down to the nearest calendar time-unit delta_t")
+            doc_intro("taking the calendar time-zone and dst into account")
+            doc_parameter("t", "int", "timestamp utc seconds since epoch")
+            doc_parameter("delta_t", "int", "timestep in seconds, with semantic interpretation of Calendar.(DAY,WEEK,MONTH,YEAR)")
+            doc_returns("t", "int", "new trimmed timestamp, seconds utc since epoch")
+            doc_see_also("add(t,delta_t,n),diff_units(t1,t2,delta_t)")
+        )
+        .def_readonly("YEAR",&calendar::YEAR, "defines a semantic year")
+        .def_readonly("MONTH",&calendar::MONTH,"defines a semantic calendar month")
+        .def_readonly("DAY",&calendar::DAY,"defines a semantic calendar day")
+        .def_readonly("WEEK",&calendar::WEEK,"defines a semantic calendar week")
+        .def_readonly("HOUR",&calendar::HOUR,"hour, 3600 seconds")
+        .def_readonly("MINUTE",&calendar::MINUTE,"minute, 60 seconds")
+        .def_readonly("SECOND",&calendar::SECOND,"second, 1 second")
         .add_property("tz_info",&calendar::get_tz_info,"The TzInfo keeping the time-zone name, utc-offset and DST rules (if any)")//,return_value_policy<return_internal_reference>())
         ;
 
@@ -99,7 +191,10 @@ namespace expose {
         .def_readwrite("minute",&YMDhms::minute)
         .def_readwrite("second",&YMDhms::second)
         .def("max",&YMDhms::max,"returns the maximum representation").staticmethod("max")
-        .def("min",&YMDhms::max,"returns the minimum representation").staticmethod("min");
+        .def("min",&YMDhms::max,"returns the minimum representation").staticmethod("min")
+        .def(self==self)
+        .def(self!=self)
+           ;
 
         class_<YWdhms>("YWdhms", "Defines calendar coordinates as iso Year Week week-day hour minute second")
             .def(init<int, optional<int, int, int, int, int>>(args("Y", "W", "wd", "h", "m", "s"), 
@@ -122,7 +217,10 @@ namespace expose {
             .def_readwrite("minute", &YWdhms::minute)
             .def_readwrite("second", &YWdhms::second)
             .def("max", &YWdhms::max, "returns the maximum representation").staticmethod("max")
-            .def("min", &YWdhms::max, "returns the minimum representation").staticmethod("min");
+            .def("min", &YWdhms::max, "returns the minimum representation").staticmethod("min")
+            .def(self == self)
+            .def(self != self)
+            ;
 
         class_<time_zone::tz_info_t,bases<>,time_zone::tz_info_t_,boost::noncopyable>("TzInfo",
             "TzInfo class is responsible for providing information about the\n"

--- a/core/utctime_utilities.cpp
+++ b/core/utctime_utilities.cpp
@@ -58,7 +58,7 @@ namespace shyft {
             }
             return string("[not-valid-period>");
         }
-        
+
         // returns sun=0, mon=1 etc.. based on code from boost greg.date
         static inline int day_of_week_idx(YMDhms const&c) {
             unsigned short a = static_cast<unsigned short>((14 - c.month) / 12);
@@ -66,7 +66,7 @@ namespace shyft {
             unsigned short m = static_cast<unsigned short>(c.month + 12 * a - 2);
             return static_cast<int>((c.day + y + (y / 4) - (y / 100) + (y / 400) + (31 * m) / 12) % 7);
         }
-        
+
         // return iso weekday, mon=1, sun=7;
         static inline int iso_week_day(YMDhms const&c) {
             auto wd = day_of_week_idx(c);
@@ -106,7 +106,6 @@ namespace shyft {
             auto jdn = day_number(t);
             auto cw = from_day_number(jdn);
             cw.month = 1;cw.day = 1;// round/trim down to year.1.1
-            auto jdn_y_1_1 = day_number(cw);
             auto w1_daynumber = trim_day_number_to_week(day_number(cw));
             auto cy = from_day_number(w1_daynumber);
             if (cy.month == 12 && cy.day < 29)

--- a/core/utctime_utilities.cpp
+++ b/core/utctime_utilities.cpp
@@ -58,18 +58,79 @@ namespace shyft {
             }
             return string("[not-valid-period>");
         }
+        
+        // returns sun=0, mon=1 etc.. based on code from boost greg.date
+        static inline int day_of_week_idx(YMDhms const&c) {
+            unsigned short a = static_cast<unsigned short>((14 - c.month) / 12);
+            unsigned short y = static_cast<unsigned short>(c.year - a);
+            unsigned short m = static_cast<unsigned short>(c.month + 12 * a - 2);
+            return static_cast<int>((c.day + y + (y / 4) - (y / 100) + (y / 400) + (31 * m) / 12) % 7);
+        }
+        
+        // return iso weekday, mon=1, sun=7;
+        static inline int iso_week_day(YMDhms const&c) {
+            auto wd = day_of_week_idx(c);
+            return wd == 0 ? 7 : wd;
+        }
+
+        // returns the day-number trimmed to start of iso-week (trunc,round downwards)
+        static inline unsigned long trim_day_number_to_week(unsigned long jdn) {
+            return 7 * (jdn / 7);// jd starts on monday.
+        }
 
         utctime calendar::time(YMDhms c) const {
             if(c.is_null()) return no_utctime;
             if(c==YMDhms::max()) return max_utctime;
             if(c==YMDhms::min()) return min_utctime;
             if (!c.is_valid_coordinates())
-                throw std::runtime_error("Calendar.time with invalid YMDhms coordinates attempted");
+                throw std::runtime_error("calendar.time with invalid YMDhms coordinates attempted");
 
             utctime r= ((int(day_number(c)) - UnixDay)*DAY) + seconds(c.hour, c.minute, c.second);
             auto utc_diff_1= tz_info->utc_offset(r);// detect if we are in the dst-shift hour
             auto utc_diff_2= tz_info->utc_offset(r-utc_diff_1);
             return (utc_diff_1==utc_diff_2)?r-utc_diff_1: r-utc_diff_2;
+        }
+
+        utctime calendar::time_from_week(int Y, int W, int wd, int h, int m, int s) const {
+            return time(YWdhms(Y, W, wd, h, m, s));
+        }
+        utctime calendar::time(YWdhms c) const {
+            if (c.is_null()) return no_utctime;
+            if (c == YWdhms::max()) return max_utctime;
+            if (c == YWdhms::min()) return min_utctime;
+            if (!c.is_valid_coordinates())
+                throw std::runtime_error("calendar.time with invalid YWdhms coordinates attempted");
+
+            // figure out utc-time of week 1:
+            utctime t = int(day_number(YMDhms(c.iso_year, 1, 14)) - UnixDay)*DAY;
+            auto jdn = day_number(t);
+            auto cw = from_day_number(jdn);
+            cw.month = 1;cw.day = 1;// round/trim down to year.1.1
+            auto jdn_y_1_1 = day_number(cw);
+            auto w1_daynumber = trim_day_number_to_week(day_number(cw));
+            auto cy = from_day_number(w1_daynumber);
+            if (cy.month == 12 && cy.day < 29)
+                    w1_daynumber += 7;
+            // then just add relative weeks days from that
+            auto w_daynumber = w1_daynumber + 7 *(c.iso_week-1) + (c.week_day - 1);
+            utctime r = (int(w_daynumber) - UnixDay)*DAY + seconds(c.hour, c.minute, c.second);// make it local utc-time
+            // map it back to true utc-time (subtract the tz-offset at the time)
+            auto utc_diff_1 = tz_info->utc_offset(r);// detect if we are in the dst-shift hour
+            auto utc_diff_2 = tz_info->utc_offset(r - utc_diff_1);
+            return (utc_diff_1 == utc_diff_2) ? r - utc_diff_1 : r - utc_diff_2;
+
+        }
+
+        template <class C>
+        static inline C& fill_in_hms_from_t(utctime t, C& r) {
+            utctime tj = calendar::UnixSecond + t;
+            utctime td = calendar::DAY*(tj / calendar::DAY);
+            utctimespan dx = tj - td;// n seconds this day.
+            r.hour = int(dx / calendar::HOUR);
+            dx -= r.hour*calendar::HOUR;
+            r.minute = int(dx / calendar::MINUTE);
+            r.second = int(dx % calendar::MINUTE);
+            return r;
         }
 
         YMDhms  calendar::calendar_units(utctime t) const {
@@ -82,25 +143,44 @@ namespace shyft {
             auto x = from_day_number(jdn);
             YMDhms r;
             r.year = x.year; r.month = x.month; r.day = x.day;
-            utctime tj = UnixSecond + t;
-            utctime td = DAY*(tj / DAY);
-            utctimespan dx = tj - td;// n seconds this day.
-            r.hour = int(dx / HOUR);
-            dx -= r.hour*HOUR;
-            r.minute = int(dx / MINUTE);
-            r.second = int(dx % MINUTE);
-            return r;
+            return fill_in_hms_from_t(t, r);
+        }
+
+        YWdhms calendar::calendar_week_units(utctime t) const {
+            if (t == no_utctime)  return YWdhms();
+            if (t == max_utctime) return YWdhms::max();
+            if (t == min_utctime) return YWdhms::min();
+            auto tz_dt = tz_info->utc_offset(t);
+            t += tz_dt;
+            auto jdn = day_number(t);
+            auto c = from_day_number(jdn);
+            YWdhms r;
+            r.week_day = iso_week_day(c);
+            auto jdnw = trim_day_number_to_week(jdn);
+            c = from_day_number(jdnw);
+            if (c.month == 12 && c.day >= 29) { // we are lucky: it has to be week one
+                r.iso_year = c.year + 1; // but iso-year start the year before, so plus one
+                r.iso_week = 1;
+            } else if (c.month == 1 && c.day <= 4) { // still lucky, it's week one
+                r.iso_year = c.year;
+                r.iso_week = 1;
+            } else { // since week one is sorted out above, this is week 2 and up.
+                c.month = 1;c.day = 1; // round/trim down to year.1.1 and we are sure we are on the same (iso) year
+                auto w1_daynumber = trim_day_number_to_week(day_number(c));
+                auto cy = from_day_number(w1_daynumber); // now figure out correct iso-week start
+                if (cy.month == 12&& cy.day < 29) //iso week 1 start next week
+                    w1_daynumber += 7; // step up.
+                //c = from_day_number(w1_daynumber + 14);// just pick year for week 2
+                r.iso_year = c.year; //we are on week 2 or more so safely use c.year
+                r.iso_week = 1 + (jdn - w1_daynumber) / 7;
+            }
+            return fill_in_hms_from_t(t,r);
         }
 
         int calendar::day_of_week(utctime t) const {
             if (t == no_utctime || t == min_utctime || t == max_utctime)
                 return -1;
-            auto ymd = calendar_units(t);
-            unsigned short a = static_cast<unsigned short>((14 - ymd.month) / 12);
-            unsigned short y = static_cast<unsigned short>(ymd.year - a);
-            unsigned short m = static_cast<unsigned short>(ymd.month + 12 * a - 2);
-            int d = static_cast<int>((ymd.day + y + (y / 4) - (y / 100) + (y / 400) + (31 * m) / 12) % 7);
-            return d;
+            return day_of_week_idx(calendar_units(t));
         }
         ///< returns day_of year, 1..365..
         size_t calendar::day_of_year(utctime t) const {
@@ -136,7 +216,7 @@ namespace shyft {
             }break;
             }
             auto tz_offset=tz_info->utc_offset(t);
-            const utctime t0 = utctime(3LL * DAY) + utctime(WEEK * 52L * 2000LL);// + 3 days to get to a isoweek monday, then add 2000 years to get a positive number
+            const utctime t0 = utctime(+3LL * DAY) + utctime(WEEK * 52L * 2000LL);// + 3 days to get to a isoweek monday, then add 2000 years to get a positive number
             t += t0 + tz_offset;
             t= deltaT*(t / deltaT) - t0 ;
             return  t - tz_info->utc_offset(t);

--- a/core/utctime_utilities.h
+++ b/core/utctime_utilities.h
@@ -224,10 +224,11 @@ namespace shyft {
             ///< if a 'null' or valid_coordinates
 			bool is_valid() const { return is_null() || is_valid_coordinates(); }
 			bool is_null() const { return year == 0 && month == 0 && day == 0 && hour == 0 && minute == 0 && second == 0; }
-			bool operator==(const YMDhms& x) const {
+			bool operator==(YMDhms const& x) const {
                 return x.year == year && x.month == month && x.day == day && x.hour == hour
                        && x.minute == minute && x.second == second;
             }
+            bool operator!=(YMDhms const&o) const { return !operator==(o); }
 			static YMDhms max() {return YMDhms(YEAR_MAX,12,31,23,59,59);}
 			static YMDhms min() {return YMDhms(YEAR_MIN,1,1,0,0,0);}
 		};

--- a/core/utctime_utilities.h
+++ b/core/utctime_utilities.h
@@ -231,6 +231,38 @@ namespace shyft {
 			static YMDhms max() {return YMDhms(YEAR_MAX,12,31,23,59,59);}
 			static YMDhms min() {return YMDhms(YEAR_MIN,1,1,0,0,0);}
 		};
+        struct YWdhms {
+            int iso_year;
+            int iso_week;
+            int week_day;
+            int hour;
+            int minute;
+            int second;
+            YWdhms() :iso_year(0), iso_week(0), week_day(0), hour(0), minute(0), second(0) {}
+            YWdhms(int iso_year,
+                int iso_week=1,
+                int week_day=1,
+                int hour=0,
+                int minute=0,
+                int second=0
+            ):iso_year(iso_year), iso_week(iso_week), week_day(week_day), hour(hour), minute(minute), second(second) {
+                if (!is_valid())
+                    throw std::runtime_error("calendar iso week coordinates failed simple range check for one or more item");
+            }
+            bool operator==(YWdhms const& x) const {
+                return x.iso_year == iso_year && x.iso_week == iso_week && x.week_day == week_day && x.hour == hour
+                    && x.minute == minute && x.second == second;
+            }
+            bool operator!=(YWdhms const&x) const { return !operator==(x); }
+            bool is_null() const { return iso_year == 0 && iso_week == 0 && week_day == 0 && hour == 0 && minute == 0 && second == 0; }
+            ///< just check that YMDhms are within reasonable ranges,\note it might still be an 'invalid' date!
+            bool is_valid_coordinates() const { return !(iso_year<YMDhms::YEAR_MIN || iso_year>YMDhms::YEAR_MAX || iso_week < 1 || iso_week>53 || week_day < 1 || week_day>7 || hour < 0 || hour>23 || minute < 0 || minute>59 || second < 0 || second>59); }
+            ///< if a 'null' or valid_coordinates
+            bool is_valid() const { return is_null() || is_valid_coordinates(); }
+            static YWdhms max() { return YWdhms(YMDhms::YEAR_MAX, 52, 6, 23, 59, 59); }
+            static YWdhms min() { return YWdhms(YMDhms::YEAR_MIN, 1, 1, 0, 0, 0); }
+
+        };
         /** \brief Calendar deals with the concept of human calendar.
          *
          * Please notice that although the calendar concept is complete,
@@ -281,8 +313,8 @@ namespace shyft {
 				int year = static_cast<unsigned short>(100 * b + d - 4800 + (m / 10));
 				return YMDhms(year, month, day);
 			}
-			static int day_number(utctime t) {
-				return (int)(int)((UnixSecond + t) / DAY);
+			static int inline day_number(utctime t) {
+				return (int)((UnixSecond + t) / DAY);
 			}
 			static inline utctimespan seconds(int h, int m, int s) { return h*HOUR + m*MINUTE + s*SECOND; }
 
@@ -313,11 +345,13 @@ namespace shyft {
 			 * \return utctime
 			 */
 			utctime time(YMDhms c) const;
+            utctime time(YWdhms c) const; 
 
             ///<short hand for calendar::time(YMDhms)
             utctime time(int Y,int M=1,int D=1,int h=0,int m=0,int s=0) const {
                 return time(YMDhms(Y,M,D,h,m,s));
             }
+            utctime time_from_week(int Y, int W = 1, int wd = 1, int h = 0, int m = 0, int s = 0) const;
             /**\brief returns *utc_year* of t \note for internal dst calculations only */
 			static inline int utc_year(utctime t) {
                 if(t == no_utctime  ) throw std::runtime_error("year of no_utctime");
@@ -333,6 +367,15 @@ namespace shyft {
              * \return calendar units YMDhms
              */
 			YMDhms  calendar_units(utctime t) const ;
+
+            /**\brief return the calendar iso week units of t taking timezone and dst into account
+            *
+            * Special utctime values, no_utctime max_utctime, min_utctime are mapped to corresponding
+            * YWdhms special values.
+            * \sa YWdhms
+            * \return calendar iso week units YWdhms
+            */
+            YWdhms calendar_week_units(utctime t) const;
 
 			///< returns  0=sunday, 1= monday ... 6=sat.
 			int day_of_week(utctime t) const ;

--- a/shyft/api/__init__.py
+++ b/shyft/api/__init__.py
@@ -46,6 +46,8 @@ def VectorString(v):
 
 DoubleVector.__str__ = lambda self: VectorString(self)
 
+Calendar.__str__ = lambda self: "Calendar('{0}')".format(self.tz_info.name())
+
 
 def ShowUtcTime(v):
     utc = Calendar()
@@ -78,6 +80,17 @@ StringVector.push_back = lambda self, x: self.append(x)
 # FIx up YMDhms
 YMDhms.__str__ = lambda self: "YMDhms({0},{1},{2},{3},{4},{5})".format(self.year, self.month, self.day, self.hour,
                                                                        self.minute, self.second)
+
+YMDhms.__repr__ = lambda self: "{0}({1},{2},{3},{4},{5},{6})".format(self.__class__.__name__,
+                                                                    self.year, self.month, self.day, self.hour,
+                                                                    self.minute, self.second)
+
+YWdhms.__str__ = lambda self: "YWdhms({0},{1},{2},{3},{4},{5})".format(self.iso_year, self.iso_week, self.week_day, self.hour,
+                                                                       self.minute, self.second)
+
+YWdhms.__repr__ = lambda self: "{0}({1},{2},{3},{4},{5},{6})".format(self.__class__.__name__,
+                                                                     self.iso_year, self.iso_week, self.week_day, self.hour,
+                                                                     self.minute, self.second)
 
 # Fix up GeoPoint
 GeoPoint.__str__ = lambda self: "GeoPoint({0},{1},{2})".format(self.x, self.y, self.z)

--- a/shyft/tests/api/test_calendar_and_time.py
+++ b/shyft/tests/api/test_calendar_and_time.py
@@ -39,32 +39,31 @@ class Calendar(unittest.TestCase):
         self.assertEqual(7, osl.diff_units(t0, t1, api.Calendar.DAY))
         self.assertEqual(1, osl.diff_units(t0, t1, api.Calendar.WEEK))
         self.assertEqual(0, osl.diff_units(t0, t1, api.Calendar.MONTH))
-        self.assertEqual(7*24, osl.diff_units(t0, t1, api.deltahours(1)))
+        self.assertEqual(7 * 24, osl.diff_units(t0, t1, api.deltahours(1)))
 
     def test_calendar_add_during_dst(self):
         osl = api.Calendar("Europe/Oslo")
         t0 = osl.time(2016, 3, 27)  # dst change during spring
-        t1 = osl.add(t0, api.Calendar.DAY,  1)
+        t1 = osl.add(t0, api.Calendar.DAY, 1)
         t2 = osl.add(t1, api.Calendar.DAY, -1)
         self.assertEqual(t0, t2)
         self.assertEqual("2016-03-28T00:00:00+02", osl.to_string(t1))
         self.assertEqual(1, osl.diff_units(t0, t1, api.Calendar.DAY))
         self.assertEqual(23, osl.diff_units(t0, t1, api.Calendar.HOUR))
         t0 = osl.time(2016, 10, 30)
-        t1 = osl.add(t0, api.Calendar.WEEK,  1)
+        t1 = osl.add(t0, api.Calendar.WEEK, 1)
         t2 = osl.add(t1, api.Calendar.WEEK, -1)
         self.assertEqual(t0, t2)
         self.assertEqual("2016-11-06T00:00:00+01", osl.to_string(t1))
-        self.assertEqual(168+1, osl.diff_units(t0, t1, api.Calendar.HOUR))
+        self.assertEqual(168 + 1, osl.diff_units(t0, t1, api.Calendar.HOUR))
 
     def test_calendar_add_3h_during_dst(self):
         osl = api.Calendar("Europe/Oslo")
         t0 = osl.time(2016, 3, 27)  # dst change during spring
-        t1 = osl.add(t0, api.Calendar.DAY,  1)
-        dt3h=api.deltahours(3)
-        d3h= osl.diff_units(t0,t1,dt3h)
+        t1 = osl.add(t0, api.Calendar.DAY, 1)
+        dt3h = api.deltahours(3)
+        d3h = osl.diff_units(t0, t1, dt3h)
         self.assertEqual(8, d3h)
-
 
     def test_trim_day(self):
         t = api.utctime_now()
@@ -82,6 +81,17 @@ class Calendar(unittest.TestCase):
         c1 = api.YMDhms(1960, 1, 2, 3, 4, 5)
         t1 = self.std.time(c1)
         c2 = self.std.calendar_units(t1)
+        cw = self.std.calendar_week_units(t1)
+        tw2 = self.std.time_from_week(1959, 53, 6, 3, 4, 5)
+        tw1 = self.std.time(cw)
+        self.assertEqual(tw2, t1)
+        self.assertEqual(tw1, t1)
+        self.assertEqual(cw.iso_year, 1959)
+        self.assertEqual(cw.iso_week, 53)
+        self.assertEqual(cw.week_day, 6)
+        self.assertEqual(cw.hour, 3)
+        self.assertEqual(cw.minute, 4)
+        self.assertEqual(cw.second, 5)
         self.assertEqual(c1.year, c2.year, 'roundtrip should keep year')
         self.assertEqual(c1.month, c2.month)
         self.assertEqual(c1.day, c2.day)


### PR DESCRIPTION
# Overview

This PR add iso-week support to the shyft Calendar class.
This means we now can convert from iso-calendar coordinates, iso-year,iso-week, week-day,hour,minute,second to utc-time (seconds in utc since epoch).
and vice-versa.

In addition, the python doc-strings for the Calendar class is updated to make it self-documenting while writing. __str__ and __repr__ is also added to ease working and debugging with the shyft system.

This PR only adds new functionality to existing code-base, or adds/improves the documentation for python scripting.

```python
from shyft.api import Calendar
c = Calendar('Europe/Oslo')
t1 = c.time(2017,2,26,12,30,15)  # Y,M,D,h,m,s ..
t2 = c.time_from_week(2017,8,7,12,30,15)  # iso year 2017 week 8, week_day 7.. 
assert t1 == t2
cu1 = c.calendar_units(t1) # line cu1.year,cu1.month,cu1.day ..
cu2 = c.calendar_week_units(t2)  #  like cu2.iso_year,cu2.iso_week,cu2.week_day
```


