### PR TITLE
fixing mapping of hbv parameters when writing optimized parameters to yaml file after calibration

### DIFF
--- a/shyft/orchestration/simulators/config_simulator.py
+++ b/shyft/orchestration/simulators/config_simulator.py
@@ -165,7 +165,7 @@ class ConfigCalibrator(simulator.DefaultSimulator):
         """Save calibrated params in a model-like YAML file."""
         name_map = {"pt": "priestley_taylor", "kirchner": "kirchner", "p_corr": "precipitation_correction",
                     "ae": "actual_evapotranspiration", "gs": "gamma_snow", "ss": "skaugen_snow", "hs": "hbv_snow","gm":"glacier_melt",
-                    "hbv_actual_evapotranspiration": "ae", "hbv_soil": "soil", "hbv_tank": "tank","routing":"routing"
+                    "ae": "hbv_actual_evapotranspiration", "soil": "hbv_soil", "tank": "hbv_tank","routing":"routing"
                     }
         model_file = self.model_config_file
         model_dict = yaml.load(open(model_file))


### PR DESCRIPTION
There is a key error when writing calibration results of an hbv-stack calibration to yaml files. The reason is a mixup of mapping arguments. The suggested solution should work - I tested it with an HBV version of the shyft-doc notebooks.

However, there is sth one should be aware - and this probably needs to be fixed to my understanding:

The parameters of actual evaportanspiration of the pt_gs_k stack and of the hbv stack both map to "ae" (see e.g. api.hbv_stack.HbvParameter.ae). This can lead to false mapping, when using the mapping backward, as done in [here](https://github.com/statkraft/shyft/blob/master/shyft/orchestration/simulators/config_simulator.py#L168). In the shown example, the key "ae" is thus used twice in the dictionary, where it should be unique.
This can lead to a false parameter name in the output model.yaml file (e.g. "actual_evapotranspiration" instead of "hbv_actual_evapotranspiration" and vice versa).