### PR TITLE
fixing state collect issue as reported by Yisak

### DIFF
--- a/core/cell_model.h
+++ b/core/cell_model.h
@@ -139,7 +139,7 @@ namespace shyft {
         /**Utility function used to  initialize a pts_t in the core, typically making space, zero fill a ts
         *  prior to a run to ensure values are zero */
         inline void ts_init(pts_t&ts, const timeaxis&ta, int start_step, int n_steps, fx_policy_t fx_policy) {
-            if (ts.size() != ta.size()) {
+            if (ts.size() != ta.size() || ta.size()==0 ) {
                 ts = pts_t(ta, 0.0, fx_policy);
             } else {
                 ts.fill_range(0.0, start_step, n_steps);

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -227,10 +227,14 @@ class RegionModel(unittest.TestCase):
         # now, re-run the process in 24-hours steps x 10
         model.set_states(s0)  # restore state s0
         self.assertEqual(s0.size(), model.initial_state.size())
-        for section in range(10):
-            model2.run_cells(use_ncore=0, start_step=section * 24, n_steps=24)
-            section_discharge = model2.statistics.discharge(cids)
-            self.assertEqual(section_discharge.size(), sum_discharge.size())  # notice here that the values after current step are 0.0
+        for do_collect_state in [False,True]:
+            model2.set_state_collection(-1,do_collect_state)  # issue reported by Yisak, prior to 21.3, this would crash
+            model2.set_states(s0)
+            # now  after fix, it works Ok
+            for section in range(10):
+                model2.run_cells(use_ncore=0, start_step=section * 24, n_steps=24)
+                section_discharge = model2.statistics.discharge(cids)
+                self.assertEqual(section_discharge.size(), sum_discharge.size())  # notice here that the values after current step are 0.0
         stepwise_sum_discharge = model2.statistics.discharge(cids)
         # assert stepwise_sum_discharge == sum_discharge
         diff_ts = sum_discharge.values.to_numpy() - stepwise_sum_discharge.values.to_numpy()


### PR DESCRIPTION
# Overview

Setting state_collection(-1,False) on a model could for some cases cause segmentation fault.

This fixes the issues, plus adds tests that detect the issue before the fix.