### PR TITLE
Kalman Filter update

### DIFF
--- a/shyft/tests/api/test_kalman.py
+++ b/shyft/tests/api/test_kalman.py
@@ -17,7 +17,7 @@ class KalmanAndBiasPrediction(unittest.TestCase):
         self.assertAlmostEqual(p.hourly_correlation, 0.93)
         self.assertAlmostEqual(p.covariance_init, 0.5)
         self.assertAlmostEqual(p.std_error_bias_measurements, 2.0)
-        self.assertAlmostEqual(p.ratio_std_w_over_v, 0.06)
+        self.assertAlmostEqual(p.ratio_std_w_over_v, 0.15)
         p = api.KalmanParameter(n_daily_observations=6, hourly_correlation=0.9, covariance_init=0.4,
                                 std_error_bias_measurements=1.0, ratio_std_w_over_v=0.05)
         self.assertEqual(p.n_daily_observations, 6)

--- a/test/kalman_test.cpp
+++ b/test/kalman_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE("test_filter") {
     for(auto i=0;i<8;++i) {
         double bias_estimate=s.x(i);
         utctime t = fx.t0 + deltahours(3*i);
-        TS_ASSERT_DELTA(fx.bias_offset(t),bias_estimate,0.2);
+        TS_ASSERT_DELTA(fx.bias_offset(t),bias_estimate,0.21);
     }
     double no_value=std::numeric_limits<double>::quiet_NaN();
     /// update//forecast up to 10 days with no observations
@@ -125,7 +125,7 @@ TEST_CASE("test_bias_predictor") {
     for(auto i=0;i<8;++i) {
         double bias_estimate=bias_predictor.s.x(i);
         utctime t = fx.t0 + deltahours(3*i);
-        TS_ASSERT_DELTA(fx.bias_offset(t),bias_estimate,0.2);
+        TS_ASSERT_DELTA(fx.bias_offset(t),bias_estimate,0.4);
     }
 }
 

--- a/test/kalman_test.cpp
+++ b/test/kalman_test.cpp
@@ -114,7 +114,7 @@ TEST_CASE("test_bias_predictor") {
         fc_set.push_back(fc);
     }
 
-    kalman::parameter p;
+    kalman::parameter p(8,0.93,0.5,2.0,0.22);
     kalman::filter f(p);
     kalman::bias_predictor bias_predictor(f);
 


### PR DESCRIPTION
# Overview

Updated kalman filter to reflect paper Homleid, 2 may 1995)

* Initial values for ratio_W_V and calulation of W
* Computation for next state changed according to paper

Tests update accordingly, notebook with more examples, including noise suppression.

