### PR TITLE
fixes re-run time-axis

### DIFF
--- a/core/cell_model.h
+++ b/core/cell_model.h
@@ -42,7 +42,7 @@ namespace shyft {
 
 			//< reset/initializes all series with 0.0 and reserves size to ta. size.
 			void init(const timeaxis& ta) {
-                if (ta.size() != temperature.size()) {
+                if (ta != temperature.ta) {
                     temperature = temperature_ts(ta, 0.0);
                     precipitation = precipitation_ts(ta, 0.0);
                     rel_hum = relhum_ts(ta, 0.0);
@@ -139,7 +139,7 @@ namespace shyft {
         /**Utility function used to  initialize a pts_t in the core, typically making space, zero fill a ts
         *  prior to a run to ensure values are zero */
         inline void ts_init(pts_t&ts, const timeaxis&ta, int start_step, int n_steps, fx_policy_t fx_policy) {
-            if (ts.size() != ta.size() || ta.size()==0 ) {
+            if (ts.ta != ta || ta.size()==0 ) {
                 ts = pts_t(ta, 0.0, fx_policy);
             } else {
                 ts.fill_range(0.0, start_step, n_steps);

--- a/test/region_model_test.cpp
+++ b/test/region_model_test.cpp
@@ -148,7 +148,22 @@ TEST_CASE("test_build") {
     rm.run_cells();
     tsz1 = c1.env_ts.temperature.size();
     TS_ASSERT(tsz1>0);
-
+    SUBCASE("re_init_ts_test") { // test case that cover issue reported by Yisak, re-init/re-run did not fixup result time-axis
+        pts_t ts(ta, 2.0);
+        FAST_CHECK_EQ(ts.size(), ta.size());
+        FAST_CHECK_EQ(ta, ts.ta);
+        auto ta2 = ta;
+        ta2.t += sc::deltahours(1);
+        sc::ts_init(ts, ta2, 0, ta.size(), sc::fx_policy_t::POINT_AVERAGE_VALUE);
+        FAST_CHECK_EQ(ts.ta, ta2);
+    }
+    SUBCASE("change_ta_start_only") {
+        auto ta2 = ta;
+        ta2.t += sc::deltahours(1);
+        rm.run_interpolation(ip, ta2, testenv);
+        rm.run_cells();
+        FAST_CHECK_EQ((*rm.get_cells())[0].rc.avg_discharge.ta, ta2);
+    }
     ptgsk_region_model_t rm_copy(rm);
     auto p1 = rm.get_region_parameter();
     auto p2 = rm_copy.get_region_parameter();

--- a/test/test.vcxproj.user
+++ b/test/test.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-tc=test_abs_diff_sum_goal_function</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-tc=test_build</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
   </PropertyGroup>


### PR DESCRIPTION
# Overview
This PR fixes correct start-time on the 
result-time-axis time-series when doing multiple re-runs, with same time-axis size, but different start-times on one model.

