### PR TITLE
Time-series vector operations support

### DIFF
--- a/api/api_serialization.cpp
+++ b/api/api_serialization.cpp
@@ -100,6 +100,13 @@ void shyft::api::convolve_w_ts::serialize(Archive & ar, const unsigned int versi
     ;
 }
 
+template<class Archive>
+void shyft::api::ats_vector::serialize(Archive& ar, const unsigned int version) {
+    ar
+    & make_nvp("ats_vec",base_object<shyft::api::ats_vec>(*this))
+    ;
+}
+
 // kind of special, mix core and api, hmm!
 template<>
 template <class Archive>
@@ -198,7 +205,7 @@ x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::hbv_stack::sta
 x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::pt_gs_k::state>);
 x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::pt_ss_k::state>);
 x_serialize_implement(shyft::api::cell_state_with_id<shyft::core::pt_hs_k::state>);
-
+x_serialize_implement(shyft::api::ats_vector);
 //
 // 4. Then include the archive supported
 //
@@ -227,7 +234,7 @@ x_arch(shyft::api::cell_state_with_id<shyft::core::hbv_stack::state>);
 x_arch(shyft::api::cell_state_with_id<shyft::core::pt_gs_k::state>);
 x_arch(shyft::api::cell_state_with_id<shyft::core::pt_ss_k::state>);
 x_arch(shyft::api::cell_state_with_id<shyft::core::pt_hs_k::state>);
