### PR TITLE
Improve  and utilize multi-core performance, percentiles with nan support

### DIFF
--- a/api/api.cbp
+++ b/api/api.cbp
@@ -3,7 +3,6 @@
 	<FileVersion major="1" minor="6" />
 	<Project>
 		<Option title="api" />
-		<Option pch_mode="2" />
 		<Option compiler="gcc" />
 		<Build>
 			<Target title="Debug">

--- a/api/api.cpp
+++ b/api/api.cpp
@@ -1,3 +1,3 @@
-#include "api.h"
+//#include "api.h"
 
 

--- a/api/boostpython/boostpython.cbp
+++ b/api/boostpython/boostpython.cbp
@@ -3,7 +3,6 @@
 	<FileVersion major="1" minor="6" />
 	<Project>
 		<Option title="boostpython" />
-		<Option pch_mode="2" />
 		<Option compiler="gcc" />
 		<Option virtualFolders="api/;" />
 		<Build>

--- a/api/time_series.cpp
+++ b/api/time_series.cpp
@@ -233,13 +233,15 @@ namespace shyft{
         apoint_ts apoint_ts::convolve_w(const std::vector<double> &w, shyft::time_series::convolve_policy conv_policy) const {
             return apoint_ts(std::make_shared<shyft::api::convolve_w_ts>(*this, w, conv_policy));
         }
-        std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const gta_t& ta, const vector<int>& percentile_list) {
+
+
+        std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& tsv1,const gta_t& ta, const vector<int>& percentile_list) {
             std::vector<apoint_ts> r;r.reserve(percentile_list.size());
-            //-- use core calc here:
-            auto rp= shyft::time_series::calculate_percentiles(ta,ts_list,percentile_list);
+            auto rp= shyft::time_series::calculate_percentiles(ta,deflate_ts_vector<gts_t>(tsv1),percentile_list);
             for(auto&ts:rp) r.emplace_back(ta,std::move(ts.v),POINT_AVERAGE_VALUE);
             return r;
         }
+
         std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const time_axis::fixed_dt& ta, const vector<int>& percentile_list) {
             return percentiles(ts_list,time_axis::generic_dt(ta),percentile_list);
         }
