### PR TITLE
Integral of time-series function

### DIFF
--- a/api/api_serialization.cpp
+++ b/api/api_serialization.cpp
@@ -57,6 +57,15 @@ void shyft::api::average_ts::serialize(Archive & ar, const unsigned int version)
 }
 
 template<class Archive>
+void shyft::api::integral_ts::serialize(Archive & ar, const unsigned int version) {
+    ar
+        & make_nvp("ipoint_ts", base_object<shyft::api::ipoint_ts>(*this))
+        & make_nvp("ta", ta)
+        & make_nvp("ts", ts)
+        ;
+}
+
+template<class Archive>
 void shyft::api::accumulate_ts::serialize(Archive & ar, const unsigned int version) {
     ar
     & make_nvp("ipoint_ts",base_object<shyft::api::ipoint_ts>(*this))
@@ -171,6 +180,7 @@ x_serialize_implement(shyft::api::ipoint_ts);
 x_serialize_implement(shyft::api::gpoint_ts);
 x_serialize_implement(shyft::api::aref_ts);
 x_serialize_implement(shyft::api::average_ts);
+x_serialize_implement(shyft::api::integral_ts);
 x_serialize_implement(shyft::api::accumulate_ts);
 x_serialize_implement(shyft::api::time_shift_ts);
 x_serialize_implement(shyft::api::periodic_ts);
@@ -199,6 +209,7 @@ x_arch(shyft::api::ipoint_ts);
 x_arch(shyft::api::gpoint_ts);
 x_arch(shyft::api::aref_ts);
 x_arch(shyft::api::average_ts);
+x_arch(shyft::api::integral_ts);
 x_arch(shyft::api::accumulate_ts);
 x_arch(shyft::api::time_shift_ts);
 x_arch(shyft::api::periodic_ts);

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -177,7 +177,17 @@ namespace expose {
                 doc_notes()
                 doc_note("the self point interpretation policy is used when calculating the true average")
 			)
-			.def("accumulate", &shyft::api::apoint_ts::accumulate, args("ta"),
+            .def("integral", &shyft::api::apoint_ts::integral, args("ta"),
+                doc_intro("create a new ts that is the true integral of self")
+                doc_intro("over the specified time-axis ta.")
+                doc_intro(" defined as integral of the non-nan part of each time-axis interval")
+                doc_parameters()
+                doc_parameter("ta", "TimeAxis", "time-axis that specifies the periods where true-integral is applied")
+                doc_returns("ts", "TimeSeries", "a new time-series expression, that will provide the true-integral when requested")
+                doc_notes()
+                doc_note("the self point interpretation policy is used when calculating the true average")
+            )
+            .def("accumulate", &shyft::api::apoint_ts::accumulate, args("ta"),
                 doc_intro("create a new ts where each i'th value is the ")
                 doc_intro("    integral f(t) *dt, from t0..ti,")
                 doc_intro("given the specified time-axis ta")
@@ -250,9 +260,12 @@ namespace expose {
 
         ;
         typedef shyft::api::apoint_ts (*avg_func_t)(const shyft::api::apoint_ts&,const shyft::time_axis::generic_dt&);
+        typedef shyft::api::apoint_ts(*int_func_t)(const shyft::api::apoint_ts&, const shyft::time_axis::generic_dt&);
         avg_func_t avg=shyft::api::average;
+        int_func_t intfnc = shyft::api::integral;
 		avg_func_t acc = shyft::api::accumulate;
         def("average",avg,args("ts","time_axis"),"creates a true average time-series of ts for intervals as specified by time_axis");
+        def("integral", intfnc, args("ts", "time_axis"), "creates a true integral time-series of ts for intervals as specified by time_axis");
 		def("accumulate", acc, args("ts", "time_axis"), "create a new ts that is the integral f(t) *dt, t0..ti, the specified time-axis");
         //def("max",shyft::api::max,(boost::python::arg("ts_a"),boost::python::arg("ts_b")),"creates a new time-series that is the max of the supplied ts_a and ts_b");
 

--- a/api/timeseries.cpp
+++ b/api/timeseries.cpp
@@ -19,6 +19,8 @@ namespace shyft{
        // add operators and functions to the apoint_ts class, of all variants that we want to expose
         apoint_ts average(const apoint_ts& ts,const gta_t& ta/*fx-type */)  { return apoint_ts(std::make_shared<average_ts>(ta,ts));}
         apoint_ts average(apoint_ts&& ts,const gta_t& ta)  { return apoint_ts(std::make_shared<average_ts>(ta,std::move(ts)));}
+        apoint_ts integral(const apoint_ts& ts, const gta_t& ta/*fx-type */) { return apoint_ts(std::make_shared<integral_ts>(ta, ts)); }
+        apoint_ts integral(apoint_ts&& ts, const gta_t& ta) { return apoint_ts(std::make_shared<integral_ts>(ta, std::move(ts))); }
 
 		apoint_ts accumulate(const apoint_ts& ts, const gta_t& ta/*fx-type */) { return apoint_ts(std::make_shared<accumulate_ts>(ta, ts)); }
 		apoint_ts accumulate(apoint_ts&& ts, const gta_t& ta) { return apoint_ts(std::make_shared<accumulate_ts>(ta, std::move(ts))); }
@@ -122,6 +124,9 @@ namespace shyft{
         apoint_ts apoint_ts::average(const gta_t &ta) const {
             return shyft::api::average(*this,ta);
         }
+        apoint_ts apoint_ts::integral(const gta_t &ta) const {
+            return shyft::api::integral(*this, ta);
+        }
 		apoint_ts apoint_ts::accumulate(const gta_t &ta) const {
 			return shyft::api::accumulate(*this, ta);
 		}
@@ -142,7 +147,9 @@ namespace shyft{
                     ;// maybe throw ?
             } else if (dynamic_cast<const api::average_ts*>(its.get())) {
                 find_ts_bind_info(dynamic_cast<const api::average_ts*>(its.get())->ts, r);
-            } else if (dynamic_cast<const api::accumulate_ts*>(its.get())) {
+            } else if (dynamic_cast<const api::integral_ts*>(its.get())) {
+                find_ts_bind_info(dynamic_cast<const api::integral_ts*>(its.get())->ts, r);
+            } else if(dynamic_cast<const api::accumulate_ts*>(its.get())) {
                 find_ts_bind_info(dynamic_cast<const api::accumulate_ts*>(its.get())->ts, r);
             } else if (dynamic_cast<const api::time_shift_ts*>(its.get())) {
                 find_ts_bind_info(dynamic_cast<const api::time_shift_ts*>(its.get())->ts, r);

--- a/shyft/tests/api/test_dtss.py
+++ b/shyft/tests/api/test_dtss.py
@@ -49,7 +49,8 @@ class DtssTestCase(unittest.TestCase):
             tsv.append(float(1 + i / 10) * TimeSeries(ta, np.linspace(start=0, stop=1.0, num=ta.size()),
                                                       point_fx.POINT_AVERAGE_VALUE))
 
-        tsv.append(TimeSeries('dummy://a'))
+        dummy_ts= TimeSeries('dummy://a')
+        tsv.append(dummy_ts.integral(ta))
 
         # then start the server
         dtss = DtsServer()
@@ -74,7 +75,7 @@ class DtssTestCase(unittest.TestCase):
             assert_array_almost_equal(r1[i].values.to_numpy(), tsv[i].values.to_numpy(), decimal=4)
 
         self.assertEqual(len(r2), len(percentile_list))
-        tsv[len(tsv)-1].bind(TimeSeries(ta,fill_value=1.0))
+        dummy_ts.bind(TimeSeries(ta,fill_value=1.0))
         p2 = tsv.percentiles(ta24, percentile_list)
         # r2 = tsv.percentiles(ta24,percentile_list)
 

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -303,6 +303,23 @@ class TimeSeries(unittest.TestCase):
             self.assertAlmostEqual(expected_value, ts1.value(i), 3, "expect integral f(t)*dt")
             self.assertAlmostEqual(expected_value, ts1_values[i], 3, "expect value vector equal as well")
 
+    def test_integral(self):
+        c = api.Calendar()
+        t0 = c.time(2016, 1, 1)
+        dt = api.deltahours(1)
+        n = 240
+        ta = api.TimeAxis(t0, dt, n)
+        fill_value = 1.0
+        ts = api.TimeSeries(ta=ta, fill_value=fill_value, point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)
+        ts_i1 = ts.integral(ta)
+        ts_i2 = api.integral(ts,ta)
+        ts_i1_values = ts_i1.values
+        for i in range(n):
+            expected_value = dt*fill_value
+            self.assertAlmostEqual(expected_value,ts_i1.value(i),4,"expect integral of each interval")
+            self.assertAlmostEqual(expected_value,ts_i2.value(i),4,"expect integral of each interval")
+            self.assertAlmostEqual(expected_value,ts_i1_values[i],4,"expect integral of each interval")
+
     def test_kling_gupta_and_nash_sutcliffe(self):
         """
         Test/verify exposure of the kling_gupta and nash_sutcliffe correlation functions

--- a/test/timeseries_test.cpp
+++ b/test/timeseries_test.cpp
@@ -748,6 +748,16 @@ TEST_CASE("test_api_ts") {
     for(const auto&v:cv) {
         TS_ASSERT_DELTA(v,(a_value+3*b_value)*4 +(a_value*b_value/2.0), 0.001);
     }
+    SUBCASE("integral_ts") {
+        auto a_i_ts = a.integral(ta2);
+        auto a_i_v = a_i_ts.values();
+        TS_ASSERT_EQUALS(a_i_v.size(), ta2.size());
+        for (size_t i = 0;i < ta2.size();++i) {
+            TS_ASSERT_DELTA(a_i_v[i], a_i_ts.value(i), 0.00001);
+            TS_ASSERT_DELTA(a_i_v[i], a_value*double(ta2.period(i).timespan()),0.00001);
+        }
+    }
+
     // verify some special fx
     a.set(0,a_value*b_value);
     TS_ASSERT_DELTA(a.value(0),a_value*b_value,0.0001);


### PR DESCRIPTION
# Overview

This is a minor functional extension, adding 

TimeSeries.integral(ta:TimeAxis)->TimeSeries member function and
corresponding free api function:
integral(ts:TimeSeries,ta:TimeAxis)->TimeSeries 

Usage and tests included in python tests-suite:
```python
    def test_integral(self):
        c = api.Calendar()
        t0 = c.time(2016, 1, 1)
        dt = api.deltahours(1)
        n = 240
        ta = api.TimeAxis(t0, dt, n)
        fill_value = 1.0
        ts = api.TimeSeries(ta=ta, fill_value=fill_value, point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)
        ts_i1 = ts.integral(ta)
        ts_i2 = api.integral(ts,ta)
        ts_i1_values = ts_i1.values
        for i in range(n):
            expected_value = dt*fill_value
            self.assertAlmostEqual(expected_value,ts_i1.value(i),4,"expect integral of each interval")
            self.assertAlmostEqual(expected_value,ts_i2.value(i),4,"expect integral of each interval")
            self.assertAlmostEqual(expected_value,ts_i1_values[i],4,"expect integral of each interval")
```
