### PR TITLE
Time points

### DIFF
--- a/api/boostpython/api_time_axis.cpp
+++ b/api/boostpython/api_time_axis.cpp
@@ -79,7 +79,7 @@ namespace expose {
                     doc_intro("or calendar-specific periods like day,week,month,quarters or years.")
                     doc_see_also("TimeAxisFixedDeltaT,TimeAxisByPoints,TimeAxis")
                 )
-                .def(init<shared_ptr<const calendar>,utctime,utctimespan,long>(
+                .def(init<shared_ptr<calendar>const&,utctime,utctimespan,long>(
                         args("calendar","start","delta_t","n"),
                         doc_intro("creates a calendar time-axis")
                         doc_parameters()
@@ -92,7 +92,7 @@ namespace expose {
                 .def_readonly("n",&calendar_dt::n,"int,number of periods")
                 .def_readonly("start",&calendar_dt::t,"start of the time-axis, in seconds since 1970.01.01 UTC")
                 .def_readonly("delta_t",&calendar_dt::dt,"int,timespan of each interval,use Calendar.DAY|.WEEK|.MONTH|.QUARTER|.YEAR, or seconds")
-                .def_readonly("calendar",&calendar_dt::cal,"Calendar, the calendar of the time-axis")
+                .add_property("calendar",&calendar_dt::get_calendar,"Calendar, the calendar of the time-axis")
                 ;
             e_time_axis_std<calendar_dt>(c_dt);
         }

--- a/api/boostpython/api_time_axis.cpp
+++ b/api/boostpython/api_time_axis.cpp
@@ -130,6 +130,15 @@ namespace expose {
                 e_time_axis_std<point_dt>(p_dt);
         }
 
+        static std::vector<utctime> time_axis_extract_time_points(shyft::time_axis::generic_dt const&ta) {
+            std::vector<utctime> r;r.reserve(ta.size() + 1);
+            for (size_t i = 0;i < ta.size();++i) {
+                r.emplace_back(ta.time(i));
+            }
+            if (ta.size())
+                r.emplace_back(ta.total_period().end);
+            return r;
+        }
 
         static void e_generic_dt() {
             using namespace shyft::time_axis;
@@ -209,6 +218,12 @@ namespace expose {
                 ;//.def("full_range",&point_dt::full_range,"returns a timeaxis that covers [-oo..+oo> ").staticmethod("full_range")
                 //.def("null_range",&point_dt::null_range,"returns a null timeaxis").staticmethod("null_range");
             e_time_axis_std<generic_dt>(g_dt);
+            def("time_axis_extract_time_points", time_axis_extract_time_points, args("time_axis"),
+                doc_intro("Extract all time_axis.period(i).start plus time_axis.total_period().end into a UtcTimeVector")
+                doc_parameters()
+                doc_parameter("time_axis","TimeAxis","time-axis to extract all time-points from")
+                doc_returns("time_points","UtcTimeVector","all time_axis.period(i).start plus time_axis.total_period().end")
+            );
         }
 
     }

--- a/core/time_axis.h
+++ b/core/time_axis.h
@@ -103,13 +103,13 @@ namespace shyft {
          */
         struct calendar_dt :continuous<true> {
             static constexpr utctimespan dt_h = 3600;
-            shared_ptr<const calendar> cal;
+            shared_ptr<calendar> cal;
             utctime t;
             utctimespan dt;
             size_t n;
-
+            shared_ptr<calendar> get_calendar() const { return cal; }
             calendar_dt() : t( no_utctime ), dt( 0 ), n( 0 ) {}
-            calendar_dt( const shared_ptr<const calendar>& cal, utctime t, utctimespan dt, size_t n ) : cal( cal ), t( t ), dt( dt ), n( n ) {}
+            calendar_dt( const shared_ptr< calendar>& cal, utctime t, utctimespan dt, size_t n ) : cal( cal ), t( t ), dt( dt ), n( n ) {}
             calendar_dt(const calendar_dt&c):cal(c.cal),t(c.t),dt(c.dt),n(c.n) {}
             calendar_dt(calendar_dt &&c):cal(std::move(c.cal)),t(c.t),dt(c.dt),n(c.n){}
             calendar_dt& operator=(calendar_dt&&c) {
@@ -291,7 +291,7 @@ namespace shyft {
             generic_dt(): gt( FIXED ) {}
             // provide convinience constructors, to directly create the wanted time-axis, regardless underlying rep.
             generic_dt( utctime t0,utctimespan dt,size_t n):gt(FIXED),f(t0,dt,n) {}
-            generic_dt( const shared_ptr<const calendar>& cal, utctime t, utctimespan dt, size_t n ) : gt(CALENDAR),c(cal,t,dt,n) {}
+            generic_dt( const shared_ptr<calendar>& cal, utctime t, utctimespan dt, size_t n ) : gt(CALENDAR),c(cal,t,dt,n) {}
             generic_dt( const vector<utctime>& t, utctime t_end ):gt(POINT),p(t,t_end) {}
             generic_dt( const vector<utctime>& all_points):gt(POINT),p(all_points){}
             // --
@@ -383,7 +383,7 @@ namespace shyft {
             calendar_dt cta;
             vector<utcperiod> p;// sub-periods within each cta.period, using cta.period.start as t0
             calendar_dt_p(){}
-            calendar_dt_p( const shared_ptr<const calendar>& cal, utctime t, utctimespan dt, size_t n, vector<utcperiod> p )
+            calendar_dt_p( const shared_ptr< calendar>& cal, utctime t, utctimespan dt, size_t n, vector<utcperiod> p )
                 : cta( cal, t, dt, n ), p( move( p ) ) {
                 // TODO: validate p, each p[i] non-overlapping and within ~ dt
                 // possibly throw if invalid period, but

--- a/core/utctime_utilities.h
+++ b/core/utctime_utilities.h
@@ -327,7 +327,17 @@ namespace shyft {
 			calendar(utctimespan tz=0): tz_info(new time_zone::tz_info_t(tz)) {}
 			/**\brief construct a timezone from tz_info shared ptr provided from typically time_zone db */
 			calendar(time_zone::tz_info_t_ tz_info):tz_info(tz_info) {}
-
+            calendar(calendar const&o) :tz_info(o.tz_info) {}
+            calendar(calendar&&o) :tz_info(std::move(o.tz_info)) {}
+            calendar& operator=(calendar const &o) {
+                if (this != &o)
+                    tz_info = o.tz_info;
+                return *this;
+            }
+            calendar& operator=(calendar&&o) {
+                tz_info = std::move(o.tz_info);
+                return *this;
+            }
             /**\brief construct a timezone based on region id
              * uses internal tz_info_database to lookup the name.
              * \param region_id like Europe/Oslo, \sa time_zone::tz_info_database

--- a/shyft/api/__init__.py
+++ b/shyft/api/__init__.py
@@ -139,23 +139,48 @@ TimeAxisFixedDeltaT.__call__ = lambda self, i: self.period(i)
 TimeAxisFixedDeltaT.__iter__ = lambda self: ta_iter(self)
 TimeAxisFixedDeltaT.__next__ = lambda self: ta_next(self)
 
-TimeAxisCalendarDeltaT.__str__ = lambda self: "TimeAxisCalendarDeltaT({0},{1},{2})".format(Calendar().to_string(self.start), self.delta_t, self.n)
+TimeAxisCalendarDeltaT.__str__ = lambda self: "TimeAxisCalendarDeltaT(Calendar('{3}'),{0},{1},{2})".format(Calendar().to_string(self.start), self.delta_t, self.n,self.calendar.tz_info.name())
 TimeAxisCalendarDeltaT.__len__ = lambda self: self.size()
 TimeAxisCalendarDeltaT.__call__ = lambda self, i: self.period(i)
 TimeAxisCalendarDeltaT.__iter__ = lambda self: ta_iter(self)
 TimeAxisCalendarDeltaT.__next__ = lambda self: ta_next(self)
 
-TimeAxisByPoints.__str__ = lambda self: "TimeAxisByPoints(total_period={0}, n={1} )".format(str(self.total_period()),len(self))
+TimeAxisByPoints.__str__ = lambda self: "TimeAxisByPoints(total_period={0}, n={1},points={2} )".format(str(self.total_period()),len(self),repr(TimeAxis(self).time_points))
 TimeAxisByPoints.__len__ = lambda self: self.size()
 TimeAxisByPoints.__call__ = lambda self, i: self.period(i)
 TimeAxisByPoints.__iter__ = lambda self: ta_iter(self)
 TimeAxisByPoints.__next__ = lambda self: ta_next(self)
 
-TimeAxis.__str__ = lambda self: "TimeAxis {0} {1} {2}".format(self.timeaxis_type, Calendar().to_string(self.total_period()), self.size())
+def nice_ta_string(time_axis):
+    if time_axis.timeaxis_type == TimeAxisType.FIXED:
+        return '{0}'.format(str(time_axis.fixed_dt))
+    if time_axis.timeaxis_type == TimeAxisType.CALENDAR:
+        return '{0}'.format(str(time_axis.calendar_dt))
+    return '{0}'.format(str(time_axis.point_dt))
+
+
+TimeAxis.__str__ = lambda self: nice_ta_string(self)
 TimeAxis.__len__ = lambda self: self.size()
 TimeAxis.__call__ = lambda self, i: self.period(i)
 TimeAxis.__iter__ = lambda self: ta_iter(self)
 TimeAxis.__next__ = lambda self: ta_next(self)
+
+
+TimeAxis.time_points = property( lambda self: time_axis_extract_time_points(self).to_numpy(),doc= \
+"""
+ extract all time-points from a TimeAxis
+ like
+ [ time_axis.time(i) ].append(time_axis.total_period().end) if time_axis.size() else []
+
+Parameters
+----------
+time_axis : TimeAxis
+
+Returns
+-------
+time_points:numpy.array(dtype=np.int64)
+   [ time_axis.time(i) ].append(time_axis.total_period().end)
+""")
 
 # fix up property on timeseries
 TimeSeries.time_axis = property(lambda self: self.get_time_axis(), doc="returns the time_axis of the timeseries")

--- a/shyft/tests/api/test_time_axis.py
+++ b/shyft/tests/api/test_time_axis.py
@@ -57,7 +57,7 @@ class TimeAxis(unittest.TestCase):
         self.assertTrue(len(s) > 0)
 
     def test_generic_timeaxis(self):
-        c = api.Calendar()
+        c = api.Calendar('Europe/Oslo')
         dt = api.deltahours(1)
         n = 240
         t0 = c.time(2016, 4, 10)
@@ -69,6 +69,7 @@ class TimeAxis(unittest.TestCase):
         tag2 = api.TimeAxis(c, t0, dt, n)
         self.assertEqual(len(tag2), n)
         self.assertEqual(tag2.time(0), t0)
+        self.assertIsNotNone(tag2.calendar_dt.calendar)
 
 
 if __name__ == "__main__":

--- a/shyft/tests/api/test_time_axis.py
+++ b/shyft/tests/api/test_time_axis.py
@@ -71,6 +71,17 @@ class TimeAxis(unittest.TestCase):
         self.assertEqual(tag2.time(0), t0)
         self.assertIsNotNone(tag2.calendar_dt.calendar)
 
+    def test_timeaxis_time_points(self):
+        c = api.Calendar('Europe/Oslo')
+        dt = api.deltahours(1)
+        n = 240
+        t0 = c.time(2016, 4, 10)
+        ta = api.TimeAxis(c, t0, dt, n)
+        tp = ta.time_points
+        self.assertIsNotNone(tp)
+        self.assertEqual(len(tp), n + 1)
+        self.assertEqual(len(api.TimeAxis(c, t0, dt, 0).time_points), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Overview

added:

 *  TimeAxis.time_points -> numpy array of time-points (useful for plot/chart/conversions)
 *  somewhat more debug friendly time-axis str representation

fixed:
 * exposure of TimeAxis.calendar_dt.calendar so that it works regardless access-paths