@@ -248,20 +250,6 @@ namespace shyft{
             if(i==std::string::npos || i>=time_axis().size() )
                 return nan;
             return value_at(time_axis().time(i));
-            // Hmm! here we have to define what value(i) means
-            // .. we could define it as
-            //     the value at the beginning of the i'th period
-            //
-            //   then we define value(t) as
-            //    as the point interpretation of f(t)..
-            //
-            //if(fx_policy==ts_point_fx::POINT_AVERAGE_VALUE)
-            //    return value_at(ta.time(i));
-            //utcperiod p=ta.period(i);
-            //double v0= value_at(p.start);
-            //double v1= value_at(p.end);
-            //if(isfinite(v1)) return 0.5*(v0 + v1);
-            //return v0;
         }
         double abin_op_scalar_ts::value_at(utctime t) const {
             bind_check();

--- a/core/core.cbp
+++ b/core/core.cbp
@@ -3,7 +3,6 @@
 	<FileVersion major="1" minor="6" />
 	<Project>
 		<Option title="core" />
-		<Option pch_mode="2" />
 		<Option compiler="gcc" />
 		<Option virtualFolders="methods/;interpolation/;method_stacks/;time_and_calendar/;geo/;time_series/;compiler_etc/;experimental/;optimizers/;serialization/;" />
 		<Option show_notes="0">
@@ -180,10 +179,10 @@
 		<Unit filename="time_series.h">
 			<Option virtualFolder="time_series/" />
 		</Unit>
-    <Unit filename="time_series_statistics.h">
-      <Option virtualFolder="time_series/" />
-    </Unit>
-    <Unit filename="unit_conversion.h">
+		<Unit filename="time_series_statistics.h">
+			<Option virtualFolder="time_series/" />
+		</Unit>
+		<Unit filename="unit_conversion.h">
 			<Option virtualFolder="compiler_etc/" />
 		</Unit>
 		<Unit filename="utctime_utilities.cpp">

--- a/core/dtss.h
+++ b/core/dtss.h
@@ -117,11 +117,7 @@ namespace shyft {
             ts_vector_t
             do_evaluate_ts_vector(core::utcperiod bind_period, ts_vector_t& atsv) {
                 do_bind_ts(bind_period, atsv);
-                ts_vector_t evaluated_tsv;
-                for (auto &ats : atsv) // TODO: in parallel
-                   evaluated_tsv.emplace_back(ats.time_axis(), ats.values(), ats.point_interpretation());
-
-                return evaluated_tsv;
+                return api::deflate_ts_vector<api::apoint_ts>(atsv);
             }
 
             ts_vector_t

--- a/core/time_series_statistics.h
+++ b/core/time_series_statistics.h
@@ -160,38 +160,42 @@ namespace shyft {
         accessor "accumulate" on time-axis to dt, using stair-case or linear between points
         create result vector[1..n] (the time-axis dimension)
         where each element is vector[1..np] (for each timestep, we get the percentiles
-        for each timestep_i in time-axis
-        for each tsa_i: accessors(time-axis,ts)
-        sample vector[timestep_i].emplace_back( tsa_i(time_step_i) )
-        percentiles_timeseries[timestep_i]= calculate_percentiles(..)
+         for each timestep_i in time-axis
+          for each tsa_i: accessors(time-axis,ts)
+            sample vector[timestep_i].emplace_back( tsa_i(time_step_i) ) (possibly skipping nans if selected)
+            percentiles_timeseries[timestep_i]= calculate_percentiles(..)
+
 
         \return percentiles_timeseries
 
         */
         template <class ts_t, class ta_t>
-        inline std::vector< point_ts<ta_t> > calculate_percentiles(const ta_t& ta, const std::vector<ts_t>& ts_list, const std::vector<int>& percentiles, size_t min_t_steps = 1000) {
+        inline std::vector< point_ts<ta_t> > calculate_percentiles(const ta_t& ta, const std::vector<ts_t>& ts_list, const std::vector<int>& percentiles, size_t min_t_steps = 1000,bool skip_nans=true) {
             std::vector<point_ts<ta_t>> result;
             auto fx_p = ts_list.size() ? ts_list.front().point_interpretation() : ts_point_fx::POINT_AVERAGE_VALUE;
             for (size_t r = 0; r < percentiles.size(); ++r) // pre-init the result ts that we are going to fill up
                 result.emplace_back(ta, 0.0, fx_p);
 
-            auto partition_calc = [&result, &ts_list, &ta, &percentiles](size_t i0, size_t n) {
+            auto partition_calc = [&result, &ts_list, &ta, &percentiles,skip_nans](size_t i0, size_t n) {
 
                 std::vector < average_accessor<ts_t, ta_t>> tsa_list; tsa_list.reserve(ts_list.size());
                 for (const auto& ts : ts_list) // initialize the ts accessors to we can accumulate to time-axis ta e.g.(hour->day)
                     tsa_list.emplace_back(ts, ta);
 
-                std::vector<double> samples(tsa_list.size(), 0.0);
+                std::vector<double> samples;samples.reserve(tsa_list.size());
 
                 for (size_t t = i0; t < i0 + n; ++t) {//each time step t in the time-axis, here we could do parallel partition
-                    for (size_t i = 0; i < tsa_list.size(); ++i) // get samples from all the "tsa"
-                        samples[i] = tsa_list[i].value(t);
+                    samples.clear();
+                    for (size_t i = 0; i < tsa_list.size(); ++i) { // get samples from all the "tsa"
+                        auto v=tsa_list[i].value(t);
+                        if(!skip_nans || isfinite(v))
+                            samples.emplace_back(v);
+                    }
                     // possible with pipe-line to percentile calc here !
                     std::vector<double> percentiles_at_t(calculate_percentiles_excel_method_full_sort(samples, percentiles));
                     for (size_t p = 0; p < result.size(); ++p) {
-                        if(percentiles[p]==statistics_property::MAX_EXTREME || percentiles[p]==statistics_property::MIN_EXTREME)
-                            continue;
-                        result[p].set(t, percentiles_at_t[p]);
+                        if(!(percentiles[p]==statistics_property::MAX_EXTREME || percentiles[p]==statistics_property::MIN_EXTREME))
+                            result[p].set(t, percentiles_at_t[p]);
                     }
                 }
             };

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -3,7 +3,6 @@
 	<FileVersion major="1" minor="6" />
 	<Project>
 		<Option title="test" />
-		<Option pch_mode="2" />
 		<Option compiler="gcc" />
 		<Option virtualFolders="methods/;method_stacks/;interpolation/;optimizers/;utils/;compiler_etc/;time_and_calendar/;serialization/;full_model/;api/;time_series/;routing/;dtss/;" />
 		<Build>
@@ -13,7 +12,7 @@
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="-ts=time_series.h" />
+				<Option parameters="-nv -tc=test_ts_statistics_calculations" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>

--- a/test/time_series_test.cpp
+++ b/test/time_series_test.cpp
@@ -932,6 +932,20 @@ TEST_CASE("test_ts_statistics_calculations") {
     TS_ASSERT_DELTA(r1[5].value(0), 9.0,0.0001);// "100-percentile");
     TS_ASSERT_DELTA(r1[6].value(0), 0.0, 0.0001);// "-1000 min xtreme");
     TS_ASSERT_DELTA(r1[7].value(0), 9.0, 0.0001);// "+1000 max xtreme");
+    SUBCASE("with_nan_ts") {
+        auto ts_w_nans=tts_t(ta,shyft::nan,POINT_AVERAGE_VALUE);
+        tsv1.push_back(ts_w_nans);
+        r1 = calculate_percentiles(tad, tsv1, {0,10,50,statistics_property::AVERAGE,70,100,statistics_property::MIN_EXTREME,statistics_property::MAX_EXTREME});
+        // nan are ignored(filtered out) by default
+        TS_ASSERT_DELTA(r1[0].value(0), 0.0,0.0001);// " 0-percentile");
+        TS_ASSERT_DELTA(r1[1].value(0), 0.9,0.0001);// "10-percentile");
+        TS_ASSERT_DELTA(r1[2].value(0), 4.5,0.0001);// "50-percentile");
+        TS_ASSERT_DELTA(r1[3].value(0), 4.5,0.0001);// "avg");
+        TS_ASSERT_DELTA(r1[4].value(0), 6.3,0.0001);// "70-percentile");
+        TS_ASSERT_DELTA(r1[5].value(0), 9.0,0.0001);// "100-percentile");
+        TS_ASSERT_DELTA(r1[6].value(0), 0.0, 0.0001);// "-1000 min xtreme");
+        TS_ASSERT_DELTA(r1[7].value(0), 9.0, 0.0001);// "+1000 max xtreme");
+    }
 }
 
 /** just verify that it calculate at full speed */


### PR DESCRIPTION
# Overview

This PR contains internal computational improvements to the dtss functionality,
giving speedups 5x..10x depending on context.

The PR also contains a minor change to the percentile function that now supports nan in the
source ts's. They are simply filtered out, giving fewer members that goes into the
percentile calculation. Future extensions here includes ability to specify what to
do when encountering nan's, -like ignore, or set result to nan. (context/application specific).

For linux/codeblocks, we switch to putting precompiled headers into destination directories.
This solves the problem when you switch between debug/release build (the gch is invalid for one of them). However, you need to remove the .gch files generated from previous builds of codeblocks.
With the new settings, the PCH generated are specific for Debug and/or Release, kept in different directories, so switching Debug/Release builds goes without having to remove .gch files.
