### PR TITLE
Precipitation direct response only for lake/reservoir areas not covered by snow

### DIFF
--- a/core/pt_gs_k.h
+++ b/core/pt_gs_k.h
@@ -300,7 +300,7 @@ namespace shyft {
             const double forest_fraction=geo_cell_data.land_type_fractions_info().forest();
             const double total_lake_fraction = geo_cell_data.land_type_fractions_info().lake() + geo_cell_data.land_type_fractions_info().reservoir(); // both give direct response for now
             const double glacier_fraction = geo_cell_data.land_type_fractions_info().glacier();
-            const double kirchner_fraction = 1 - total_lake_fraction - glacier_fraction;
+            const double kirchner_fraction = 1 - glacier_fraction;
             const double cell_area_m2 = geo_cell_data.area();
             const double glacier_area_m2 = geo_cell_data.area()*glacier_fraction;
             const double altitude= geo_cell_data.mid_point().z;
@@ -324,10 +324,11 @@ namespace shyft {
                                   period.timespan());
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.gs.outflow, response.ae.ae); // all units mm/h over 'same' area
 
+                double bare_lake_fraction = total_lake_fraction*(1.0 - response.gs.sca);// only direct response on bare (no snow-cover) lakes
                 response.total_discharge =
-                      std::max(0.0,prec - response.ae.ae)*total_lake_fraction // when it rains, remove ae. from direct response
+                      std::max(0.0,prec - response.ae.ae)*bare_lake_fraction // when it rains, remove ae. from direct response
                     + shyft::m3s_to_mmh(response.gm_melt_m3s,cell_area_m2)
-                    + response.kirchner.q_avg*kirchner_fraction;
+                    + response.kirchner.q_avg*(kirchner_fraction-bare_lake_fraction);//let kirchner respond to all except glacier and direct lake
                 response.charge_m3s =
                     + shyft::mmh_to_m3s(prec, cell_area_m2)
                     - shyft::mmh_to_m3s(response.ae.ae, cell_area_m2)

--- a/core/pt_hs_k.h
+++ b/core/pt_hs_k.h
@@ -190,7 +190,7 @@ namespace shyft {
             R response;
             const double total_lake_fraction = geo_cell_data.land_type_fractions_info().lake() + geo_cell_data.land_type_fractions_info().reservoir();
             const double glacier_fraction = geo_cell_data.land_type_fractions_info().glacier();
-            const double kirchner_fraction = 1 - total_lake_fraction - glacier_fraction;
+            const double kirchner_fraction = 1 - glacier_fraction;
             const double cell_area_m2 = geo_cell_data.area();
             const double glacier_area_m2 = geo_cell_data.area()*glacier_fraction;
 
@@ -214,11 +214,11 @@ namespace shyft {
                                     period.timespan());
 
                 kirchner.step(period.start, period.end, state.kirchner.q, response.kirchner.q_avg, response.snow.outflow, response.ae.ae); //all units mm/h over 'same' area
-
+                double bare_lake_fraction = total_lake_fraction*(1.0 - state.snow.sca);// only direct response on bare (no snow-cover) lakes
                 response.total_discharge =
-                      std::max(0.0, prec - response.ae.ae)*total_lake_fraction // when it rains, remove ae. from direct response
+                      std::max(0.0, prec - response.ae.ae)*bare_lake_fraction // when it rains, remove ae. from direct response
                     + m3s_to_mmh(response.gm_melt_m3s, cell_area_m2)
-                    + response.kirchner.q_avg * kirchner_fraction;
+                    + response.kirchner.q_avg * (kirchner_fraction-bare_lake_fraction);
                 response.charge_m3s =
                     + shyft::mmh_to_m3s(prec, cell_area_m2)
                     - shyft::mmh_to_m3s(response.ae.ae, cell_area_m2)

--- a/shyft/tests/api/test_region_model_stacks.py
+++ b/shyft/tests/api/test_region_model_stacks.py
@@ -281,7 +281,7 @@ class RegionModel(unittest.TestCase):
         river_upstream_inflow_m3s = model.river_upstream_inflow_m3s(
             1)  # should be 0.0 in this case, since we do not have a routing network
         self.assertIsNotNone(river_out_m3s)
-        self.assertAlmostEqual(river_out_m3s.value(0), 87.4, 0)
+        self.assertAlmostEqual(river_out_m3s.value(0), 108.441, 0)
         self.assertIsNotNone(river_local_m3s)
         self.assertIsNotNone(river_upstream_inflow_m3s)
         model.connect_catchment_to_river(0, 0)

--- a/shyft/tests/test_config_simulator.py
+++ b/shyft/tests/test_config_simulator.py
@@ -33,7 +33,7 @@ class ConfigSimulationTestCase(unittest.TestCase):
         discharge = simulator.region_model.statistics.discharge(cids)
 
         # Regression tests on discharge values
-        self.assertAlmostEqual(discharge.values[0], 0.1961, 3)
+        self.assertAlmostEqual(discharge.values[0], 0.08517, 3)
         self.assertAlmostEqual(discharge.values[3], 2.748813, 3)  #
         # x self.assertAlmostEqual(discharge.values[6400], 58.8385, 3) # was 58.9381,3 before glacier&fractions adjustments
         # x self.assertAlmostEqual(discharge.values[3578],5.5069,3)

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -13,7 +13,7 @@
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="routing_test test_build_valid_river_network" />
+				<Option parameters="-nv -tc=test_mass_balance" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>
@@ -21,7 +21,7 @@
 					<Add directory="../bin/Debug" />
 				</Linker>
 				<ExtraCommands>
-					<Add after="cd ../bin/Debug &amp;&amp; ./test_shyft -nv  --test-suite=serialization" />
+					<Add after="cd ../bin/Debug &amp;&amp; ./test_shyft -nv  -tc=test_mass_balance" />
 					<Mode after="always" />
 				</ExtraCommands>
 			</Target>


### PR DESCRIPTION
# Overview

According to observations,  only precipitation that goes into non-covered lake/reservoir contributes directly to observed/measured inflow. (Little or no direct response is observed during winter-time.)

In periods with no snow-covered areas, the response is exactly as before, the precipitation that goes into reservoir/lakes gives a direct response (unless routed through river-network that is available).

During periods where we have snow covered area, only the uncovered lake/reservoir areas gives a direct response, the other part is routed through kirchner or (hbv)tank routine, so a more smooth response should be expected during these times.

There is no change in the interfaces, although we could have introduced yet another parameter to control this behavior directly.  (Could be another PR later, if needed).