-
+x_arch(shyft::api::ats_vector);
 
 std::string shyft::api::apoint_ts::serialize() const {
     using namespace std;

--- a/api/boostpython/api_dtss.cpp
+++ b/api/boostpython/api_dtss.cpp
@@ -69,16 +69,16 @@ namespace shyft {
 
             ts_vector_t fire_cb(id_vector_t const &ts_ids,core::utcperiod p) {
                 //std::cout << "cb("<<ts_ids.size()<<")\n";
-                std::vector<api::apoint_ts> r;
+                api::ats_vector r;
                 if (cb.ptr()!=Py_None) {
                     scoped_gil_aquire gil;
                     //std::cout<<" py cb.."<<std::endl;std::cout.flush();
-                    r = boost::python::call<std::vector<api::apoint_ts>>(cb.ptr(), ts_ids, p);
+                    r = boost::python::call<ts_vector_t>(cb.ptr(), ts_ids, p);
                 } else {
                     // for testing, just fill in constant values.
                     api::gta_t ta(p.start, core::deltahours(1), p.timespan() / core::deltahours(1));
                     for (size_t i = 0;i < ts_ids.size();++i)
-                        r.emplace_back(ta, double(i), time_series::ts_point_fx::POINT_AVERAGE_VALUE);
+                        r.push_back(api::apoint_ts(ta, double(i), time_series::ts_point_fx::POINT_AVERAGE_VALUE));
                 }
                 return r;
             }
@@ -110,7 +110,7 @@ namespace shyft {
             }
             ts_vector_t evaluate(ts_vector_t const& tsv, core::utcperiod p) {
                 scoped_gil_release gil;
-                return impl.evaluate(tsv,p);
+                return ts_vector_t(impl.evaluate(tsv,p));
             }
 
         };
@@ -123,7 +123,7 @@ namespace expose {
     using namespace boost::python;
     void dtss_finalize() {
 #ifdef _WIN32
-        //to avoid infinite hang at exit on win, you need git clone https://github.com/sigbjorn/dlib 
+        //to avoid infinite hang at exit on win, you need git clone https://github.com/sigbjorn/dlib
         WSACleanup();
 #endif
     }

--- a/api/boostpython/api_kalman.cpp
+++ b/api/boostpython/api_kalman.cpp
@@ -14,7 +14,7 @@ namespace expose {
 	typedef std::shared_ptr<geo_temperature_vector> geo_temperature_vector_;
 	typedef std::vector<sa::PrecipitationSource> geo_precipitation_vector;
 	typedef std::shared_ptr<geo_precipitation_vector> geo_precipitation_vector_;
-    typedef std::vector<sa::apoint_ts> apoint_ts_vector; // this type is already exposed in api, so we can use it directly
+    typedef sa::ats_vector apoint_ts_vector; // this type is already exposed in api, so we can use it directly
 
 
 	static void kalman_parameter() {

--- a/api/time_series.h
+++ b/api/time_series.h
@@ -9,926 +9,1028 @@ namespace shyft {
     namespace api {
         using namespace shyft::core;
         using namespace shyft::time_series;
-            /**
-                time-series math to be exposed to python
+        /**
+            time-series math to be exposed to python
 
-                This provide functionality like
+            This provide functionality like
 
-                a = TsFactory.create_ts(..)
-                b = TsFactory.create_ts(..)
-                c = a + 3*b
-                d = max(c,0.0)
+            a = TsFactory.create_ts(..)
+            b = TsFactory.create_ts(..)
+            c = a + 3*b
+            d = max(c,0.0)
 
-                implementation strategy
+            implementation strategy
 
-                provide a type apoint_ts, that always appears as a time-series.
+            provide a type apoint_ts, that always appears as a time-series.
 
-                It could however represent either a
-                  point_ts<time_axis:generic_dt>
-                or an expression
-                  like a abin_op_ts( lhs,op,rhs)
+            It could however represent either a
+              point_ts<time_axis:generic_dt>
+            or an expression
+              like a abin_op_ts( lhs,op,rhs)
 
-                Then we provide operators:
-                apoint_ts bin_op a_point_ts
-                and
-                double bin_op a_points_ts
+            Then we provide operators:
+            apoint_ts bin_op a_point_ts
+            and
+            double bin_op a_points_ts
+         */
+
+        /** \brief generic time-axis
+
+            Using the time_axis library and concept directly.
+            This time-axis is generic, but currently only dense-types
+            fixed_dt (fastest)
+            calendar_dt( quite fast, but with calendar semantics)
+            point_dt ( a point at start of each interval, plus the end point of the last interval, could give performance hits in some scenarios)
+
+         */
+        typedef shyft::time_axis::generic_dt gta_t;
+        typedef shyft::time_series::point_ts<gta_t> gts_t;
+        typedef shyft::time_series::point_ts<time_axis::fixed_dt> rts_t;
+        /** \brief A virtual abstract interface (thus the prefix i) base for point_ts
+         *
+         * There are three defining properties of a time-series:
+         *
+         * 1. The \ref time_axis provided by the time_axis() method
+         *    or direct time-axis information as provided by the
+         *    total_period(),size(), time(i), index_of(t) methods
+         *
+         * 2. The values, provided by values(),
+         *    or any of the value(i),value_at(utctime t) methods.
+         *
+         * 3. The \ref ts_point_fx
+         *    that determines how the points should be projected to f(t)
+         *
+         */
+        struct ipoint_ts {
+            typedef gta_t ta_t;// time-axis type
+            ipoint_ts() {} // ease boost serialization
+            virtual ~ipoint_ts(){}
+
+            virtual ts_point_fx point_interpretation() const =0;
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) =0;
+
+            /** \return Returns the effective time-axis of the timeseries
              */
+            virtual const gta_t& time_axis() const =0;
 
-            /** \brief generic time-axis
-
-                Using the time_axis library and concept directly.
-                This time-axis is generic, but currently only dense-types
-                fixed_dt (fastest)
-                calendar_dt( quite fast, but with calendar semantics)
-                point_dt ( a point at start of each interval, plus the end point of the last interval, could give performance hits in some scenarios)
-
+            /** \return the total period of time_axis(), same as time_axis().total_period()
              */
-            typedef shyft::time_axis::generic_dt gta_t;
-            typedef shyft::time_series::point_ts<gta_t> gts_t;
-			typedef shyft::time_series::point_ts<time_axis::fixed_dt> rts_t;
-            /** \brief A virtual abstract interface (thus the prefix i) base for point_ts
-             *
-             * There are three defining properties of a time-series:
-             *
-             * 1. The \ref time_axis provided by the time_axis() method
-             *    or direct time-axis information as provided by the
-             *    total_period(),size(), time(i), index_of(t) methods
-             *
-             * 2. The values, provided by values(),
-             *    or any of the value(i),value_at(utctime t) methods.
-             *
-             * 3. The \ref ts_point_fx
-             *    that determines how the points should be projected to f(t)
-             *
+            virtual utcperiod total_period() const=0;
+
+            /** \return the index_of(utctime t), using time_axis().index_of(t) \ref time_axis::fixed_dt
              */
-            struct ipoint_ts {
-                typedef gta_t ta_t;// time-axis type
-                ipoint_ts() {} // ease boost serialization
-                virtual ~ipoint_ts(){}
+            virtual size_t index_of(utctime t) const=0; ///< we might want index_of(t,ix-hint..)
 
-                virtual ts_point_fx point_interpretation() const =0;
-                virtual void set_point_interpretation(ts_point_fx point_interpretation) =0;
-
-                /** \return Returns the effective time-axis of the timeseries
-                 */
-                virtual const gta_t& time_axis() const =0;
-
-                /** \return the total period of time_axis(), same as time_axis().total_period()
-                 */
-                virtual utcperiod total_period() const=0;
-
-                /** \return the index_of(utctime t), using time_axis().index_of(t) \ref time_axis::fixed_dt
-                 */
-                virtual size_t index_of(utctime t) const=0; ///< we might want index_of(t,ix-hint..)
-
-                /** \return number of points that descr. y=f(t) on t ::= period
-                 */
-                virtual size_t size() const=0;
-
-                /** \return time_axis().time(i), the start of the i'th period in the time-axis
-                 */
-                virtual utctime time(size_t i) const=0;
-
-                /** \return the value at the i'th period of the time-axis
-                 */
-                virtual double value(size_t i) const=0;
-
-                /** \return the f(t) at the specified time t, \note if t outside total_period() nan is returned
-                 */
-                virtual double value_at(utctime t) const =0;
-
-                /** \return the values, one for each of the time_axis() intervals as a vector
-                 */
-                virtual std::vector<double> values() const =0;
-
-                /** for internal computation and expression trees, we need to know *if*
-                 * there are unbound symbolic ts in the chain of this ts
-                 * We know that a point-ts never do not need a binding, but
-                 * all others are expressions of ts, and could potentially
-                 * needs a bind (if it has an unbound symbolic ts in it's siblings)
-                 */
-                virtual bool needs_bind() const =0;
-
-                /** propagate do_bind to expression tree siblings(if any)
-                 * then do any needed binding stuff needed for the specific class impl.
-                 */
-                virtual void do_bind()=0;
-
-                // to be removed:
-                point get(size_t i) const {return point(time(i),value(i));}
-                x_serialize_decl();
-            };
-            struct average_ts;//fwd api
-			struct accumulate_ts;//fwd api
-            struct integral_ts;// fwd api
-            struct time_shift_ts;// fwd api
-            struct aglacier_melt_ts;// fwd api
-            struct aref_ts;// fwd api
-            struct ts_bind_info;
-
-
-            /** \brief  apoint_ts, a value-type conceptual ts.
-             *
-             *  This is the class that we expose to python, with operations, expressions etc.
-             *  and that we build all the exposed semantics on.
-             *  It holds a shared_ptr to some ipoint_ts, that could be a concrete point timeseries or
-             *  an expression.
-             *
+            /** \return number of points that descr. y=f(t) on t ::= period
              */
-            struct apoint_ts {
-                /** a ref to the real implementation, could be a concrete point ts, or an expression */
-                std::shared_ptr<ipoint_ts> ts;// consider unique pointer instead,possibly public, to ease transparency in python
+            virtual size_t size() const=0;
 
-               typedef gta_t ta_t;///< this is the generic time-axis type for apoint_ts, needed by timeseries namespace templates
-               friend struct average_ts;
-               friend struct integral_ts;
-               friend struct time_shift_ts;
-               friend struct accumulate_ts;
-               friend struct aglacier_melt_ts;
-                // constructors that we want to expose
-                // like
-
-                // these are for the python exposure
-                apoint_ts(const time_axis::fixed_dt& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-                apoint_ts(const time_axis::fixed_dt& ta,const std::vector<double>& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-
-                apoint_ts(const time_axis::point_dt& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-                apoint_ts(const time_axis::point_dt& ta,const std::vector<double>& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-				apoint_ts(const rts_t & rts);// ct for result-ts at cell-level that we want to wrap.
-				apoint_ts(const vector<double>& pattern, utctimespan dt, const time_axis::generic_dt& ta);
-				apoint_ts(const vector<double>& pattern, utctimespan dt, utctime pattern_t0,const time_axis::generic_dt& ta);
-                // these are the one we need.
-                apoint_ts(const gta_t& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-                apoint_ts(const gta_t& ta,const std::vector<double>& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-                apoint_ts(const gta_t& ta,std::vector<double>&& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-
-                apoint_ts(gta_t&& ta,std::vector<double>&& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-                apoint_ts(gta_t&& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
-                apoint_ts(const std::shared_ptr<ipoint_ts>& c):ts(c) {}
-
-                apoint_ts(std::string ref_ts_id);
-                // some more exotic stuff like average_ts
-
-                apoint_ts()=default;
-                bool needs_bind() const {
-                    return sts()->needs_bind();
-                }
-                void do_bind() {
-                    sts()->do_bind();
-                }
-                std::shared_ptr<ipoint_ts> const& sts() const {
-                    if(!ts)
-                        throw runtime_error("TimeSeries is empty");
-                    return ts;
-                }
-                std::shared_ptr<ipoint_ts> & sts() {
-                    if(!ts)
-                        throw runtime_error("TimeSeries is empty");
-                    return ts;
-                }
-
-                /**\brief Easy to compare for equality, but tricky if performance needed */
-                bool operator==(const apoint_ts& other) const;
-
-                // interface we want to expose
-                // the standard ipoint-ts stuff:
-                ts_point_fx point_interpretation() const {return ts->point_interpretation();}
-                void set_point_interpretation(ts_point_fx point_interpretation) { sts()->set_point_interpretation(point_interpretation); };
-                const gta_t& time_axis() const { return sts()->time_axis();};
-                utcperiod total_period() const {return ts?ts->total_period():utcperiod();};   ///< Returns period that covers points, given
-                size_t index_of(utctime t) const {return ts?ts->index_of(t):std::string::npos;};
-                size_t open_range_index_of(utctime t, size_t ix_hint = std::string::npos) const {
-                    return ts ? ts->time_axis().open_range_index_of(t, ix_hint):std::string::npos; }
-                size_t size() const {return ts?ts->size():0;};        ///< number of points that descr. y=f(t) on t ::= period
-                utctime time(size_t i) const {return sts()->time(i);};///< get the i'th time point
-                double value(size_t i) const {return sts()->value(i);};///< get the i'th value
-                double operator()(utctime t) const  {return sts()->value_at(t);};
-                std::vector<double> values() const {return ts?ts->values():std::vector<double>();}
-
-                //-- then some useful functions/properties
-                apoint_ts average(const gta_t& ta) const;
-                apoint_ts integral(gta_t const &ta) const;
-				apoint_ts accumulate(const gta_t& ta) const;
-				apoint_ts time_shift(utctimespan dt) const;
-				apoint_ts max(double a) const;
-                apoint_ts min(double a) const;
-                apoint_ts max(const apoint_ts& other) const;
-                apoint_ts min(const apoint_ts& other) const;
-                static apoint_ts max(const apoint_ts& a, const apoint_ts& b);
-                static apoint_ts min(const apoint_ts& a, const apoint_ts& b);
-				std::vector<apoint_ts> partition_by(const calendar& cal, utctime t, utctimespan partition_interval, size_t n_partitions, utctime common_t0) const;
-                apoint_ts convolve_w(const std::vector<double>& w, shyft::time_series::convolve_policy conv_policy) const;
-
-                //-- in case the underlying ipoint_ts is a gpoint_ts (concrete points)
-                //   we would like these to be working (exception if it's not possible,i.e. an expression)
-                point get(size_t i) const {return point(time(i),value(i));}
-                void set(size_t i, double x) ;
-                void fill(double x) ;
-                void scale_by(double x) ;
-
-                /** given that this ts is a bind-able ts (aref_ts)
-                 * and that bts is a gpoint_ts, make
-                 * a *copy* of gpoint_ts and use it as representation
-                 * for the values of this ts
-                 * \parameter bts time-series of type point that will be applied to this ts.
-                 * \throw runtime_error if any of preconditions is not true.
-                 */
-                void bind(const apoint_ts& bts);
-
-                /** recursive search through the expression that this ts represents,
-                 *  and return a list of bind_ts_info that can be used to
-                 *  inspect and possibly 'bind' to values \ref bind.
-                 * \return a vector of ts_bind_info
-                 */
-                std::vector<ts_bind_info> find_ts_bind_info() const;
-
-                std::string serialize() const;
-                static apoint_ts deserialize(const std::string&ss);
-                std::vector<char> serialize_to_bytes() const;
-                static apoint_ts deserialize_from_bytes(const std::vector<char>&ss);
-                x_serialize_decl();
-            };
-
-            /** ts_bind_info gives information about the timeseries and it's binding
-            * represented by encoded string reference
-            * Given that you have a concrete ts,
-            * you can bind that the bind_info.ts
-            * using bind_info.ts.bind().
-            */
-            struct ts_bind_info {
-                ts_bind_info(const std::string& id, const apoint_ts&ts) :reference(id), ts(ts) {}
-                ts_bind_info() {}
-                bool operator==(const ts_bind_info& o) const { return reference == o.reference; }
-                std::string reference;
-                apoint_ts ts;
-            };
-
-            /** \brief gpoint_ts a generic concrete point_ts, a terminal, not an expression
-             *
-             * The gpoint_ts is typically provided by repositories, that reads time-series
-             * from some provider, like database, file(netcdf etc), providing a set of values
-             * that are aligned to the specified time-axis.
-             *
+            /** \return time_axis().time(i), the start of the i'th period in the time-axis
              */
-            struct gpoint_ts:ipoint_ts {
-                gts_t rep;
-                // To create gpoint_ts, we use const ref, move ct wherever possible:
-                // note (we would normally use ct template here, but we are aiming at exposing to python)
-                gpoint_ts(const gta_t&ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(ta,fill_value,point_fx){}
-                gpoint_ts(const gta_t&ta,const std::vector<double>& v,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(ta,v,point_fx) {}
-                gpoint_ts(gta_t&&ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(std::move(ta),fill_value,point_fx){}
-                gpoint_ts(gta_t&&ta,std::vector<double>&& v,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(std::move(ta),std::move(v),point_fx) {}
-                gpoint_ts(const gta_t& ta,std::vector<double>&& v,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(ta,std::move(v),point_fx) {}
+            virtual utctime time(size_t i) const=0;
 
-                // now for the gpoint_ts it self, constructors incl. move
-                gpoint_ts() = default; // default for serialization conv
-                // implement ipoint_ts contract:
-                virtual ts_point_fx point_interpretation() const {return rep.point_interpretation();}
-                virtual void set_point_interpretation(ts_point_fx point_interpretation) {rep.set_point_interpretation(point_interpretation);}
-                virtual const gta_t& time_axis() const {return rep.time_axis();}
-                virtual utcperiod total_period() const {return rep.total_period();}
-                virtual size_t index_of(utctime t) const {return rep.index_of(t);}
-                virtual size_t size() const {return rep.size();}
-                virtual utctime time(size_t i) const {return rep.time(i);};
-                virtual double value(size_t i) const {return rep.v[i];}
-                virtual double value_at(utctime t) const {return rep(t);}
-                virtual std::vector<double> values() const {return rep.v;}
-                // implement some extra functions to manipulate the points
-                void set(size_t i, double x) {rep.set(i,x);}
-                void fill(double x) {rep.fill(x);}
-                void scale_by(double x) {rep.scale_by(x);}
-                virtual bool needs_bind() const { return false;}
-                virtual void do_bind()  {}
-                x_serialize_decl();
-            };
-
-            struct aref_ts:ipoint_ts {
-                typedef shyft::time_series::ref_ts<gts_t> ref_ts_t;
-                ref_ts_t rep;
-                aref_ts(string sym_ref):rep(sym_ref) {}
-                aref_ts() = default; // default for serialization conv
-                // implement ipoint_ts contract:
-                virtual ts_point_fx point_interpretation() const {return rep.point_interpretation();}
-                virtual void set_point_interpretation(ts_point_fx point_interpretation) {rep.set_point_interpretation(point_interpretation);}
-                virtual const gta_t& time_axis() const {return rep.time_axis();}
-                virtual utcperiod total_period() const {return rep.total_period();}
-                virtual size_t index_of(utctime t) const {return rep.index_of(t);}
-                virtual size_t size() const {return rep.size();}
-                virtual utctime time(size_t i) const {return rep.time(i);};
-                virtual double value(size_t i) const {return rep.value(i);}
-                virtual double value_at(utctime t) const {return rep(t);}
-                virtual std::vector<double> values() const {return rep.bts().v;}
-                // implement some extra functions to manipulate the points
-                void set(size_t i, double x) {rep.set(i,x);}
-                void fill(double x) {rep.fill(x);}
-                void scale_by(double x) {rep.scale_by(x);}
-                virtual bool needs_bind() const { return shyft::time_series::e_needs_bind(rep);}
-                virtual void do_bind()  {}
-                x_serialize_decl();
-           };
-
-            /** \brief The average_ts is used for providing ts average values over a time-axis
-             *
-             * Given a any ts, concrete, or an expression, provide the true average values on the
-             * intervals as provided by the specified time-axis.
-             *
-             * true average for each period in the time-axis is defined as:
-             *
-             *   integral of f(t) dt from t0 to t1 / (t1-t0)
-             *
-             * using the f(t) interpretation of the supplied ts (linear or stair case).
-             *
-             * The \ref ts_point_fx is always POINT_AVERAGE_VALUE for the result ts.
-             *
-             * \note if a nan-value intervals are excluded from the integral and time-computations.
-             *       E.g. let's say half the interval is nan, then the true average is computed for
-             *       the other half of the interval.
-             *
+            /** \return the value at the i'th period of the time-axis
              */
-            struct average_ts:ipoint_ts {
-                gta_t ta;
-                std::shared_ptr<ipoint_ts> ts;
-                // useful constructors
-                average_ts(gta_t&& ta,const apoint_ts& ats):ta(std::move(ta)),ts(ats.ts) {}
-                average_ts(gta_t&& ta,apoint_ts&& ats):ta(std::move(ta)),ts(std::move(ats.ts)) {}
-                average_ts(const gta_t& ta,apoint_ts&& ats):ta(ta),ts(std::move(ats.ts)) {}
-                average_ts(const gta_t& ta,const apoint_ts& ats):ta(ta),ts(ats.ts) {}
-                average_ts(const gta_t& ta,const std::shared_ptr<ipoint_ts> &ts ):ta(ta),ts(ts){}
-                average_ts(gta_t&& ta,const std::shared_ptr<ipoint_ts> &ts ):ta(std::move(ta)),ts(ts){}
-                // std copy ct and assign
-                average_ts()=default;
-                // implement ipoint_ts contract:
-                virtual ts_point_fx point_interpretation() const {return ts_point_fx::POINT_AVERAGE_VALUE;}
-                virtual void set_point_interpretation(ts_point_fx point_interpretation) {;}
-                virtual const gta_t& time_axis() const {return ta;}
-                virtual utcperiod total_period() const {return ta.total_period();}
-                virtual size_t index_of(utctime t) const {return ta.index_of(t);}
-                virtual size_t size() const {return ta.size();}
-                virtual utctime time(size_t i) const {return ta.time(i);};
-                virtual double value(size_t i) const {
-                    #ifdef _DEBUG
-                    if(i>ta.size())
-                        return nan;
-                    #endif
-                    size_t ix_hint=(i*ts->size())/ta.size();// assume almost fixed delta-t.
-                    return average_value(*ts,ta.period(i),ix_hint,ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);
-                }
-                virtual double value_at(utctime t) const {
-                    // return true average at t
-                    if(!ta.total_period().contains(t))
-                        return nan;
-                    return value(index_of(t));
-                }
-                virtual std::vector<double> values() const {
-                    std::vector<double> r;r.reserve(ta.size());
-                    size_t ix_hint=ts->index_of(ta.time(0));
-                    bool linear_interpretation=ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE;
-                    for(size_t i=0;i<ta.size();++i) {
-                        r.push_back(average_value(*ts,ta.period(i),ix_hint,linear_interpretation));
-                    }
-                    return r;
-                }
-                virtual bool needs_bind() const { return ts->needs_bind();}
-                virtual void do_bind() {ts->do_bind();}
-                x_serialize_decl();
+            virtual double value(size_t i) const=0;
 
-            };
-
-            /** \brief The integral_ts is used for providing ts integral values over a time-axis
-            *
-            * Given a any ts, concrete, or an expression, provide the 'true integral' values on the
-            * intervals as provided by the specified time-axis.
-            *
-            * true inegral for each period in the time-axis is defined as:
-            *
-            *   integral of f(t) dt from t0 to t1
-            *
-            * using the f(t) interpretation of the supplied ts (linear or stair case).
-            *
-            * The \ref ts_point_fx is always POINT_AVERAGE_VALUE for the result ts.
-            *
-            * \note if a nan-value intervals are excluded from the integral and time-computations.
-            *       E.g. let's say half the interval is nan, then the true integral is computed for
-            *       the other half of the interval.
-            *
-            */
-            struct integral_ts :ipoint_ts {
-                gta_t ta;
-                std::shared_ptr<ipoint_ts> ts;
-                // useful constructors
-                integral_ts(gta_t&& ta, const apoint_ts& ats) :ta(std::move(ta)), ts(ats.ts) {}
-                integral_ts(gta_t&& ta, apoint_ts&& ats) :ta(std::move(ta)), ts(std::move(ats.ts)) {}
-                integral_ts(const gta_t& ta, apoint_ts&& ats) :ta(ta), ts(std::move(ats.ts)) {}
-                integral_ts(const gta_t& ta, const apoint_ts& ats) :ta(ta), ts(ats.ts) {}
-                integral_ts(const gta_t& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(ta), ts(ts) {}
-                integral_ts(gta_t&& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(std::move(ta)), ts(ts) {}
-                // std copy ct and assign
-                integral_ts()=default;
-                // implement ipoint_ts contract:
-                virtual ts_point_fx point_interpretation() const { return ts_point_fx::POINT_AVERAGE_VALUE; }
-                virtual void set_point_interpretation(ts_point_fx point_interpretation) { ; }
-                virtual const gta_t& time_axis() const { return ta; }
-                virtual utcperiod total_period() const { return ta.total_period(); }
-                virtual size_t index_of(utctime t) const { return ta.index_of(t); }
-                virtual size_t size() const { return ta.size(); }
-                virtual utctime time(size_t i) const { return ta.time(i); };
-                virtual double value(size_t i) const {
-                    if (i>ta.size())
-                        return nan;
-                    size_t ix_hint = (i*ts->size()) / ta.size();// assume almost fixed delta-t.
-                    utctimespan tsum = 0;
-                    return accumulate_value(*ts, ta.period(i), ix_hint,tsum, ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);
-                }
-                virtual double value_at(utctime t) const {
-                    // return true average at t
-                    if (!ta.total_period().contains(t))
-                        return nan;
-                    return value(index_of(t));
-                }
-                virtual std::vector<double> values() const {
-                    std::vector<double> r;r.reserve(ta.size());
-                    size_t ix_hint = ts->index_of(ta.time(0));
-                    bool linear_interpretation = ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE;
-                    for (size_t i = 0;i<ta.size();++i) {
-                        utctimespan tsum = 0;
-                        r.push_back(accumulate_value(*ts, ta.period(i), ix_hint,tsum, linear_interpretation));
-                    }
-                    return r;
-                }
-                virtual bool needs_bind() const { return ts->needs_bind();}
-                virtual void do_bind() {ts->do_bind();}
-                x_serialize_decl();
-
-            };
-
-			/** \brief The accumulate_ts is used for providing accumulated(integrated) ts values over a time-axis
-			*
-			* Given a any ts, concrete, or an expression, provide the true accumulated values,
-			* defined as area under non-nan values of the f(t) curve,
-			* on the intervals points as provided by the specified time-axis.
-			*
-			* The value at the i'th point of the time-axis is given by:
-			*
-			*   integral of f(t) dt from t0 to ti ,
-			*
-			*   where t0 is time_axis.period(0).start, and ti=time_axis.period(i).start
-			*
-			* using the f(t) interpretation of the supplied ts (linear or stair case).
-			*
-			* \note The value at t=t0 is 0.0 (by definition)
-			* \note The value of t outside ta.total_period() is nan
-			*
-			* The \ref ts_point_fx is always POINT_INSTANT_VALUE for the result ts.
-			*
-			* \note if a nan-value intervals are excluded from the integral and time-computations.
-			*       E.g. let's say half the interval is nan, then the true average is computed for
-			*       the other half of the interval.
-			*
-			*/
-			struct accumulate_ts :ipoint_ts {
-				gta_t ta;
-				std::shared_ptr<ipoint_ts> ts;
-				// useful constructors
-				accumulate_ts(gta_t&& ta, const apoint_ts& ats) :ta(std::move(ta)), ts(ats.ts) {}
-				accumulate_ts(gta_t&& ta, apoint_ts&& ats) :ta(std::move(ta)), ts(std::move(ats.ts)) {}
-				accumulate_ts(const gta_t& ta, apoint_ts&& ats) :ta(ta), ts(std::move(ats.ts)) {}
-				accumulate_ts(const gta_t& ta, const apoint_ts& ats) :ta(ta), ts(ats.ts) {}
-				accumulate_ts(const gta_t& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(ta), ts(ts) {}
-				accumulate_ts(gta_t&& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(std::move(ta)), ts(ts) {}
-				// std copy ct and assign
-				accumulate_ts()=default;
-				// implement ipoint_ts contract:
-				virtual ts_point_fx point_interpretation() const { return ts_point_fx::POINT_INSTANT_VALUE; }
-				virtual void set_point_interpretation(ts_point_fx point_interpretation) { ; }// we could throw here..
-				virtual const gta_t& time_axis() const { return ta; }
-				virtual utcperiod total_period() const { return ta.total_period(); }
-				virtual size_t index_of(utctime t) const { return ta.index_of(t); }
-				virtual size_t size() const { return ta.size(); }
-				virtual utctime time(size_t i) const { return ta.time(i); };
-				virtual double value(size_t i) const {
-					if (i>ta.size())
-						return nan;
-					if (i == 0)// by definition,0.0 at i=0
-						return 0.0;
-					size_t ix_hint = 0;// assume almost fixed delta-t.
-					utctimespan tsum;
-					return accumulate_value(*ts, utcperiod(ta.time(0), ta.time(i)), ix_hint, tsum, ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);
-				}
-				virtual double value_at(utctime t) const {
-					// return true accumulated value at t
-					if (!ta.total_period().contains(t))
-						return nan;
-					if (t == ta.time(0))
-						return 0.0; // by definition
-					utctimespan tsum;
-					size_t ix_hint = 0;
-					return accumulate_value(*this, utcperiod(ta.time(0), t), ix_hint, tsum, ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !;
-				}
-				virtual std::vector<double> values() const {
-					std::vector<double> r;r.reserve(ta.size());
-					accumulate_accessor<ipoint_ts, gta_t> accumulate(*ts, ta);// use accessor, that
-					for (size_t i = 0;i<ta.size();++i) {                      // given sequential access
-						r.push_back(accumulate.value(i));                     // reuses acc.computation
-					}
-					return r;
-				}
-				virtual bool needs_bind() const { return ts->needs_bind();}
-				virtual void do_bind() {ts->do_bind();}
-				// to help the average function, return the i'th point of the underlying timeseries
-				//point get(size_t i) const {return point(ts->time(i),ts->value(i));}
-                x_serialize_decl();
-
-			};
-
-            /** \brief time_shift ts do a time-shift dt on the supplied ts
-             *
-             * The values are exactly the same as the supplied ts argument to the constructor
-             * but the time-axis is shifted utctimespan dt to the left.
-             * e.g.: t_new = t_original + dt
-             *
-             *       lets say you have a time-series 'a'  with time-axis covering 2015
-             *       and you want to time-shift so that you have a time- series 'b'data for 2016,
-             *       then you could do this to get 'b':
-             *
-             *           utc = calendar() // utc calendar
-             *           dt  = utc.time(2016,1,1) - utc.time(2015,1,1)
-             *            b  = timeshift_ts(a, dt)
-             *
-             * \note If the ts given at constructor time is an unbound ts or expression,
-             *       then .do_deferred_bind() needs to be called before any call to
-             *       value or time-axis function calls.
-             *
+            /** \return the f(t) at the specified time t, \note if t outside total_period() nan is returned
              */
-            struct time_shift_ts:ipoint_ts {
-                std::shared_ptr<ipoint_ts> ts;
-                gta_t ta;
-                utctimespan dt=0;// despite ta time-axis, we need it
+            virtual double value_at(utctime t) const =0;
 
-                time_shift_ts()=default;
-
-                //-- useful ct goes here
-                time_shift_ts(const apoint_ts& ats,utctimespan adt)
-                    :ts(ats.ts),dt(adt) {
-                    if(!ts->needs_bind())
-                        do_deferred_bind();
-
-                }
-                time_shift_ts(apoint_ts&& ats, utctimespan adt)
-                    :ts(std::move(ats.ts)),dt(adt) {
-                    if(!ts->needs_bind())
-                        do_deferred_bind();
-                }
-                time_shift_ts(const std::shared_ptr<ipoint_ts> &ts, utctime adt )
-                    :ts(ts),dt(adt){
-                    if(!ts->needs_bind())
-                        do_deferred_bind();
-                }
-                void do_deferred_bind() {
-                    if(ta.size()==0) {//TODO: introduce bound flag, and use that, using the ta.size() is a problem if ta *is* size 0.
-                        ta= time_axis::time_shift(ts->time_axis(),dt);
-                    }
-                }
-                // implement ipoint_ts contract:
-                virtual ts_point_fx point_interpretation() const {return ts->point_interpretation();}
-                virtual void set_point_interpretation(ts_point_fx point_interpretation) {ts->set_point_interpretation(point_interpretation);}
-                virtual const gta_t& time_axis() const {return ta;}
-                virtual utcperiod total_period() const {return ta.total_period();}
-                virtual size_t index_of(utctime t) const {return ta.index_of(t);}
-                virtual size_t size() const {return ta.size();}
-                virtual utctime time(size_t i) const {return ta.time(i);};
-                virtual double value(size_t i) const {return ts->value(i);}
-                virtual double value_at(utctime t) const {return ts->value_at(t-dt);}
-                virtual std::vector<double> values() const {return ts->values();}
-                virtual bool needs_bind() const { return ts->needs_bind();}
-                virtual void do_bind() {ts->do_bind();do_deferred_bind();}
-                x_serialize_decl();
-
-            };
-
-			/** \brief periodic_ts is used for providing ts periodic values over a time-axis
-			*
-			*/
-			struct periodic_ts : ipoint_ts {
-				typedef shyft::time_series::periodic_ts<gta_t> pts_t;
-				pts_t ts;
-
-				periodic_ts(const vector<double>& pattern, utctimespan dt, const gta_t& ta) : ts(pattern, dt, ta) {}
-				periodic_ts(const vector<double>& pattern, utctimespan dt, utctime pattern_t0,const gta_t& ta) : ts(pattern, dt,pattern_t0,ta) {}
-				periodic_ts(const periodic_ts& c) : ts(c.ts) {}
-				periodic_ts(periodic_ts&& c) : ts(move(c.ts)) {}
-				periodic_ts& operator=(const periodic_ts& c) {
-					if (this != &c) {
-						ts = c.ts;
-					}
-					return *this;
-				}
-				periodic_ts& operator=(periodic_ts&& c) {
-					ts = move(c.ts);
-					return *this;
-				}
-                periodic_ts()=default;
-				// implement ipoint_ts contract
-				virtual ts_point_fx point_interpretation() const { return ts_point_fx::POINT_AVERAGE_VALUE; }
-				virtual void set_point_interpretation(ts_point_fx) { ; }
-				virtual const gta_t& time_axis() const { return ts.ta; }
-				virtual utcperiod total_period() const { return ts.ta.total_period(); }
-				virtual size_t index_of(utctime t) const { return ts.index_of(t); }
-				virtual size_t size() const { return ts.ta.size(); }
-				virtual utctime time(size_t i) const { return ts.ta.time(i); }
-				virtual double value(size_t i) const { return ts.value(i); }
-				virtual double value_at(utctime t) const { return value(index_of(t)); }
-				virtual vector<double> values() const { return ts.values(); }
-				virtual bool needs_bind() const { return false;}// this is a terminal node, no bind needed
-				virtual void do_bind()  {}
-                x_serialize_decl();
-			};
-
-            /** \brief convolve_w is used for providing a convolution by weights ts
-            *
-            * The convolve_w_ts is particularly useful for implementing routing and model
-            * time-delays and shape-of hydro-response.
-            *
-            */
-            struct convolve_w_ts : ipoint_ts {
-                typedef vector<double> weights_t;
-                typedef shyft::time_series::convolve_w_ts<apoint_ts> cnv_ts_t;
-                cnv_ts_t ts_impl;
-
-                convolve_w_ts(const apoint_ts& ats, const weights_t& w, convolve_policy conv_policy) :ts_impl(ats, w, conv_policy) {}
-                convolve_w_ts(apoint_ts&& ats, const weights_t& w, convolve_policy conv_policy) :ts_impl(move(ats), w, conv_policy) {}
-                // hmm: convolve_w_ts(const std::shared_ptr<ipoint_ts> &ats,const weights_t& w,convolve_policy conv_policy ):ts(ats),ts_impl(*ts,w,conv_policy) {}
-
-                // std.ct
-                convolve_w_ts() =default;
-
-                // implement ipoint_ts contract
-                virtual ts_point_fx point_interpretation() const { return ts_impl.point_interpretation(); }
-                virtual void set_point_interpretation(ts_point_fx) { throw std::runtime_error("not implemented"); }
-                virtual const gta_t& time_axis() const { return ts_impl.time_axis(); }
-                virtual utcperiod total_period() const { return ts_impl.total_period(); }
-                virtual size_t index_of(utctime t) const { return ts_impl.index_of(t); }
-                virtual size_t size() const { return ts_impl.size(); }
-                virtual utctime time(size_t i) const { return ts_impl.time(i); }
-                virtual double value(size_t i) const { return ts_impl.value(i); }
-                virtual double value_at(utctime t) const { return value(index_of(t)); }
-                virtual vector<double> values() const {
-                    vector<double> r;r.reserve(size());
-                    for (size_t i = 0;i<size();++i)
-                        r.push_back(ts_impl.value(i));
-                    return r;
-                }
-                virtual bool needs_bind() const { return ts_impl.ts.needs_bind();}
-                virtual void do_bind() {ts_impl.ts.do_bind();}
-                x_serialize_decl();
-            };
-
-            /** The iop_t represent the basic 'binary' operation,
-             *   a stateless function that takes two doubles and returns the binary operation.
-             *   E.g.: a+b
-             *   The iop_t is used as the operation element of the abin_op_ts class
+            /** \return the values, one for each of the time_axis() intervals as a vector
              */
-            enum iop_t {
-                OP_NONE,OP_ADD,OP_SUB,OP_DIV,OP_MUL,OP_MIN,OP_MAX
-            };
+            virtual std::vector<double> values() const =0;
 
-            /** deferred_bind helps to defer the computation cost of the
-             * expression bin-op variants until its actually used.
-             * this is also needed when having ts_refs| unbound symbolic time-series references
-             * that we would like to serialize and pass over to another server for execution.
-             *
-             * By inspecting the time-series in the construction phase (bin_op etc.)
-             * we try to take the preparation for computation as early as possible,
-             * so, only when there is a symbolic time-series reference, there will be
-             * a deferred_bind() that will take action *after* the
-             * symbolic time-series has been prepared with real values (bound).
-             *
+            /** for internal computation and expression trees, we need to know *if*
+             * there are unbound symbolic ts in the chain of this ts
+             * We know that a point-ts never do not need a binding, but
+             * all others are expressions of ts, and could potentially
+             * needs a bind (if it has an unbound symbolic ts in it's siblings)
              */
+            virtual bool needs_bind() const =0;
 
-            /** \brief The binary operation for type ts op ts
-             *
-             * The binary operation is lazy, and only keep the reference to the two operands
-             * that are of the \ref apoint_ts type.
-             * The operation is of \ref iop_t, and details for plus minus divide multiply etc is in
-             * the implementation file.
-             *
-             * As per definition a this class implements the \ref ipoint_ts interface,
-             * and the time-axis of type \ref gta_t is currently computed in the constructor.
-             * This could take some cpu if the time-axis is of type point_dt, so we could
-             * consider working some more on the internal algorithms to avoid this.
-             *
-             * The \ref ts_point_fx is computed based on rhs,lhs. But can be overridden
-             * by the user.
-             *
+            /** propagate do_bind to expression tree siblings(if any)
+             * then do any needed binding stuff needed for the specific class impl.
              */
-            struct abin_op_ts:ipoint_ts {
+            virtual void do_bind()=0;
 
-                  apoint_ts lhs;
-                  iop_t op=iop_t::OP_NONE;
-                  apoint_ts rhs;
-                  gta_t ta;
-                  ts_point_fx fx_policy=POINT_AVERAGE_VALUE;
-                  bool bound=false;
+            // to be removed:
+            point get(size_t i) const {return point(time(i),value(i));}
+            x_serialize_decl();
+        };
+        struct average_ts;//fwd api
+        struct accumulate_ts;//fwd api
+        struct integral_ts;// fwd api
+        struct time_shift_ts;// fwd api
+        struct aglacier_melt_ts;// fwd api
+        struct aref_ts;// fwd api
+        struct ts_bind_info;
+        struct ats_vector;//fwd
 
-                  ts_point_fx point_interpretation() const {return fx_policy;}
-                  void set_point_interpretation(ts_point_fx x) {fx_policy=x;}
+        /** \brief  apoint_ts, a value-type conceptual ts.
+         *
+         *  This is the class that we expose to python, with operations, expressions etc.
+         *  and that we build all the exposed semantics on.
+         *  It holds a shared_ptr to some ipoint_ts, that could be a concrete point timeseries or
+         *  an expression.
+         *
+         */
+        struct apoint_ts {
+            /** a ref to the real implementation, could be a concrete point ts, or an expression */
+            std::shared_ptr<ipoint_ts> ts;// consider unique pointer instead,possibly public, to ease transparency in python
 
-                  void do_deferred_bind() {
-                    if(!bound) {
-                        fx_policy=result_policy(lhs.point_interpretation(),rhs.point_interpretation());
-                        ta=time_axis::combine(lhs.time_axis(),rhs.time_axis());
-                        bound=true;
-                    }
-                  }
+           typedef gta_t ta_t;///< this is the generic time-axis type for apoint_ts, needed by timeseries namespace templates
+           friend struct average_ts;
+           friend struct integral_ts;
+           friend struct time_shift_ts;
+           friend struct accumulate_ts;
+           friend struct aglacier_melt_ts;
+            // constructors that we want to expose
+            // like
 
-                  abin_op_ts()=default;
-                  abin_op_ts(const apoint_ts &lhs,iop_t op,const apoint_ts& rhs)
-                  :lhs(lhs),op(op),rhs(rhs) {
-                      if( !needs_bind() )
-                         do_deferred_bind();
-                  }
-                  void bind_check() const {if(!bound) throw runtime_error("attempting to use unbound timeseries, context abin_op_ts");}
-                  virtual utcperiod total_period() const {return time_axis().total_period();}
-                  const gta_t& time_axis() const {bind_check(); return ta;};// combine lhs,rhs
-                  size_t index_of(utctime t) const{return time_axis().index_of(t);};
-                  size_t size() const {return time_axis().size();};// use the combined ta.size();
-                  utctime time( size_t i) const {return time_axis().time(i);}; // return combined ta.time(i)
-                  double value_at(utctime t) const ;
-                  double value(size_t i) const;// return op( lhs(t), rhs(t)) ..
-                  std::vector<double> values() const;
-                  bool needs_bind() const {return lhs.needs_bind() || rhs.needs_bind(); }
-                  virtual void do_bind() {lhs.do_bind();rhs.do_bind();do_deferred_bind();}
-                  x_serialize_decl();
+            // these are for the python exposure
+            apoint_ts(const time_axis::fixed_dt& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(const time_axis::fixed_dt& ta,const std::vector<double>& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
 
-            };
+            apoint_ts(const time_axis::point_dt& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(const time_axis::point_dt& ta,const std::vector<double>& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(const rts_t & rts);// ct for result-ts at cell-level that we want to wrap.
+            apoint_ts(const vector<double>& pattern, utctimespan dt, const time_axis::generic_dt& ta);
+            apoint_ts(const vector<double>& pattern, utctimespan dt, utctime pattern_t0,const time_axis::generic_dt& ta);
+            // these are the one we need.
+            apoint_ts(const gta_t& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(const gta_t& ta,const std::vector<double>& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(const gta_t& ta,std::vector<double>&& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
 
-            /** \brief  binary operation for type ts op double
-             *
-             * The resulting time-axis and point interpretation policy is equal to the ts.
-             */
-            struct abin_op_scalar_ts:ipoint_ts {
+            apoint_ts(gta_t&& ta,std::vector<double>&& values,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(gta_t&& ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE);
+            apoint_ts(const std::shared_ptr<ipoint_ts>& c):ts(c) {}
 
-                  double lhs;
-                  iop_t op=iop_t::OP_NONE;
-                  apoint_ts rhs;
-                  gta_t ta;
-                  ts_point_fx fx_policy=POINT_AVERAGE_VALUE;
-                  bool bound=false;
+            apoint_ts(std::string ref_ts_id);
+            // some more exotic stuff like average_ts
 
-
-                  ts_point_fx point_interpretation() const {return fx_policy;}
-                  void set_point_interpretation(ts_point_fx x) {fx_policy=x;}
-
-                  void do_deferred_bind()  {
-                      if(!bound) {
-                          ta=rhs.time_axis();
-                          fx_policy= rhs.point_interpretation();
-                          bound=true;
-                      }
-                  }
-                  void bind_check() const {if(!bound) throw runtime_error("attempting to use unbound timeseries, context abin_op_scalar");}
-                  abin_op_scalar_ts()=default;
-
-                  abin_op_scalar_ts(double lhs,iop_t op,const apoint_ts& rhs)
-                  :lhs(lhs),op(op),rhs(rhs) {
-                      if(!needs_bind())
-                        do_deferred_bind();
-                  }
-
-                  virtual utcperiod total_period() const {return time_axis().total_period();}
-                  const gta_t& time_axis() const {bind_check();return ta;};// combine lhs,rhs
-                  size_t index_of(utctime t) const{return time_axis().index_of(t);};
-                  size_t size() const {return time_axis().size();};
-                  utctime time( size_t i) const {return time_axis().time(i);};
-                  double value_at(utctime t) const ;
-                  double value(size_t i) const ;
-                  std::vector<double> values() const ;
-                  bool needs_bind() const {return rhs.needs_bind(); }
-                  virtual void do_bind() {rhs.do_bind();do_deferred_bind();}
-                  x_serialize_decl();
-            };
-
-            /** \brief  binary operation for type ts op double
-             *
-             * The resulting time-axis and point interpretation policy is equal to the ts.
-             */
-            struct abin_op_ts_scalar:ipoint_ts {
-                  apoint_ts lhs;
-                  iop_t op=iop_t::OP_NONE;
-                  double rhs;
-                  gta_t ta;
-                  bool bound=false;
-                  ts_point_fx fx_policy=POINT_AVERAGE_VALUE;
-                  ts_point_fx point_interpretation() const {return fx_policy;}
-                  void set_point_interpretation(ts_point_fx x) {fx_policy=x;}
-                  void do_deferred_bind()  {
-                      if(!bound) {
-                          ta=lhs.time_axis();
-                          fx_policy= lhs.point_interpretation();
-                          bound=true;
-                      }
-                  }
-                  void bind_check() const {if(!bound) throw runtime_error("attempting to use unbound timeseries, context abin_op_ts_scalar");}
-                  abin_op_ts_scalar()=default;
-
-                  abin_op_ts_scalar(const apoint_ts &lhs,iop_t op,double rhs)
-                  :lhs(lhs),op(op),rhs(rhs) {
-                      if(!needs_bind())
-                        do_deferred_bind();
-                  }
-
-                  virtual utcperiod total_period() const {return time_axis().total_period();}
-                  const gta_t& time_axis() const {bind_check();return ta;};
-                  size_t index_of(utctime t) const{return time_axis().index_of(t);};
-                  size_t size() const {return time_axis().size();};
-                  utctime time( size_t i) const {return time_axis().time(i);};
-                  double value_at(utctime t) const;
-                  double value(size_t i) const;
-                  std::vector<double> values() const;
-                  bool needs_bind() const {return lhs.needs_bind(); }
-                  virtual void do_bind() {lhs.do_bind();do_deferred_bind();}
-                  x_serialize_decl();
-
-            };
-
-            // add operators and functions to the apoint_ts class, of all variants that we want to expose
-            apoint_ts average(const apoint_ts& ts,const gta_t& ta/*fx-type */) ;
-            apoint_ts average(apoint_ts&& ts,const gta_t& ta) ;
-
-            apoint_ts integral(const apoint_ts& ts, const gta_t& ta/*fx-type */);
-            apoint_ts integral(apoint_ts&& ts, const gta_t& ta);
-
-            apoint_ts accumulate(const apoint_ts& ts, const gta_t& ta/*fx-type */);
-			apoint_ts accumulate(apoint_ts&& ts, const gta_t& ta);
-
-            apoint_ts create_glacier_melt_ts_m3s(const apoint_ts & temp,const apoint_ts& sca_m2,double glacier_area_m2,double dtf);
-
-			double nash_sutcliffe(const apoint_ts& observation_ts, const apoint_ts& model_ts, const gta_t &ta);
-
-			double kling_gupta(const apoint_ts& observation_ts, const apoint_ts&  model_ts, const gta_t& ta, double s_r, double s_a, double s_b);
-
-			apoint_ts create_periodic_pattern_ts(const vector<double>& pattern, utctimespan dt,utctime t0, const gta_t& ta);
-
-            apoint_ts operator+(const apoint_ts& lhs,const apoint_ts& rhs) ;
-            apoint_ts operator+(const apoint_ts& lhs,double           rhs) ;
-            apoint_ts operator+(double           lhs,const apoint_ts& rhs) ;
-
-            apoint_ts operator-(const apoint_ts& lhs,const apoint_ts& rhs) ;
-            apoint_ts operator-(const apoint_ts& lhs,double           rhs) ;
-            apoint_ts operator-(double           lhs,const apoint_ts& rhs) ;
-            apoint_ts operator-(const apoint_ts& rhs) ;
-
-            apoint_ts operator/(const apoint_ts& lhs,const apoint_ts& rhs) ;
-            apoint_ts operator/(const apoint_ts& lhs,double           rhs) ;
-            apoint_ts operator/(double           lhs,const apoint_ts& rhs) ;
-
-            apoint_ts operator*(const apoint_ts& lhs,const apoint_ts& rhs) ;
-            apoint_ts operator*(const apoint_ts& lhs,double           rhs) ;
-            apoint_ts operator*(double           lhs,const apoint_ts& rhs) ;
-
-
-            apoint_ts max(const apoint_ts& lhs,const apoint_ts& rhs) ;
-            apoint_ts max(const apoint_ts& lhs,double           rhs) ;
-            apoint_ts max(double           lhs,const apoint_ts& rhs) ;
-
-            apoint_ts min(const apoint_ts& lhs,const apoint_ts& rhs) ;
-            apoint_ts min(const apoint_ts& lhs,double           rhs) ;
-            apoint_ts min(double           lhs,const apoint_ts& rhs) ;
-
-            ///< percentiles, need to include several forms of time_axis for python
-            std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const gta_t & ta,const vector<int>& percentiles);
-            std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const time_axis::fixed_dt & ta,const vector<int>& percentiles);
-
-            ///< time_shift i.e. same ts values, but time-axis is time-axis + dt
-            apoint_ts time_shift(const apoint_ts &ts, utctimespan dt);
-
-            /** Given a vector of expressions, deflate(evalute) the expressions and return the
-             * equivalent concrete point-time-series of the expressions in the
-             * preferred destination type Ts
-             * Useful for the dtss,
-             * evaluates the expressions in parallell
-             */
-            template <class Ts>
-            std::vector<Ts>
-            deflate_ts_vector(std::vector<apoint_ts> const&tsv1) {
-                std::vector<Ts> tsv2(tsv1.size());
-
-                auto deflate_range=[&tsv1,&tsv2](size_t i0,size_t n) {
-                    for(size_t i=i0;i<i0+n;++i)
-                        tsv2[i]= Ts(tsv1[i].time_axis(),tsv1[i].values(),tsv1[i].point_interpretation());
-                };
-                auto n_threads = thread::hardware_concurrency();
-                if(n_threads <2) n_threads=4;// hard coded minimum
-                std::vector<std::future<void>> calcs;
-                size_t ps= 1 + tsv1.size()/n_threads;
-                for (size_t p = 0;p < tsv1.size(); ) {
-                    size_t np = p + ps <= tsv1.size() ? ps : tsv1.size() - p;
-                    calcs.push_back(std::async(std::launch::async, deflate_range, p, np));
-                    p += np;
-                }
-                for (auto &f : calcs) f.get();
-                return tsv2;
+            apoint_ts()=default;
+            bool needs_bind() const {
+                return sts()->needs_bind();
+            }
+            void do_bind() {
+                sts()->do_bind();
+            }
+            std::shared_ptr<ipoint_ts> const& sts() const {
+                if(!ts)
+                    throw runtime_error("TimeSeries is empty");
+                return ts;
+            }
+            std::shared_ptr<ipoint_ts> & sts() {
+                if(!ts)
+                    throw runtime_error("TimeSeries is empty");
+                return ts;
             }
 
+            /**\brief Easy to compare for equality, but tricky if performance needed */
+            bool operator==(const apoint_ts& other) const;
+
+            // interface we want to expose
+            // the standard ipoint-ts stuff:
+            ts_point_fx point_interpretation() const {return ts->point_interpretation();}
+            void set_point_interpretation(ts_point_fx point_interpretation) { sts()->set_point_interpretation(point_interpretation); };
+            const gta_t& time_axis() const { return sts()->time_axis();};
+            utcperiod total_period() const {return ts?ts->total_period():utcperiod();};   ///< Returns period that covers points, given
+            size_t index_of(utctime t) const {return ts?ts->index_of(t):std::string::npos;};
+            size_t open_range_index_of(utctime t, size_t ix_hint = std::string::npos) const {
+                return ts ? ts->time_axis().open_range_index_of(t, ix_hint):std::string::npos; }
+            size_t size() const {return ts?ts->size():0;};        ///< number of points that descr. y=f(t) on t ::= period
+            utctime time(size_t i) const {return sts()->time(i);};///< get the i'th time point
+            double value(size_t i) const {return sts()->value(i);};///< get the i'th value
+            double operator()(utctime t) const  {return sts()->value_at(t);};
+            std::vector<double> values() const {return ts?ts->values():std::vector<double>();}
+
+            //-- then some useful functions/properties
+            apoint_ts average(const gta_t& ta) const;
+            apoint_ts integral(gta_t const &ta) const;
+            apoint_ts accumulate(const gta_t& ta) const;
+            apoint_ts time_shift(utctimespan dt) const;
+            apoint_ts max(double a) const;
+            apoint_ts min(double a) const;
+            apoint_ts max(const apoint_ts& other) const;
+            apoint_ts min(const apoint_ts& other) const;
+            static apoint_ts max(const apoint_ts& a, const apoint_ts& b);
+            static apoint_ts min(const apoint_ts& a, const apoint_ts& b);
+            ats_vector partition_by(const calendar& cal, utctime t, utctimespan partition_interval, size_t n_partitions, utctime common_t0) const;
+            apoint_ts convolve_w(const std::vector<double>& w, shyft::time_series::convolve_policy conv_policy) const;
+
+            //-- in case the underlying ipoint_ts is a gpoint_ts (concrete points)
+            //   we would like these to be working (exception if it's not possible,i.e. an expression)
+            point get(size_t i) const {return point(time(i),value(i));}
+            void set(size_t i, double x) ;
+            void fill(double x) ;
+            void scale_by(double x) ;
+
+            /** given that this ts is a bind-able ts (aref_ts)
+             * and that bts is a gpoint_ts, make
+             * a *copy* of gpoint_ts and use it as representation
+             * for the values of this ts
+             * \parameter bts time-series of type point that will be applied to this ts.
+             * \throw runtime_error if any of preconditions is not true.
+             */
+            void bind(const apoint_ts& bts);
+
+            /** recursive search through the expression that this ts represents,
+             *  and return a list of bind_ts_info that can be used to
+             *  inspect and possibly 'bind' to values \ref bind.
+             * \return a vector of ts_bind_info
+             */
+            std::vector<ts_bind_info> find_ts_bind_info() const;
+
+            std::string serialize() const;
+            static apoint_ts deserialize(const std::string&ss);
+            std::vector<char> serialize_to_bytes() const;
+            static apoint_ts deserialize_from_bytes(const std::vector<char>&ss);
+            x_serialize_decl();
+        };
+
+        /** ts_bind_info gives information about the timeseries and it's binding
+        * represented by encoded string reference
+        * Given that you have a concrete ts,
+        * you can bind that the bind_info.ts
+        * using bind_info.ts.bind().
+        */
+        struct ts_bind_info {
+            ts_bind_info(const std::string& id, const apoint_ts&ts) :reference(id), ts(ts) {}
+            ts_bind_info() {}
+            bool operator==(const ts_bind_info& o) const { return reference == o.reference; }
+            std::string reference;
+            apoint_ts ts;
+        };
+
+        /** \brief gpoint_ts a generic concrete point_ts, a terminal, not an expression
+         *
+         * The gpoint_ts is typically provided by repositories, that reads time-series
+         * from some provider, like database, file(netcdf etc), providing a set of values
+         * that are aligned to the specified time-axis.
+         *
+         */
+        struct gpoint_ts:ipoint_ts {
+            gts_t rep;
+            // To create gpoint_ts, we use const ref, move ct wherever possible:
+            // note (we would normally use ct template here, but we are aiming at exposing to python)
+            gpoint_ts(const gta_t&ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(ta,fill_value,point_fx){}
+            gpoint_ts(const gta_t&ta,const std::vector<double>& v,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(ta,v,point_fx) {}
+            gpoint_ts(gta_t&&ta,double fill_value,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(std::move(ta),fill_value,point_fx){}
+            gpoint_ts(gta_t&&ta,std::vector<double>&& v,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(std::move(ta),std::move(v),point_fx) {}
+            gpoint_ts(const gta_t& ta,std::vector<double>&& v,ts_point_fx point_fx=POINT_INSTANT_VALUE):rep(ta,std::move(v),point_fx) {}
+
+            // now for the gpoint_ts it self, constructors incl. move
+            gpoint_ts() = default; // default for serialization conv
+            // implement ipoint_ts contract:
+            virtual ts_point_fx point_interpretation() const {return rep.point_interpretation();}
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) {rep.set_point_interpretation(point_interpretation);}
+            virtual const gta_t& time_axis() const {return rep.time_axis();}
+            virtual utcperiod total_period() const {return rep.total_period();}
+            virtual size_t index_of(utctime t) const {return rep.index_of(t);}
+            virtual size_t size() const {return rep.size();}
+            virtual utctime time(size_t i) const {return rep.time(i);};
+            virtual double value(size_t i) const {return rep.v[i];}
+            virtual double value_at(utctime t) const {return rep(t);}
+            virtual std::vector<double> values() const {return rep.v;}
+            // implement some extra functions to manipulate the points
+            void set(size_t i, double x) {rep.set(i,x);}
+            void fill(double x) {rep.fill(x);}
+            void scale_by(double x) {rep.scale_by(x);}
+            virtual bool needs_bind() const { return false;}
+            virtual void do_bind()  {}
+            x_serialize_decl();
+        };
+
+        struct aref_ts:ipoint_ts {
+            typedef shyft::time_series::ref_ts<gts_t> ref_ts_t;
+            ref_ts_t rep;
+            aref_ts(string sym_ref):rep(sym_ref) {}
+            aref_ts() = default; // default for serialization conv
+            // implement ipoint_ts contract:
+            virtual ts_point_fx point_interpretation() const {return rep.point_interpretation();}
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) {rep.set_point_interpretation(point_interpretation);}
+            virtual const gta_t& time_axis() const {return rep.time_axis();}
+            virtual utcperiod total_period() const {return rep.total_period();}
+            virtual size_t index_of(utctime t) const {return rep.index_of(t);}
+            virtual size_t size() const {return rep.size();}
+            virtual utctime time(size_t i) const {return rep.time(i);};
+            virtual double value(size_t i) const {return rep.value(i);}
+            virtual double value_at(utctime t) const {return rep(t);}
+            virtual std::vector<double> values() const {return rep.bts().v;}
+            // implement some extra functions to manipulate the points
+            void set(size_t i, double x) {rep.set(i,x);}
+            void fill(double x) {rep.fill(x);}
+            void scale_by(double x) {rep.scale_by(x);}
+            virtual bool needs_bind() const { return shyft::time_series::e_needs_bind(rep);}
+            virtual void do_bind()  {}
+            x_serialize_decl();
+       };
+
+        /** \brief The average_ts is used for providing ts average values over a time-axis
+         *
+         * Given a any ts, concrete, or an expression, provide the true average values on the
+         * intervals as provided by the specified time-axis.
+         *
+         * true average for each period in the time-axis is defined as:
+         *
+         *   integral of f(t) dt from t0 to t1 / (t1-t0)
+         *
+         * using the f(t) interpretation of the supplied ts (linear or stair case).
+         *
+         * The \ref ts_point_fx is always POINT_AVERAGE_VALUE for the result ts.
+         *
+         * \note if a nan-value intervals are excluded from the integral and time-computations.
+         *       E.g. let's say half the interval is nan, then the true average is computed for
+         *       the other half of the interval.
+         *
+         */
+        struct average_ts:ipoint_ts {
+            gta_t ta;
+            std::shared_ptr<ipoint_ts> ts;
+            // useful constructors
+            average_ts(gta_t&& ta,const apoint_ts& ats):ta(std::move(ta)),ts(ats.ts) {}
+            average_ts(gta_t&& ta,apoint_ts&& ats):ta(std::move(ta)),ts(std::move(ats.ts)) {}
+            average_ts(const gta_t& ta,apoint_ts&& ats):ta(ta),ts(std::move(ats.ts)) {}
+            average_ts(const gta_t& ta,const apoint_ts& ats):ta(ta),ts(ats.ts) {}
+            average_ts(const gta_t& ta,const std::shared_ptr<ipoint_ts> &ts ):ta(ta),ts(ts){}
+            average_ts(gta_t&& ta,const std::shared_ptr<ipoint_ts> &ts ):ta(std::move(ta)),ts(ts){}
+            // std copy ct and assign
+            average_ts()=default;
+            // implement ipoint_ts contract:
+            virtual ts_point_fx point_interpretation() const {return ts_point_fx::POINT_AVERAGE_VALUE;}
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) {;}
+            virtual const gta_t& time_axis() const {return ta;}
+            virtual utcperiod total_period() const {return ta.total_period();}
+            virtual size_t index_of(utctime t) const {return ta.index_of(t);}
+            virtual size_t size() const {return ta.size();}
+            virtual utctime time(size_t i) const {return ta.time(i);};
+            virtual double value(size_t i) const {
+                #ifdef _DEBUG
+                if(i>ta.size())
+                    return nan;
+                #endif
+                size_t ix_hint=(i*ts->size())/ta.size();// assume almost fixed delta-t.
+                return average_value(*ts,ta.period(i),ix_hint,ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);
+            }
+            virtual double value_at(utctime t) const {
+                // return true average at t
+                if(!ta.total_period().contains(t))
+                    return nan;
+                return value(index_of(t));
+            }
+            virtual std::vector<double> values() const {
+                std::vector<double> r;r.reserve(ta.size());
+                size_t ix_hint=ts->index_of(ta.time(0));
+                bool linear_interpretation=ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE;
+                for(size_t i=0;i<ta.size();++i) {
+                    r.push_back(average_value(*ts,ta.period(i),ix_hint,linear_interpretation));
+                }
+                return r;
+            }
+            virtual bool needs_bind() const { return ts->needs_bind();}
+            virtual void do_bind() {ts->do_bind();}
+            x_serialize_decl();
+
+        };
+
+        /** \brief The integral_ts is used for providing ts integral values over a time-axis
+        *
+        * Given a any ts, concrete, or an expression, provide the 'true integral' values on the
+        * intervals as provided by the specified time-axis.
+        *
+        * true inegral for each period in the time-axis is defined as:
+        *
+        *   integral of f(t) dt from t0 to t1
+        *
+        * using the f(t) interpretation of the supplied ts (linear or stair case).
+        *
+        * The \ref ts_point_fx is always POINT_AVERAGE_VALUE for the result ts.
+        *
+        * \note if a nan-value intervals are excluded from the integral and time-computations.
+        *       E.g. let's say half the interval is nan, then the true integral is computed for
+        *       the other half of the interval.
+        *
+        */
+        struct integral_ts :ipoint_ts {
+            gta_t ta;
+            std::shared_ptr<ipoint_ts> ts;
+            // useful constructors
+            integral_ts(gta_t&& ta, const apoint_ts& ats) :ta(std::move(ta)), ts(ats.ts) {}
+            integral_ts(gta_t&& ta, apoint_ts&& ats) :ta(std::move(ta)), ts(std::move(ats.ts)) {}
+            integral_ts(const gta_t& ta, apoint_ts&& ats) :ta(ta), ts(std::move(ats.ts)) {}
+            integral_ts(const gta_t& ta, const apoint_ts& ats) :ta(ta), ts(ats.ts) {}
+            integral_ts(const gta_t& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(ta), ts(ts) {}
+            integral_ts(gta_t&& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(std::move(ta)), ts(ts) {}
+            // std copy ct and assign
+            integral_ts()=default;
+            // implement ipoint_ts contract:
+            virtual ts_point_fx point_interpretation() const { return ts_point_fx::POINT_AVERAGE_VALUE; }
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) { ; }
+            virtual const gta_t& time_axis() const { return ta; }
+            virtual utcperiod total_period() const { return ta.total_period(); }
+            virtual size_t index_of(utctime t) const { return ta.index_of(t); }
+            virtual size_t size() const { return ta.size(); }
+            virtual utctime time(size_t i) const { return ta.time(i); };
+            virtual double value(size_t i) const {
+                if (i>ta.size())
+                    return nan;
+                size_t ix_hint = (i*ts->size()) / ta.size();// assume almost fixed delta-t.
+                utctimespan tsum = 0;
+                return accumulate_value(*ts, ta.period(i), ix_hint,tsum, ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);
+            }
+            virtual double value_at(utctime t) const {
+                // return true average at t
+                if (!ta.total_period().contains(t))
+                    return nan;
+                return value(index_of(t));
+            }
+            virtual std::vector<double> values() const {
+                std::vector<double> r;r.reserve(ta.size());
+                size_t ix_hint = ts->index_of(ta.time(0));
+                bool linear_interpretation = ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE;
+                for (size_t i = 0;i<ta.size();++i) {
+                    utctimespan tsum = 0;
+                    r.push_back(accumulate_value(*ts, ta.period(i), ix_hint,tsum, linear_interpretation));
+                }
+                return r;
+            }
+            virtual bool needs_bind() const { return ts->needs_bind();}
+            virtual void do_bind() {ts->do_bind();}
+            x_serialize_decl();
+
+        };
+
+        /** \brief The accumulate_ts is used for providing accumulated(integrated) ts values over a time-axis
+        *
+        * Given a any ts, concrete, or an expression, provide the true accumulated values,
+        * defined as area under non-nan values of the f(t) curve,
+        * on the intervals points as provided by the specified time-axis.
+        *
+        * The value at the i'th point of the time-axis is given by:
+        *
+        *   integral of f(t) dt from t0 to ti ,
+        *
+        *   where t0 is time_axis.period(0).start, and ti=time_axis.period(i).start
+        *
+        * using the f(t) interpretation of the supplied ts (linear or stair case).
+        *
+        * \note The value at t=t0 is 0.0 (by definition)
+        * \note The value of t outside ta.total_period() is nan
+        *
+        * The \ref ts_point_fx is always POINT_INSTANT_VALUE for the result ts.
+        *
+        * \note if a nan-value intervals are excluded from the integral and time-computations.
+        *       E.g. let's say half the interval is nan, then the true average is computed for
+        *       the other half of the interval.
+        *
+        */
+        struct accumulate_ts :ipoint_ts {
+            gta_t ta;
+            std::shared_ptr<ipoint_ts> ts;
+            // useful constructors
+            accumulate_ts(gta_t&& ta, const apoint_ts& ats) :ta(std::move(ta)), ts(ats.ts) {}
+            accumulate_ts(gta_t&& ta, apoint_ts&& ats) :ta(std::move(ta)), ts(std::move(ats.ts)) {}
+            accumulate_ts(const gta_t& ta, apoint_ts&& ats) :ta(ta), ts(std::move(ats.ts)) {}
+            accumulate_ts(const gta_t& ta, const apoint_ts& ats) :ta(ta), ts(ats.ts) {}
+            accumulate_ts(const gta_t& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(ta), ts(ts) {}
+            accumulate_ts(gta_t&& ta, const std::shared_ptr<ipoint_ts> &ts) :ta(std::move(ta)), ts(ts) {}
+            // std copy ct and assign
+            accumulate_ts()=default;
+            // implement ipoint_ts contract:
+            virtual ts_point_fx point_interpretation() const { return ts_point_fx::POINT_INSTANT_VALUE; }
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) { ; }// we could throw here..
+            virtual const gta_t& time_axis() const { return ta; }
+            virtual utcperiod total_period() const { return ta.total_period(); }
+            virtual size_t index_of(utctime t) const { return ta.index_of(t); }
+            virtual size_t size() const { return ta.size(); }
+            virtual utctime time(size_t i) const { return ta.time(i); };
+            virtual double value(size_t i) const {
+                if (i>ta.size())
+                    return nan;
+                if (i == 0)// by definition,0.0 at i=0
+                    return 0.0;
+                size_t ix_hint = 0;// assume almost fixed delta-t.
+                utctimespan tsum;
+                return accumulate_value(*ts, utcperiod(ta.time(0), ta.time(i)), ix_hint, tsum, ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);
+            }
+            virtual double value_at(utctime t) const {
+                // return true accumulated value at t
+                if (!ta.total_period().contains(t))
+                    return nan;
+                if (t == ta.time(0))
+                    return 0.0; // by definition
+                utctimespan tsum;
+                size_t ix_hint = 0;
+                return accumulate_value(*this, utcperiod(ta.time(0), t), ix_hint, tsum, ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !;
+            }
+            virtual std::vector<double> values() const {
+                std::vector<double> r;r.reserve(ta.size());
+                accumulate_accessor<ipoint_ts, gta_t> accumulate(*ts, ta);// use accessor, that
+                for (size_t i = 0;i<ta.size();++i) {                      // given sequential access
+                    r.push_back(accumulate.value(i));                     // reuses acc.computation
+                }
+                return r;
+            }
+            virtual bool needs_bind() const { return ts->needs_bind();}
+            virtual void do_bind() {ts->do_bind();}
+            // to help the average function, return the i'th point of the underlying timeseries
+            //point get(size_t i) const {return point(ts->time(i),ts->value(i));}
+            x_serialize_decl();
+
+        };
+
+        /** \brief time_shift ts do a time-shift dt on the supplied ts
+         *
+         * The values are exactly the same as the supplied ts argument to the constructor
+         * but the time-axis is shifted utctimespan dt to the left.
+         * e.g.: t_new = t_original + dt
+         *
+         *       lets say you have a time-series 'a'  with time-axis covering 2015
+         *       and you want to time-shift so that you have a time- series 'b'data for 2016,
+         *       then you could do this to get 'b':
+         *
+         *           utc = calendar() // utc calendar
+         *           dt  = utc.time(2016,1,1) - utc.time(2015,1,1)
+         *            b  = timeshift_ts(a, dt)
+         *
+         * \note If the ts given at constructor time is an unbound ts or expression,
+         *       then .do_deferred_bind() needs to be called before any call to
+         *       value or time-axis function calls.
+         *
+         */
+        struct time_shift_ts:ipoint_ts {
+            std::shared_ptr<ipoint_ts> ts;
+            gta_t ta;
+            utctimespan dt=0;// despite ta time-axis, we need it
+
+            time_shift_ts()=default;
+
+            //-- useful ct goes here
+            time_shift_ts(const apoint_ts& ats,utctimespan adt)
+                :ts(ats.ts),dt(adt) {
+                if(!ts->needs_bind())
+                    do_deferred_bind();
+
+            }
+            time_shift_ts(apoint_ts&& ats, utctimespan adt)
+                :ts(std::move(ats.ts)),dt(adt) {
+                if(!ts->needs_bind())
+                    do_deferred_bind();
+            }
+            time_shift_ts(const std::shared_ptr<ipoint_ts> &ts, utctime adt )
+                :ts(ts),dt(adt){
+                if(!ts->needs_bind())
+                    do_deferred_bind();
+            }
+            void do_deferred_bind() {
+                if(ta.size()==0) {//TODO: introduce bound flag, and use that, using the ta.size() is a problem if ta *is* size 0.
+                    ta= time_axis::time_shift(ts->time_axis(),dt);
+                }
+            }
+            // implement ipoint_ts contract:
+            virtual ts_point_fx point_interpretation() const {return ts->point_interpretation();}
+            virtual void set_point_interpretation(ts_point_fx point_interpretation) {ts->set_point_interpretation(point_interpretation);}
+            virtual const gta_t& time_axis() const {return ta;}
+            virtual utcperiod total_period() const {return ta.total_period();}
+            virtual size_t index_of(utctime t) const {return ta.index_of(t);}
+            virtual size_t size() const {return ta.size();}
+            virtual utctime time(size_t i) const {return ta.time(i);};
+            virtual double value(size_t i) const {return ts->value(i);}
+            virtual double value_at(utctime t) const {return ts->value_at(t-dt);}
+            virtual std::vector<double> values() const {return ts->values();}
+            virtual bool needs_bind() const { return ts->needs_bind();}
+            virtual void do_bind() {ts->do_bind();do_deferred_bind();}
+            x_serialize_decl();
+
+        };
+
+        /** \brief periodic_ts is used for providing ts periodic values over a time-axis
+        *
+        */
+        struct periodic_ts : ipoint_ts {
+            typedef shyft::time_series::periodic_ts<gta_t> pts_t;
+            pts_t ts;
+
+            periodic_ts(const vector<double>& pattern, utctimespan dt, const gta_t& ta) : ts(pattern, dt, ta) {}
+            periodic_ts(const vector<double>& pattern, utctimespan dt, utctime pattern_t0,const gta_t& ta) : ts(pattern, dt,pattern_t0,ta) {}
+            periodic_ts(const periodic_ts& c) : ts(c.ts) {}
+            periodic_ts(periodic_ts&& c) : ts(move(c.ts)) {}
+            periodic_ts& operator=(const periodic_ts& c) {
+                if (this != &c) {
+                    ts = c.ts;
+                }
+                return *this;
+            }
+            periodic_ts& operator=(periodic_ts&& c) {
+                ts = move(c.ts);
+                return *this;
+            }
+            periodic_ts()=default;
+            // implement ipoint_ts contract
+            virtual ts_point_fx point_interpretation() const { return ts_point_fx::POINT_AVERAGE_VALUE; }
+            virtual void set_point_interpretation(ts_point_fx) { ; }
+            virtual const gta_t& time_axis() const { return ts.ta; }
+            virtual utcperiod total_period() const { return ts.ta.total_period(); }
+            virtual size_t index_of(utctime t) const { return ts.index_of(t); }
+            virtual size_t size() const { return ts.ta.size(); }
+            virtual utctime time(size_t i) const { return ts.ta.time(i); }
+            virtual double value(size_t i) const { return ts.value(i); }
+            virtual double value_at(utctime t) const { return value(index_of(t)); }
+            virtual vector<double> values() const { return ts.values(); }
+            virtual bool needs_bind() const { return false;}// this is a terminal node, no bind needed
+            virtual void do_bind()  {}
+            x_serialize_decl();
+        };
+
+        /** \brief convolve_w is used for providing a convolution by weights ts
+        *
+        * The convolve_w_ts is particularly useful for implementing routing and model
+        * time-delays and shape-of hydro-response.
+        *
+        */
+        struct convolve_w_ts : ipoint_ts {
+            typedef vector<double> weights_t;
+            typedef shyft::time_series::convolve_w_ts<apoint_ts> cnv_ts_t;
+            cnv_ts_t ts_impl;
+
+            convolve_w_ts(const apoint_ts& ats, const weights_t& w, convolve_policy conv_policy) :ts_impl(ats, w, conv_policy) {}
+            convolve_w_ts(apoint_ts&& ats, const weights_t& w, convolve_policy conv_policy) :ts_impl(move(ats), w, conv_policy) {}
+            // hmm: convolve_w_ts(const std::shared_ptr<ipoint_ts> &ats,const weights_t& w,convolve_policy conv_policy ):ts(ats),ts_impl(*ts,w,conv_policy) {}
+
+            // std.ct
+            convolve_w_ts() =default;
+
+            // implement ipoint_ts contract
+            virtual ts_point_fx point_interpretation() const { return ts_impl.point_interpretation(); }
+            virtual void set_point_interpretation(ts_point_fx) { throw std::runtime_error("not implemented"); }
+            virtual const gta_t& time_axis() const { return ts_impl.time_axis(); }
+            virtual utcperiod total_period() const { return ts_impl.total_period(); }
+            virtual size_t index_of(utctime t) const { return ts_impl.index_of(t); }
+            virtual size_t size() const { return ts_impl.size(); }
+            virtual utctime time(size_t i) const { return ts_impl.time(i); }
+            virtual double value(size_t i) const { return ts_impl.value(i); }
+            virtual double value_at(utctime t) const { return value(index_of(t)); }
+            virtual vector<double> values() const {
+                vector<double> r;r.reserve(size());
+                for (size_t i = 0;i<size();++i)
+                    r.push_back(ts_impl.value(i));
+                return r;
+            }
+            virtual bool needs_bind() const { return ts_impl.ts.needs_bind();}
+            virtual void do_bind() {ts_impl.ts.do_bind();}
+            x_serialize_decl();
+        };
+
+        /** The iop_t represent the basic 'binary' operation,
+         *   a stateless function that takes two doubles and returns the binary operation.
+         *   E.g.: a+b
+         *   The iop_t is used as the operation element of the abin_op_ts class
+         */
+        enum iop_t {
+            OP_NONE,OP_ADD,OP_SUB,OP_DIV,OP_MUL,OP_MIN,OP_MAX
+        };
+
+        /** deferred_bind helps to defer the computation cost of the
+         * expression bin-op variants until its actually used.
+         * this is also needed when having ts_refs| unbound symbolic time-series references
+         * that we would like to serialize and pass over to another server for execution.
+         *
+         * By inspecting the time-series in the construction phase (bin_op etc.)
+         * we try to take the preparation for computation as early as possible,
+         * so, only when there is a symbolic time-series reference, there will be
+         * a deferred_bind() that will take action *after* the
+         * symbolic time-series has been prepared with real values (bound).
+         *
+         */
+
+        /** \brief The binary operation for type ts op ts
+         *
+         * The binary operation is lazy, and only keep the reference to the two operands
+         * that are of the \ref apoint_ts type.
+         * The operation is of \ref iop_t, and details for plus minus divide multiply etc is in
+         * the implementation file.
+         *
+         * As per definition a this class implements the \ref ipoint_ts interface,
+         * and the time-axis of type \ref gta_t is currently computed in the constructor.
+         * This could take some cpu if the time-axis is of type point_dt, so we could
+         * consider working some more on the internal algorithms to avoid this.
+         *
+         * The \ref ts_point_fx is computed based on rhs,lhs. But can be overridden
+         * by the user.
+         *
+         */
+        struct abin_op_ts:ipoint_ts {
+
+              apoint_ts lhs;
+              iop_t op=iop_t::OP_NONE;
+              apoint_ts rhs;
+              gta_t ta;
+              ts_point_fx fx_policy=POINT_AVERAGE_VALUE;
+              bool bound=false;
+
+              ts_point_fx point_interpretation() const {return fx_policy;}
+              void set_point_interpretation(ts_point_fx x) {fx_policy=x;}
+
+              void do_deferred_bind() {
+                if(!bound) {
+                    fx_policy=result_policy(lhs.point_interpretation(),rhs.point_interpretation());
+                    ta=time_axis::combine(lhs.time_axis(),rhs.time_axis());
+                    bound=true;
+                }
+              }
+
+              abin_op_ts()=default;
+              abin_op_ts(const apoint_ts &lhs,iop_t op,const apoint_ts& rhs)
+              :lhs(lhs),op(op),rhs(rhs) {
+                  if( !needs_bind() )
+                     do_deferred_bind();
+              }
+              void bind_check() const {if(!bound) throw runtime_error("attempting to use unbound timeseries, context abin_op_ts");}
+              virtual utcperiod total_period() const {return time_axis().total_period();}
+              const gta_t& time_axis() const {bind_check(); return ta;};// combine lhs,rhs
+              size_t index_of(utctime t) const{return time_axis().index_of(t);};
+              size_t size() const {return time_axis().size();};// use the combined ta.size();
+              utctime time( size_t i) const {return time_axis().time(i);}; // return combined ta.time(i)
+              double value_at(utctime t) const ;
+              double value(size_t i) const;// return op( lhs(t), rhs(t)) ..
+              std::vector<double> values() const;
+              bool needs_bind() const {return lhs.needs_bind() || rhs.needs_bind(); }
+              virtual void do_bind() {lhs.do_bind();rhs.do_bind();do_deferred_bind();}
+              x_serialize_decl();
+
+        };
+
+        /** \brief  binary operation for type ts op double
+         *
+         * The resulting time-axis and point interpretation policy is equal to the ts.
+         */
+        struct abin_op_scalar_ts:ipoint_ts {
+
+              double lhs;
+              iop_t op=iop_t::OP_NONE;
+              apoint_ts rhs;
+              gta_t ta;
+              ts_point_fx fx_policy=POINT_AVERAGE_VALUE;
+              bool bound=false;
+
+
+              ts_point_fx point_interpretation() const {return fx_policy;}
+              void set_point_interpretation(ts_point_fx x) {fx_policy=x;}
+
+              void do_deferred_bind()  {
+                  if(!bound) {
+                      ta=rhs.time_axis();
+                      fx_policy= rhs.point_interpretation();
+                      bound=true;
+                  }
+              }
+              void bind_check() const {if(!bound) throw runtime_error("attempting to use unbound timeseries, context abin_op_scalar");}
+              abin_op_scalar_ts()=default;
+
+              abin_op_scalar_ts(double lhs,iop_t op,const apoint_ts& rhs)
+              :lhs(lhs),op(op),rhs(rhs) {
+                  if(!needs_bind())
+                    do_deferred_bind();
+              }
+
+              virtual utcperiod total_period() const {return time_axis().total_period();}
+              const gta_t& time_axis() const {bind_check();return ta;};// combine lhs,rhs
+              size_t index_of(utctime t) const{return time_axis().index_of(t);};
+              size_t size() const {return time_axis().size();};
+              utctime time( size_t i) const {return time_axis().time(i);};
+              double value_at(utctime t) const ;
+              double value(size_t i) const ;
+              std::vector<double> values() const ;
+              bool needs_bind() const {return rhs.needs_bind(); }
+              virtual void do_bind() {rhs.do_bind();do_deferred_bind();}
+              x_serialize_decl();
+        };
+
+        /** \brief  binary operation for type ts op double
+         *
+         * The resulting time-axis and point interpretation policy is equal to the ts.
+         */
+        struct abin_op_ts_scalar:ipoint_ts {
+              apoint_ts lhs;
+              iop_t op=iop_t::OP_NONE;
+              double rhs;
+              gta_t ta;
+              bool bound=false;
+              ts_point_fx fx_policy=POINT_AVERAGE_VALUE;
+              ts_point_fx point_interpretation() const {return fx_policy;}
+              void set_point_interpretation(ts_point_fx x) {fx_policy=x;}
+              void do_deferred_bind()  {
+                  if(!bound) {
+                      ta=lhs.time_axis();
+                      fx_policy= lhs.point_interpretation();
+                      bound=true;
+                  }
+              }
+              void bind_check() const {if(!bound) throw runtime_error("attempting to use unbound timeseries, context abin_op_ts_scalar");}
+              abin_op_ts_scalar()=default;
+
+              abin_op_ts_scalar(const apoint_ts &lhs,iop_t op,double rhs)
+              :lhs(lhs),op(op),rhs(rhs) {
+                  if(!needs_bind())
+                    do_deferred_bind();
+              }
+
+              virtual utcperiod total_period() const {return time_axis().total_period();}
+              const gta_t& time_axis() const {bind_check();return ta;};
+              size_t index_of(utctime t) const{return time_axis().index_of(t);};
+              size_t size() const {return time_axis().size();};
+              utctime time( size_t i) const {return time_axis().time(i);};
+              double value_at(utctime t) const;
+              double value(size_t i) const;
+              std::vector<double> values() const;
+              bool needs_bind() const {return lhs.needs_bind(); }
+              virtual void do_bind() {lhs.do_bind();do_deferred_bind();}
+              x_serialize_decl();
+
+        };
+
+        // add operators and functions to the apoint_ts class, of all variants that we want to expose
+        apoint_ts average(const apoint_ts& ts,const gta_t& ta/*fx-type */) ;
+        apoint_ts average(apoint_ts&& ts,const gta_t& ta) ;
+
+        apoint_ts integral(const apoint_ts& ts, const gta_t& ta/*fx-type */);
+        apoint_ts integral(apoint_ts&& ts, const gta_t& ta);
+
+        apoint_ts accumulate(const apoint_ts& ts, const gta_t& ta/*fx-type */);
+        apoint_ts accumulate(apoint_ts&& ts, const gta_t& ta);
+
+        apoint_ts create_glacier_melt_ts_m3s(const apoint_ts & temp,const apoint_ts& sca_m2,double glacier_area_m2,double dtf);
+
+        double nash_sutcliffe(const apoint_ts& observation_ts, const apoint_ts& model_ts, const gta_t &ta);
+
+        double kling_gupta(const apoint_ts& observation_ts, const apoint_ts&  model_ts, const gta_t& ta, double s_r, double s_a, double s_b);
+
+        apoint_ts create_periodic_pattern_ts(const vector<double>& pattern, utctimespan dt,utctime t0, const gta_t& ta);
+
+        apoint_ts operator+(const apoint_ts& lhs,const apoint_ts& rhs) ;
+        apoint_ts operator+(const apoint_ts& lhs,double           rhs) ;
+        apoint_ts operator+(double           lhs,const apoint_ts& rhs) ;
+
+        apoint_ts operator-(const apoint_ts& lhs,const apoint_ts& rhs) ;
+        apoint_ts operator-(const apoint_ts& lhs,double           rhs) ;
+        apoint_ts operator-(double           lhs,const apoint_ts& rhs) ;
+        apoint_ts operator-(const apoint_ts& rhs) ;
+
+        apoint_ts operator/(const apoint_ts& lhs,const apoint_ts& rhs) ;
+        apoint_ts operator/(const apoint_ts& lhs,double           rhs) ;
+        apoint_ts operator/(double           lhs,const apoint_ts& rhs) ;
+
+        apoint_ts operator*(const apoint_ts& lhs,const apoint_ts& rhs) ;
+        apoint_ts operator*(const apoint_ts& lhs,double           rhs) ;
+        apoint_ts operator*(double           lhs,const apoint_ts& rhs) ;
+
+
+        apoint_ts max(const apoint_ts& lhs,const apoint_ts& rhs) ;
+        apoint_ts max(const apoint_ts& lhs,double           rhs) ;
+        apoint_ts max(double           lhs,const apoint_ts& rhs) ;
+
+        apoint_ts min(const apoint_ts& lhs,const apoint_ts& rhs) ;
+        apoint_ts min(const apoint_ts& lhs,double           rhs) ;
+        apoint_ts min(double           lhs,const apoint_ts& rhs) ;
+
+        ///< percentiles, need to include several forms of time_axis for python
+        std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const gta_t & ta,const vector<int>& percentiles);
+        std::vector<apoint_ts> percentiles(const std::vector<apoint_ts>& ts_list,const time_axis::fixed_dt & ta,const vector<int>& percentiles);
+
+        ///< time_shift i.e. same ts values, but time-axis is time-axis + dt
+        apoint_ts time_shift(const apoint_ts &ts, utctimespan dt);
+
+        /** Given a vector of expressions, deflate(evaluate) the expressions and return the
+         * equivalent concrete point-time-series of the expressions in the
+         * preferred destination type Ts
+         * Useful for the dtss,
+         * evaluates the expressions in parallell
+         */
+        template <class Ts,class TsV>
+        std::vector<Ts>
+        deflate_ts_vector(TsV const&tsv1) {
+            std::vector<Ts> tsv2(tsv1.size());
+
+            auto deflate_range=[&tsv1,&tsv2](size_t i0,size_t n) {
+                for(size_t i=i0;i<i0+n;++i)
+                    tsv2[i]= Ts(tsv1[i].time_axis(),tsv1[i].values(),tsv1[i].point_interpretation());
+            };
+            auto n_threads = thread::hardware_concurrency();
+            if(n_threads <2) n_threads=4;// hard coded minimum
+            std::vector<std::future<void>> calcs;
+            size_t ps= 1 + tsv1.size()/n_threads;
+            for (size_t p = 0;p < tsv1.size(); ) {
+                size_t np = p + ps <= tsv1.size() ? ps : tsv1.size() - p;
+                calcs.push_back(std::async(std::launch::async, deflate_range, p, np));
+                p += np;
+            }
+            for (auto &f : calcs) f.get();
+            return tsv2;
+        }
+
+        /** \brief ats_vector represents a list of time-series, support math-operations.
+         *
+         * Supports handling and math operations for vectors of time-series.
+         * Especially convinient in python due to compact notation and speed.
+         */
+        typedef vector<apoint_ts> ats_vec;
+        struct ats_vector:ats_vec  {  // inheritance from vector, to get most parts for free
+            // constructor stuff that needs to be complete for boost::python
+            ats_vector()=default;
+            ats_vector(ats_vec const&c):ats_vec(c) {}
+            ats_vector(ats_vec&& c):ats_vec(c) {}
+            ats_vector(ats_vector const&c):ats_vec(c) {}
+            ats_vector(size_t sz):ats_vec(sz) {}
+            ats_vector(ats_vector&&c):ats_vec(move(c)) {}
+            ats_vector& operator=(ats_vector const&c) {
+                if(this !=&c) {
+                    ats_vec::operator=(c);
+                }
+                return *this;
+            }
+            ats_vector& operator=(ats_vector&&c) {
+                ats_vec::operator=(c);
+                return *this;
+            }
+            //-- minimal iterator support in order to expose it as vector
+            ats_vector(ats_vec::iterator b,ats_vec::iterator e):ats_vec(b,e) {}
+            auto begin() {return ats_vec::begin();}
+            auto begin() const {return ats_vec::begin();}
+            auto end() {return ats_vec::end();}
+            auto end() const {return ats_vec::end();}
+            void reserve(size_t x) {ats_vec::reserve(x);}
+            apoint_ts& operator()(size_t i) {return *(begin()+i);}
+            apoint_ts const & operator()(size_t i) const {return *(begin()+i);}
+
+            vector<double> values_at_time(utctime t) const {
+                std::vector<double> r;r.reserve(size());
+                for (auto const &ts : *this ) r.push_back(ts(t));
+                return r;
+            }
+            ats_vector percentiles(gta_t const &ta,vector<int> const& percentile_list) const {
+                ats_vector r;r.reserve(percentile_list.size());
+                auto rp= shyft::time_series::calculate_percentiles(ta,deflate_ts_vector<gts_t>(*this),percentile_list);
+                for(auto&ts:rp) r.emplace_back(ta,std::move(ts.v),POINT_AVERAGE_VALUE);
+                return r;
+            }
+            ats_vector percentiles_f(time_axis::fixed_dt const&ta,vector<int> const& percentile_list) const {
+                return percentiles(gta_t(ta),percentile_list);
+            }
+            ats_vector slice(vector<int>const& slice_spec) const {
+                if(slice_spec.size()==0) {
+                    return ats_vector(*this);// just a clone of this
+                } else {
+                    ats_vector r;for(auto ix:slice_spec) r.push_back(begin()[ix]);
+                    return r;
+                }
+            }
+
+            ats_vector average(gta_t const&ta) {
+                ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.average(ta)); return r;
+            }
+            ats_vector integral(gta_t const&ta) {
+                ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.integral(ta)); return r;
+            }
+            ats_vector accumulate(gta_t const&ta) {
+                ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.accumulate(ta)); return r;
+            }
+            ats_vector time_shift(utctimespan delta_t) {
+                ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.time_shift(delta_t)); return r;
+            }
+            x_serialize_decl();
+        };
+
+        // multiply operators
+        ats_vector operator*(ats_vector const &a,double b);
+        ats_vector operator*(double a,ats_vector const &b);
+        ats_vector operator*(ats_vector const &a,ats_vector const& b);
+        ats_vector operator*(ats_vector::value_type const &a,ats_vector const& b);
+        ats_vector operator*(ats_vector const& b,ats_vector::value_type const &a);
+
+
+        // divide operators
+        ats_vector operator/(ats_vector const &a,double b);
+        ats_vector operator/(double a,ats_vector const &b);
+        ats_vector operator/(ats_vector const &a,ats_vector const& b);
+        ats_vector operator/(ats_vector::value_type const &a,ats_vector const& b);
+        ats_vector operator/(ats_vector const& b,ats_vector::value_type const &a);
+
+        // add operators
+        ats_vector operator+(ats_vector const &a,double b);
+        ats_vector operator+(double a,ats_vector const &b);
+        ats_vector operator+(ats_vector const &a,ats_vector const& b);
+        ats_vector operator+(ats_vector::value_type const &a,ats_vector const& b);
+        ats_vector operator+(ats_vector const& b,ats_vector::value_type const &a);
+
+        // sub operators
+        ats_vector operator-(const ats_vector& a);
+
+        ats_vector operator-(ats_vector const &a,double b);
+        ats_vector operator-(double a,ats_vector const &b);
+        ats_vector operator-(ats_vector const &a,ats_vector const& b);
+        ats_vector operator-(ats_vector::value_type const &a,ats_vector const& b);
+        ats_vector operator-(ats_vector const& b,ats_vector::value_type const &a);
     }
     namespace time_series {
         template<>
@@ -952,3 +1054,4 @@ x_serialize_export_key(shyft::api::aref_ts);
 x_serialize_export_key(shyft::time_series::convolve_w_ts<shyft::api::apoint_ts>); // oops need this from core
 x_serialize_export_key(shyft::api::convolve_w_ts);
 x_serialize_export_key(shyft::api::apoint_ts);
+x_serialize_export_key(shyft::api::ats_vector);

--- a/core/dtss.h
+++ b/core/dtss.h
@@ -65,7 +65,8 @@ namespace shyft {
 
         }
 
-        typedef std::vector<api::apoint_ts> ts_vector_t;
+        //typedef std::vector<api::apoint_ts> ts_vector_t;
+        typedef api::ats_vector ts_vector_t;
         typedef std::vector<std::string> id_vector_t;
         typedef std::function< ts_vector_t (id_vector_t const& ts_ids,core::utcperiod p)> call_back_t;
 
@@ -117,7 +118,7 @@ namespace shyft {
             ts_vector_t
             do_evaluate_ts_vector(core::utcperiod bind_period, ts_vector_t& atsv) {
                 do_bind_ts(bind_period, atsv);
-                return api::deflate_ts_vector<api::apoint_ts>(atsv);
+                return ts_vector_t(api::deflate_ts_vector<api::apoint_ts>(atsv));
             }
 
             ts_vector_t

--- a/shyft/api/__init__.py
+++ b/shyft/api/__init__.py
@@ -66,8 +66,9 @@ StringVector.size = lambda self: len(self)
 
 TsVector.size = lambda self: len(self)
 TsVector.push_back = lambda self, ts: self.append(ts)
-# and this is for easy syntax:
-TsVector.percentiles = lambda self, ta, percentile_list: percentiles(self, ta, percentile_list)
+# and this is for bw.compat
+def percentiles(tsv:TsVector,time_axis:TimeAxis,percentile_list:IntVector)->TsVector:
+    return tsv.percentiles(time_axis,percentile_list)
 
 TargetSpecificationVector.size = lambda self: len(self)
 
@@ -381,12 +382,12 @@ def ts_vector_values_at_time(tsv:TsVector, t:int):
         tsv = TsVector()
         for ts in list_of_ts:
             tsv.append(ts)
-    return compute_ts_values_at_time(tsv, t).to_numpy()
+    return tsv.values_at(t).to_numpy()
 
-ts_vector_values_at_time.__doc__ = compute_ts_values_at_time.__doc__.replace('DoubleVector','ndarray').replace('TsVector','TsVector or list(TimeSeries)')
+ts_vector_values_at_time.__doc__ = TsVector.values_at.__doc__.replace('DoubleVector','ndarray').replace('TsVector','TsVector or list(TimeSeries)')
 
 TsVector.values_at_time = ts_vector_values_at_time
-TsVector.values_at_time.__doc__ = compute_ts_values_at_time.__doc__.replace('DoubleVector','ndarray')
+TsVector.values_at_time.__doc__ = TsVector.values_at.__doc__.replace('DoubleVector','ndarray')
 
 
 

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -522,6 +522,150 @@ class TimeSeries(unittest.TestCase):
         c_resurrected.bind_done()
         self.assertAlmostEqual(c_resurrected.value(10), a.value(10) * 2 * 4.0, 3)
 
+    def test_a_time_series_vector(self):
+        c = api.Calendar()
+        t0 = api.utctime_now()
+        dt = api.deltahours(1)
+        n = 240
+        ta = api.TimeAxisFixedDeltaT(t0, dt, n)
+
+        a = api.TimeSeries(ta=ta, fill_value=3.0, point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)
+        b = api.TimeSeries(ta=ta, fill_value=2.0, point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)
+        c = api.TimeSeries(ta=ta, fill_value=10.0, point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)
+        v = api.TsVector()
+        v.append(a)
+        v.append(b)
+
+        self.assertEqual(len(v), 2)
+        self.assertAlmostEqual(v[0].value(0), 3.0, "expect first ts to be 3.0")
+        aa = api.TimeSeries(ta=a.time_axis, values=a.values,
+                            point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)  # copy construct (really copy the values!)
+        a.fill(1.0)
+        self.assertAlmostEqual(v[0].value(0), 1.0, "expect first ts to be 1.0, because the vector keeps a reference ")
+        self.assertAlmostEqual(aa.value(0), 3.0)
+
+        vt = v.values_at(t0).to_numpy()
+        self.assertEqual(len(vt),len(v))
+        v1 = v[0:1]
+        self.assertEqual(len(v1),1)
+        self.assertAlmostEqual(v1[0].value(0),1.0)
+        v_clone = api.TsVector(v)
+        self.assertEqual(len(v_clone),len(v))
+        del v_clone[-1]
+        self.assertEqual(len(v_clone),1)
+        self.assertEqual(len(v), 2)
+        v_slice_all = v.slice(api.IntVector())
+        v_slice_1 = v.slice(api.IntVector([1]))
+        v_slice_12 = v.slice(api.IntVector([0, 1]))
+        self.assertEqual(len(v_slice_all), 2)
+        self.assertEqual(len(v_slice_1), 1)
+        self.assertAlmostEqual(v_slice_1[0].value(0), 2.0)
+        self.assertEqual(len(v_slice_12), 2)
+        self.assertAlmostEqual(v_slice_12[0].value(0), 1.0)
+
+        # multiplication by scalar
+        v_x_2a = v*2.0
+        v_x_2b = 2.0*v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_x_2a[i].value(0),2*v[i].value(0))
+            self.assertAlmostEqual(v_x_2b[i].value(0),2*v[i].value(0))
+
+        # division by scalar
+        v_d_a = v/3.0
+        v_d_b = 3.0/v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_d_a[i].value(0),v[i].value(0)/3.0)
+            self.assertAlmostEqual(v_d_b[i].value(0),3.0/v[i].value(0))
+
+        # addition by scalar
+        v_a_a = v + 3.0
+        v_a_b = 3.0 + v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_a_a[i].value(0),v[i].value(0)+3.0)
+            self.assertAlmostEqual(v_a_b[i].value(0),3.0+v[i].value(0))
+
+        # sub by scalar
+        v_s_a = v - 3.0
+        v_s_b = 3.0 - v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_s_a[i].value(0),v[i].value(0) - 3.0)
+            self.assertAlmostEqual(v_s_b[i].value(0),3.0 - v[i].value(0))
+
+        # multiplication vector by ts
+        v_x_ts = v*c
+        ts_x_v = c*v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_x_ts[i].value(0),v[i].value(0)*c.value(0))
+            self.assertAlmostEqual(ts_x_v[i].value(0),c.value(0)*v[i].value(0))
+
+        # division vector by ts
+        v_d_ts = v/c
+        ts_d_v = c/v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_d_ts[i].value(0),v[i].value(0)/c.value(0))
+            self.assertAlmostEqual(ts_d_v[i].value(0),c.value(0)/v[i].value(0))
+
+        # add vector by ts
+        v_a_ts = v + c
+        ts_a_v = c + v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_a_ts[i].value(0),v[i].value(0) + c.value(0))
+            self.assertAlmostEqual(ts_a_v[i].value(0),c.value(0) + v[i].value(0))
+
+        # sub vector by ts
+        v_s_ts = v - c
+        ts_s_v = c - v
+        for i in range(len(v)):
+            self.assertAlmostEqual(v_s_ts[i].value(0),v[i].value(0) - c.value(0))
+            self.assertAlmostEqual(ts_s_v[i].value(0),c.value(0) - v[i].value(0))
+
+        # vector mult vector
+        va = v
+        vb = 2.0*v
+
+        v_m_v = va * vb
+        self.assertEqual(len(v_m_v),len(va))
+        for i in range(len(va)):
+            self.assertAlmostEqual(v_m_v[i].value(0), va[i].value(0)*vb[i].value(0))
+
+        # vector div vector
+        v_d_v = va / vb
+        self.assertEqual(len(v_d_v),len(va))
+        for i in range(len(va)):
+            self.assertAlmostEqual(v_d_v[i].value(0), va[i].value(0)/vb[i].value(0))
+
+        # vector add vector
+        v_a_v = va + vb
+        self.assertEqual(len(v_a_v),len(va))
+        for i in range(len(va)):
+            self.assertAlmostEqual(v_a_v[i].value(0), va[i].value(0) + vb[i].value(0))
+
+        # vector sub vector
+        v_s_v = va - vb
+        self.assertEqual(len(v_s_v),len(va))
+        for i in range(len(va)):
+            self.assertAlmostEqual(v_s_v[i].value(0), va[i].value(0) - vb[i].value(0))
+
+        # vector unary minus
+        v_u = - va
+        self.assertEqual(len(v_u), len(va))
+        for i in range(len(va)):
+            self.assertAlmostEqual(v_u[i].value(0), -va[i].value(0))
+
+        # integral functions, just to verify exposure works, and one value is according to spec.
+        ta2 = api.TimeAxis(t0, dt*24, n//24)
+        v_avg = v.average(ta2)
+        v_int = v.integral(ta2)
+        v_acc = v.accumulate(ta2)
+        v_sft = v.time_shift(dt*24)
+        self.assertIsNotNone(v_avg)
+        self.assertIsNotNone(v_int)
+        self.assertIsNotNone(v_acc)
+        self.assertIsNotNone(v_sft)
+        self.assertAlmostEqual(v_avg[0].value(0),1.0)
+        self.assertAlmostEqual(v_int[0].value(0), 86400.0)
+        self.assertAlmostEqual(v_acc[0].value(0), 0.0)
+        self.assertAlmostEqual(v_sft[0].time(0), t0+dt*24)
 
 if __name__ == "__main__":
     unittest.main()

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -667,5 +667,14 @@ class TimeSeries(unittest.TestCase):
         self.assertAlmostEqual(v_acc[0].value(0), 0.0)
         self.assertAlmostEqual(v_sft[0].time(0), t0+dt*24)
 
+        # finally, test that exception is raised if we try to multiply two unequal sized vectors
+
+        try:
+            x= v_clone*va
+            self.assertTrue(False,'We expected exception for unequal sized ts-vector op')
+        except RuntimeError as re:
+            pass
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/time_series_test.cpp
+++ b/test/time_series_test.cpp
@@ -1451,5 +1451,7 @@ TEST_CASE("test_uniform_sum_ts") {
 		TS_ASSERT_DELTA(sum_ts.value(t)+sum_ts.value(t), cc.value(t), 0.0001);
 	}
 }
+TEST_CASE("ts_vector_operations") {
 
+}
 }


### PR DESCRIPTION
# Overview
This PR adds mathematical operations on the existing TsVector class.
Practical use has proven that this feature will increase speed, and allow building on abstraction(expressions, vector of expressions), and avoid deflating into numpy-arrays to early.

E.g.:
```python
a= TsVector()
b= TsVector()
:  # add some time-series to a and b here
c = TimeSeries(...)  # ts  vs. vector is also supported
ta = TimeAxis(...) # some time-axis

d = (a*b + c)*3.5  # a x b is vector x vector,  + c is vector + ts, ()*3.5 is vector x scalar

p = d.percentiles(ta,stat_spec)   # as usual vector supports percentiles
d_avg = d.average(ta)  # applies average to all ts in d-vector
d_sft  = d.time_shift(deltahours(24))   #  time-shift all time-series in d by 24h
d_acc = d.accumulate(ta)  #  generate the accumulate function for each ts in vector d
d_int  = d.integral(ta)  # integral of ts, over intervals given by ta

d_slice = d.slice(IntVector([1,2,10,11,12]))  # support for slicing, picking specified indexes->TsVector


```

The new features are additional, and there is no intended break of existing interfaces  or api's.

