### PR TITLE
Best effort run

### DIFF
--- a/api/api.vcxproj
+++ b/api/api.vcxproj
@@ -74,6 +74,8 @@
       <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -96,6 +98,8 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -323,8 +323,8 @@ namespace expose {
             .def("min",min_ts_f,args("ts_other"),"create a new ts that contains the min of self and ts_other")
             .def("max",max_double_f,args("number"),"create a new ts that contains the max of self and number for each time-step")
             .def("max",max_ts_f,args("ts_other"),"create a new ts that contains the max of self and ts_other")
-            .def("max",max_stat_ts_ts_f,args("ts_a","ts_b"),"create a new ts that is the max(ts_a,ts_b)").staticmethod("max")
-            .def("min",min_stat_ts_ts_f,args("ts_a","ts_b"),"create a new ts that is the max(ts_a,ts_b)").staticmethod("min")
+            //.def("max",max_stat_ts_ts_f,args("ts_a","ts_b"),"create a new ts that is the max(ts_a,ts_b)").staticmethod("max")
+            //.def("min",min_stat_ts_ts_f,args("ts_a","ts_b"),"create a new ts that is the max(ts_a,ts_b)").staticmethod("min")
 			.def("partition_by",&shyft::api::apoint_ts::partition_by,
                 args("calendar","t", "partition_interval", "n_partitions","common_t0"),
 				doc_intro("convert ts to a list of n_partitions partition-ts.")

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -298,6 +298,8 @@ namespace expose {
 			.def(self - double())
 
 			.def(-self)
+            .def(operator!(self))
+
 			.def("average", &shyft::api::apoint_ts::average, args("ta"),
                 doc_intro("create a new ts that is the true average of self")
                 doc_intro("over the specified time-axis ta.")

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -14,6 +14,10 @@ namespace expose {
 
     static void expose_ats_vector() {
         using namespace shyft::api;
+        typedef ats_vector(ats_vector::*m_double)(double)const;
+        typedef ats_vector(ats_vector::*m_ts)(apoint_ts const&)const;
+        typedef ats_vector(ats_vector::*m_tsv) (ats_vector const&)const;
+
         class_<ats_vector>("TsVector",
                 doc_intro("A vector of time-series that supports ts-math operations.")
                 doc_intro("")
@@ -96,6 +100,12 @@ namespace expose {
                 doc_parameter("delta_t","int","number of seconds to time-shift, positive values moves forward")
 				doc_returns("tsv","TsVector",	"a new time-series, that appears as time-shifted version of self")
 			)
+            .def("min",(m_double)&ats_vector::min,args("number"),"returns min of vector and a number")
+            .def("min", (m_ts)&ats_vector::min, args("ts"), "returns min of ts-vector and a ts")
+            .def("min", (m_tsv)&ats_vector::min, args("tsv"), "returns min of ts-vector and another ts-vector")
+            .def("max", (m_double)&ats_vector::max, args("number"), "returns max of vector and a number")
+            .def("max", (m_ts)&ats_vector::max, args("ts"), "returns max of ts-vector and a ts")
+            .def("max", (m_tsv)&ats_vector::max, args("tsv"), "returns max of ts-vector and another ts-vector")
             // defining vector math-operations goes here
             .def(-self)
             .def(self*double())
@@ -122,6 +132,23 @@ namespace expose {
             .def(shyft::api::apoint_ts()-self)
             .def(self-shyft::api::apoint_ts())
             ;
+            // expose min-max functions:
+            typedef ats_vector(*f_atsv_double)(ats_vector const &, double b);
+            typedef ats_vector(*f_double_atsv)(double b, ats_vector const &a);
+            typedef ats_vector(*f_atsv_ats)(ats_vector const &, apoint_ts const& );
+            typedef ats_vector(*f_ats_atsv)(apoint_ts const &b, ats_vector const& a);
+            typedef ats_vector(*f_atsv_atsv)(ats_vector const &b, ats_vector const &a);
+            
+            def("min", (f_ats_atsv)min, args("ts", "ts_vector"), "return minimum of ts and ts_vector");
+            def("min", (f_atsv_ats)min, args("ts_vector", "ts"), "return minimum of ts_vector and ts");
+            def("min", (f_atsv_double)min, args("ts_vector", "number"), "return minimum of ts_vector and number");
+            def("min", (f_double_atsv)min, args("number","ts_vector"), "return minimum of number and ts_vector");
+            def("min", (f_atsv_atsv)min, args("a", "b"), "return minimum of ts_vectors a and b (requires equal size!)");
+            def("max", (f_ats_atsv)max, args("ts", "ts_vector"), "return max of ts and ts_vector");
+            def("max", (f_atsv_ats)max, args("ts_vector", "ts"), "return max of ts_vector and ts");
+            def("max", (f_atsv_double)max, args("ts_vector", "number"), "return max of ts_vector and number");
+            def("max", (f_double_atsv)max, args("number", "ts_vector"), "return max of number and ts_vector");
+            def("max", (f_atsv_atsv)max, args("a", "b"), "return max of ts_vectors a and b (requires equal size!)");
     }
 
     #define DEF_STD_TS_STUFF() \

--- a/api/boostpython/api_time_series.cpp
+++ b/api/boostpython/api_time_series.cpp
@@ -167,9 +167,6 @@ namespace expose {
         typedef shyft::api::apoint_ts pts_t;
         typedef pts_t (pts_t::*self_dbl_t)(double) const;
         typedef pts_t (pts_t::*self_ts_t)(const pts_t &)const;
-        typedef  pts_t ( *static_ts_ts_t)(const pts_t&,const pts_t&);
-        static_ts_ts_t min_stat_ts_ts_f=&pts_t::min;
-        static_ts_ts_t max_stat_ts_ts_f=&pts_t::max;
 
         self_dbl_t min_double_f=&pts_t::min;
         self_ts_t  min_ts_f =&pts_t::min;

--- a/api/boostpython/boostpython.cbp
+++ b/api/boostpython/boostpython.cbp
@@ -24,7 +24,7 @@
 				<Option type="3" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-O2" />
+					<Add option="-O3" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />
@@ -49,7 +49,7 @@
 				<Option type="3" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-O2" />
+					<Add option="-O3" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />
@@ -74,7 +74,7 @@
 				<Option type="3" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-O2" />
+					<Add option="-O3" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />
@@ -99,7 +99,7 @@
 				<Option type="3" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-O2" />
+					<Add option="-O3" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />
@@ -124,7 +124,7 @@
 				<Option type="3" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-O2" />
+					<Add option="-O3" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />

--- a/api/boostpython/expose.h
+++ b/api/boostpython/expose.h
@@ -175,71 +175,60 @@ namespace expose {
              "be passed into a the constructor of a new region-model (clone-operation)\n"
          )
          .def("initialize_cell_environment",&M::initialize_cell_environment,boost::python::arg("time_axis"),
-			 "Initializes the cell enviroment (cell.env.ts* )\n"
-			 "\n"
-			 "The method initializes the cell environment, that keeps temperature, precipitation etc\n"
-			 "that is local to the cell.The initial values of these time - series is set to zero.\n"
-			 "The region-model time-axis is set to the supplied time-axis, so that\n"
-			 "the any calculation steps will use the supplied time-axis.\n"
-			 "This call is needed once prior to call to the .interpolate() or .run_cells() methods\n"
-			 "\n"
-			 "The call ensures that all cells.env ts are reset to zero, with a time-axis and\n"
-			 " value-vectors according to the supplied time-axis.\n"
-			 " Also note that the region-model.time_axis is set to the supplied time-axis.\n"
-			 "\n"
-			 "Parameters\n"
-			 "----------\n"
-			 " time_axis: Timeaxis\n"
-			 "    specifies the time-axis for the region-model, and thus the cells\n"
-			 "Returns\n"
-			 "-------\n"
-			 "Nothing\n"
+                doc_intro("Initializes the cell enviroment (cell.env.ts* )")
+                doc_intro("")
+                doc_intro("The method initializes the cell environment, that keeps temperature, precipitation etc")
+                doc_intro("that is local to the cell.The initial values of these time - series is set to zero.")
+                doc_intro("The region-model time-axis is set to the supplied time-axis, so that")
+                doc_intro("the any calculation steps will use the supplied time-axis.")
+                doc_intro("This call is needed once prior to call to the .interpolate() or .run_cells() methods")
+                doc_intro("")
+                doc_intro("The call ensures that all cells.env ts are reset to zero, with a time-axis and")
+                doc_intro(" value-vectors according to the supplied time-axis.")
+                doc_intro(" Also note that the region-model.time_axis is set to the supplied time-axis.")
+                doc_intro("")
+                doc_parameters()
+                doc_parameter("time_axis","TimeAxis","specifies the time-axis for the region-model, and thus the cells")
+                doc_returns("nothing","","")
 		 )
-		 .def("interpolate", interpolate_f, args("interpolation_parameter", "env"),
-				"do interpolation interpolates region_environment temp,precip,rad.. point sources\n"
-				"to a value representative for the cell.mid_point().\n"
-				"\n"
-				"note: initialize_cell_environment should be called once prior to this function\n"
-				"\n"
-				"Only supplied vectors of temp, precip etc. are interpolated, thus\n"
-				"the user of the class can choose to put in place distributed series in stead.\n"
-				"\n"
-				"Parameters\n"
-				"----------\n"
-				" interpolation_parameter : InterpolationParameter\n"
-				"     contains wanted parameters for the interpolation\n"
-				" env: RegionEnvironemnt\n"
-				"     contains the ref: region_environment type\n"
+		 .def("interpolate", interpolate_f, (boost::python::arg("interpolation_parameter"),boost::python::arg("env"),boost::python::arg("best_effort")=true),
+                doc_intro("do interpolation interpolates region_environment temp,precip,rad.. point sources")
+                doc_intro("to a value representative for the cell.mid_point().")
+                doc_intro("")
+                doc_intro("note: initialize_cell_environment should be called once prior to this function")
+                doc_intro("")
+                doc_intro("Only supplied vectors of temp, precip etc. are interpolated, thus")
+                doc_intro("the user of the class can choose to put in place distributed series in stead.")
+                doc_intro("")
+                doc_parameters()
+                doc_parameter("interpolation_parameter","InterpolationParameter","contains wanted parameters for the interpolation")
+                doc_parameter("env","RegionEnvironment","contains the region environment with geo-localized time-series for P,T,R,W,Rh")
+                doc_parameter("best_effort","bool","default=True, don't throw, just return True/False if problem, with best_effort, unfilled values is nan")
+                doc_returns("success","bool","True if interpolation runs with no exceptions(btk,raises if to few neighbours)")
 		 )
          .def("run_cells",&M::run_cells,(boost::python::arg("use_ncore")=0,boost::python::arg("start_step")=0,boost::python::arg("n_steps")=0),
-             "run_cells calculations over specified time_axis,optionally with thread_cell_count, start_step and n_steps\n"
-             "require that initialize(time_axis) or run_interpolation is done first\n"
-             "If start_step and n_steps are specified, only the specified part of the time-axis is covered.\n"
-             "notice that in any case, the current model state is used as a starting point\n"
-             "Parameters\n"
-             "----------\n"
-             "use_ncore : int\n"
-             "\t number of worker threads, or cores to use, if 0 is passed, the the core-count is used to determine the count\n"
-             "start_step : int\n"
-             "\t start_step in the time-axis to start at, default=0, meaning start at the beginning\n"
-             "n_steps :int\n"
-             "\t number of steps to run in a partial run, default=0 indicating the complete time-axis is covered\n"
+                doc_intro("run_cells calculations over specified time_axis,optionally with thread_cell_count, start_step and n_steps")
+                doc_intro("require that initialize(time_axis) or run_interpolation is done first")
+                doc_intro("If start_step and n_steps are specified, only the specified part of the time-axis is covered.")
+                doc_intro("notice that in any case, the current model state is used as a starting point")
+                doc_parameters()
+                doc_parameter("use_ncore","int","number of worker threads, or cores to use, if 0 is passed, the the core-count is used to determine the count")
+                doc_parameter("start_step","int","start_step in the time-axis to start at, default=0, meaning start at the beginning")
+                doc_parameter("n_steps","int","number of steps to run in a partial run, default=0 indicating the complete time-axis is covered")
          )
-         .def("run_interpolation",run_interpolation_f,args("interpolation_parameter","time_axis","env"),
-                    "run_interpolation interpolates region_environment temp,precip,rad.. point sources\n"
-                    "to a value representative for the cell.mid_point().\n"
-                    "\n"
-                    "note: This function is equivalent to\n"
-					"    self.initialize_cell_environment(time_axis)\n"
-					"    self.interpolate(interpolation_parameter,env)\n"
-				    "Parameters\n"
-					"----------\n"
-					" interpolation_parameter: InterpolationParameter\n"
-					"   contains wanted parameters for the interpolation\n"
-					" time_axis : Timeaxis\n"
-					"    should be equal to the ref: timeaxis the ref: region_model is prepared running for.\n"
-					" env : RegionEnvironment\n"
-					"    contains the ref: region_environment type\n"
+         .def("run_interpolation",run_interpolation_f,(boost::python::arg("interpolation_parameter"),boost::python::arg("time_axis"),boost::python::arg("env"),boost::python::arg("best_effort")=true),
+                doc_intro("run_interpolation interpolates region_environment temp,precip,rad.. point sources")
+                doc_intro("to a value representative for the cell.mid_point().")
+                doc_intro("")
+                doc_intro("note: This function is equivalent to")
+                doc_intro("    self.initialize_cell_environment(time_axis)")
+                doc_intro("    self.interpolate(interpolation_parameter,env)")
+                doc_parameters()
+                doc_parameter("interpolation_parameter","InterpolationParameter","contains wanted parameters for the interpolation")
+                doc_parameter("time_axis","TimeAxis","should be equal to the time-axis the region_model is prepared running for")
+                doc_parameter("env","RegionEnvironment","contains the ref: region_environment type")
+                doc_parameter("best_effort","bool","default=True, don't throw, just return True/False if problem, with best_effort, unfilled values is nan")
+                doc_returns("success","bool","True if interpolation runs with no exceptions(btk,raises if to few neighbours)")
             )
          .def("set_region_parameter",&M::set_region_parameter,args("p"),
                     "set the region parameter, apply it to all cells \n"

--- a/api/python/api.python.vcxproj
+++ b/api/python/api.python.vcxproj
@@ -75,6 +75,8 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -110,6 +112,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/python/hbv_stack.python.vcxproj
+++ b/api/python/hbv_stack.python.vcxproj
@@ -74,6 +74,8 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,6 +111,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/python/pt_gs_k.python.vcxproj
+++ b/api/python/pt_gs_k.python.vcxproj
@@ -74,6 +74,8 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,6 +111,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/python/pt_hs_k.python.vcxproj
+++ b/api/python/pt_hs_k.python.vcxproj
@@ -74,6 +74,8 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,6 +111,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/python/pt_ss_k.python.vcxproj
+++ b/api/python/pt_ss_k.python.vcxproj
@@ -74,6 +74,8 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,6 +111,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/api/time_series.cpp
+++ b/api/time_series.cpp
@@ -395,6 +395,29 @@ namespace shyft{
         ats_vector operator-(ats_vector::value_type const &a,ats_vector const& b) {ats_vector r;r.reserve(b.size());for(size_t i=0;i<b.size();++i) r.push_back(a-b[i]);return r;}
         ats_vector operator-(ats_vector const& b,ats_vector::value_type const &a) {ats_vector r;r.reserve(b.size());for(size_t i=0;i<b.size();++i) r.push_back(b[i]-a);return r;}
 
+        // max/min operators
+        ats_vector ats_vector::min(ats_vector const& x) const {
+            if (size() != x.size()) throw runtime_error(string("ts-vector min require same sizes: lhs.size=") + std::to_string(size()) + string(",rhs.size=") + std::to_string(x.size()));
+            ats_vector r;r.reserve(size());for (size_t i = 0;i < size();++i) r.push_back((*this)[i].min(x[i]));
+            return r;
+        }
+        ats_vector ats_vector::max(ats_vector const& x) const {
+            if (size() != x.size()) throw runtime_error(string("ts-vector max require same sizes: lhs.size=") + std::to_string(size()) + string(",rhs.size=") + std::to_string(x.size()));
+            ats_vector r;r.reserve(size());for (size_t i = 0;i < size();++i) r.push_back((*this)[i].max(x[i]));
+            return r;
+        }
+        ats_vector min(ats_vector const &a, double b) { return a.min(b); }
+        ats_vector min(double b, ats_vector const &a) { return a.min(b); }
+        ats_vector min(ats_vector const &a, apoint_ts const& b) { return a.min(b); }
+        ats_vector min(apoint_ts const &b, ats_vector const& a) { return a.min(b); }
+        ats_vector min(ats_vector const &a, ats_vector const &b) { return a.min(b); }
+
+        ats_vector max(ats_vector const &a, double b) { return a.max(b); }
+        ats_vector max(double b, ats_vector const &a) { return a.max(b); }
+        ats_vector max(ats_vector const &a, apoint_ts const & b) { return a.max(b); }
+        ats_vector max(apoint_ts const &b, ats_vector const &a) { return a.max(b); }
+        ats_vector max(ats_vector const &a, ats_vector const & b) { return a.max(b); }
+
     }
 }
 

--- a/api/time_series.h
+++ b/api/time_series.h
@@ -382,15 +382,7 @@ namespace shyft {
                     return nan;
                 return value(index_of(t));
             }
-            virtual std::vector<double> values() const {
-                std::vector<double> r;r.reserve(ta.size());
-                size_t ix_hint=ts->index_of(ta.time(0));
-                bool linear_interpretation=ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE;
-                for(size_t i=0;i<ta.size();++i) {
-                    r.push_back(average_value(*ts,ta.period(i),ix_hint,linear_interpretation));
-                }
-                return r;
-            }
+			virtual std::vector<double> values() const;
             virtual bool needs_bind() const { return ts->needs_bind();}
             virtual void do_bind() {ts->do_bind();}
             x_serialize_decl();

--- a/api/time_series.h
+++ b/api/time_series.h
@@ -186,7 +186,10 @@ namespace shyft {
                     throw runtime_error("TimeSeries is empty");
                 return ts;
             }
-
+            /** support operator! bool  to let an empty ts evaluate to */
+            bool operator !() const { // can't expose it as op, due to math promotion
+                return !(  ts && ts->size() > 0);
+            }
             /**\brief Easy to compare for equality, but tricky if performance needed */
             bool operator==(const apoint_ts& other) const;
 

--- a/api/time_series.h
+++ b/api/time_series.h
@@ -986,18 +986,33 @@ namespace shyft {
                 }
             }
 
-            ats_vector average(gta_t const&ta) {
+            ats_vector average(gta_t const&ta) const {
                 ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.average(ta)); return r;
             }
-            ats_vector integral(gta_t const&ta) {
+            ats_vector integral(gta_t const&ta) const {
                 ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.integral(ta)); return r;
             }
-            ats_vector accumulate(gta_t const&ta) {
+            ats_vector accumulate(gta_t const&ta) const {
                 ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.accumulate(ta)); return r;
             }
-            ats_vector time_shift(utctimespan delta_t) {
+            ats_vector time_shift(utctimespan delta_t) const {
                 ats_vector r;r.reserve(size());for(auto const &ts:*this) r.push_back(ts.time_shift(delta_t)); return r;
             }
+            ats_vector min(double x) const {
+                ats_vector r;r.reserve(size());for (auto const &ts : *this) r.push_back(ts.min(x)); return r;
+            }
+            ats_vector max(double x) const {
+                ats_vector r;r.reserve(size());for (auto const &ts : *this) r.push_back(ts.max(x)); return r;
+            }
+            ats_vector min(apoint_ts const& x) const {
+                ats_vector r;r.reserve(size());for (auto const &ts : *this) r.push_back(ts.min(x)); return r;
+            }
+            ats_vector max(apoint_ts const& x) const {
+                ats_vector r;r.reserve(size());for (auto const &ts : *this) r.push_back(ts.max(x)); return r;
+            }
+            ats_vector min(ats_vector const& x) const;
+            ats_vector max(ats_vector const& x) const;
+
             x_serialize_decl();
         };
 
@@ -1031,6 +1046,19 @@ namespace shyft {
         ats_vector operator-(ats_vector const &a,ats_vector const& b);
         ats_vector operator-(ats_vector::value_type const &a,ats_vector const& b);
         ats_vector operator-(ats_vector const& b,ats_vector::value_type const &a);
+        
+        // max-min func overloads (2x!)
+        ats_vector min(ats_vector const &a, double b);
+        ats_vector min(double b, ats_vector const &a);
+        ats_vector min(ats_vector const &a, apoint_ts const& b);
+        ats_vector min(apoint_ts const &b, ats_vector const& a);
+        ats_vector min(ats_vector const &a, ats_vector const &b);
+
+        ats_vector max(ats_vector const &a, double b);
+        ats_vector max(double b, ats_vector const &a);
+        ats_vector max(ats_vector const &a, apoint_ts const & b);
+        ats_vector max(apoint_ts const &b, ats_vector const &a);
+        ats_vector max(ats_vector const &a, ats_vector const & b);
     }
     namespace time_series {
         template<>

--- a/api/time_series.h
+++ b/api/time_series.h
@@ -440,16 +440,7 @@ namespace shyft {
                     return nan;
                 return value(index_of(t));
             }
-            virtual std::vector<double> values() const {
-                std::vector<double> r;r.reserve(ta.size());
-                size_t ix_hint = ts->index_of(ta.time(0));
-                bool linear_interpretation = ts->point_interpretation() == ts_point_fx::POINT_INSTANT_VALUE;
-                for (size_t i = 0;i<ta.size();++i) {
-                    utctimespan tsum = 0;
-                    r.push_back(accumulate_value(*ts, ta.period(i), ix_hint,tsum, linear_interpretation));
-                }
-                return r;
-            }
+            virtual std::vector<double> values() const ;
             virtual bool needs_bind() const { return ts->needs_bind();}
             virtual void do_bind() {ts->do_bind();}
             x_serialize_decl();
@@ -1041,7 +1032,7 @@ namespace shyft {
         ats_vector operator-(ats_vector const &a,ats_vector const& b);
         ats_vector operator-(ats_vector::value_type const &a,ats_vector const& b);
         ats_vector operator-(ats_vector const& b,ats_vector::value_type const &a);
-        
+
         // max-min func overloads (2x!)
         ats_vector min(ats_vector const &a, double b);
         ats_vector min(double b, ats_vector const &a);

--- a/api/time_series.h
+++ b/api/time_series.h
@@ -916,7 +916,7 @@ namespace shyft {
                 for(size_t i=i0;i<i0+n;++i)
                     tsv2[i]= Ts(tsv1[i].time_axis(),tsv1[i].values(),tsv1[i].point_interpretation());
             };
-            auto n_threads = thread::hardware_concurrency();
+            auto n_threads =  thread::hardware_concurrency();
             if(n_threads <2) n_threads=4;// hard coded minimum
             std::vector<std::future<void>> calcs;
             size_t ps= 1 + tsv1.size()/n_threads;
@@ -1037,7 +1037,11 @@ namespace shyft {
         inline size_t hint_based_search<api::apoint_ts>(const api::apoint_ts& source, const utcperiod& p, size_t i) {
             return source.open_range_index_of(p.start, i);
         }
-    }
+		template<>
+		inline size_t hint_based_search<api::ipoint_ts>(const api::ipoint_ts& source, const utcperiod& p, size_t i) {
+			return source.time_axis().open_range_index_of(p.start, i);
+		}
+	}
 }
 //-- serialization support
 x_serialize_export_key(shyft::api::ipoint_ts);

--- a/core/cell_model.h
+++ b/core/cell_model.h
@@ -40,20 +40,20 @@ namespace shyft {
 			relhum_ts        rel_hum;
 			windspeed_ts     wind_speed;
 
-			//< reset/initializes all series with 0.0 and reserves size to ta. size.
+			//< reset/initializes all series with nan and reserves size to ta. size.
 			void init(const timeaxis& ta) {
                 if (ta != temperature.ta) {
-                    temperature = temperature_ts(ta, 0.0);
-                    precipitation = precipitation_ts(ta, 0.0);
-                    rel_hum = relhum_ts(ta, 0.0);
-                    radiation = radiation_ts(ta, 0.0);
-                    wind_speed = windspeed_ts(ta, 0.0);
+                    temperature = temperature_ts(ta, shyft::nan);
+                    precipitation = precipitation_ts(ta, shyft::nan);
+                    rel_hum = relhum_ts(ta, shyft::nan);
+                    radiation = radiation_ts(ta, shyft::nan);
+                    wind_speed = windspeed_ts(ta, shyft::nan);
                 } else {
-                    temperature.fill(0.0);
-                    precipitation.fill(0.0);
-                    rel_hum.fill( 0.0);
-                    radiation.fill(0.0);
-                    wind_speed.fill(0.0);
+                    temperature.fill(shyft::nan);
+                    precipitation.fill(shyft::nan);
+                    rel_hum.fill( shyft::nan);
+                    radiation.fill(shyft::nan);
+                    wind_speed.fill(shyft::nan);
                 }
 			}
 		};
@@ -136,13 +136,14 @@ namespace shyft {
 			    return geo.mid_point()==x.geo.mid_point()&& geo.catchment_id()==x.geo.catchment_id();
 			}
 		};
-        /**Utility function used to  initialize a pts_t in the core, typically making space, zero fill a ts
+        /**Utility function used to  initialize a pts_t in the core, typically making space, fill a ts
         *  prior to a run to ensure values are zero */
         inline void ts_init(pts_t&ts, time_axis::fixed_dt const& ta, int start_step, int n_steps, ts_point_fx fx_policy) {
+            double const fill_value=shyft::nan;
             if (ts.ta != ta || ta.size()==0 ) {
-                ts = pts_t(ta, 0.0, fx_policy);
+                ts = pts_t(ta, fill_value, fx_policy);
             } else {
-                ts.fill_range(0.0, start_step, n_steps);
+                ts.fill_range(fill_value, start_step, n_steps);
             }
         }
 

--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -64,6 +64,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -88,6 +90,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/core/time_series.h
+++ b/core/time_series.h
@@ -423,7 +423,7 @@ namespace shyft{
 
             } // because true-average of periods is per def. POINT_AVERAGE_VALUE
             // to help average_value method for now!
-            point get(size_t i) const {return point(ta.time(i),ts.value(i));}
+            point get(size_t i) const {return point(ta.time(i),value(i));}
             size_t size() const { return ta.size();}
             size_t index_of(utctime t) const {return ta.index_of(t);}
             //--
@@ -432,7 +432,7 @@ namespace shyft{
                     return nan;
                 size_t ix_hint=(i*d_ref(ts).ta.size())/ta.size();// assume almost fixed delta-t.
                 //TODO: make specialized pr. time-axis average_value, since average of fixed_dt is trivial compared to other ta.
-                return average_value(*this,ta.period(i),ix_hint,d_ref(ts).fx_policy == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !
+                return average_value(ts,ta.period(i),ix_hint,d_ref(ts).fx_policy == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !
             }
             double operator()(utctime t) const {
                 size_t i=ta.index_of(t);
@@ -473,7 +473,7 @@ namespace shyft{
                  {
             } // because accumulate represents the integral of the distance from t0 to t, valid at t
 
-            point get(size_t i) const { return point(ta.time(i), ts.value(i)); }
+            point get(size_t i) const { return point(ta.time(i), value(i)); }
             size_t size() const { return ta.size(); }
             size_t index_of(utctime t) const { return ta.index_of(t); }
             utcperiod total_period()const {return ta.total_period();}
@@ -486,7 +486,7 @@ namespace shyft{
                 size_t ix_hint = 0;// we have to start at the beginning
                 utcperiod accumulate_period(ta.time(0), ta.time(i));
                 utctimespan tsum;
-                return accumulate_value(*this, accumulate_period, ix_hint,tsum, d_ref(ts).fx_policy == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !
+                return accumulate_value(ts, accumulate_period, ix_hint,tsum, d_ref(ts).fx_policy == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !
             }
             double operator()(utctime t) const {
                 size_t i = ta.index_of(t);
@@ -496,7 +496,7 @@ namespace shyft{
                     return 0.0; // by definition
                 utctimespan tsum;
                 size_t ix_hint = 0;
-                return accumulate_value(*this, utcperiod(ta.time(0),t), ix_hint,tsum, d_ref(ts).fx_policy == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !;
+                return accumulate_value(ts, utcperiod(ta.time(0),t), ix_hint,tsum, d_ref(ts).fx_policy == ts_point_fx::POINT_INSTANT_VALUE);// also note: average of non-nan areas !;
             }
             x_serialize_decl();
         };
@@ -1654,7 +1654,7 @@ namespace shyft{
             }
             return abs_diff_sum;
         }
- 
+
 
         /**\brief partition_by convert a time-series into a vector of time-shifted partitions of ts with a common time-reference
         *

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -191,6 +191,7 @@ class TimeSeries(unittest.TestCase):
         ta = api.TimeAxis(t0, dt, n)
 
         a = api.TimeSeries(ta=ta, fill_value=3.0, point_fx=api.point_interpretation_policy.POINT_AVERAGE_VALUE)
+        self.assertTrue(a) # should evaluate to true
         b = api.TimeSeries(ta=ta, fill_value=1.0)
         b.fill(2.0)  # demo how to fill a point ts
         self.assertAlmostEqual((1.0 - b).values.to_numpy().max(), -1.0)
@@ -478,6 +479,7 @@ class TimeSeries(unittest.TestCase):
         self.assertEqual(a.values.size(),0)
         self.assertEqual(len(a.values.to_numpy()), 0)
         self.assertFalse(a.total_period().valid())
+        self.assertFalse(a) # evaluate to false
         try:
             a.time_axis
             self.assertFail("Expected exception")

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -668,6 +668,36 @@ class TimeSeries(unittest.TestCase):
         self.assertAlmostEqual(v_acc[0].value(0), 0.0)
         self.assertAlmostEqual(v_sft[0].time(0), t0+dt*24)
 
+        # min/max functions
+        min_v_double = va.min(-1000.0)
+        max_v_double = va.max(1000.0)
+        self.assertAlmostEqual(min_v_double[0].value(0), -1000.0)
+        self.assertAlmostEqual(max_v_double[0].value(0), +1000.0)
+        min_v_double = api.min(va, -1000.0)
+        max_v_double = api.max(va, +1000.0)
+        self.assertAlmostEqual(min_v_double[0].value(0), -1000.0)
+        self.assertAlmostEqual(max_v_double[0].value(0), +1000.0)
+        # c = 10.0
+        c1000= 100.0*c
+        min_v_double = va.min(-c1000)
+        max_v_double = va.max(c1000)
+        self.assertAlmostEqual(min_v_double[0].value(0), -c1000.value(0))
+        self.assertAlmostEqual(max_v_double[0].value(0), c1000.value(0))
+        min_v_double = api.min(va, -c1000)
+        max_v_double = api.max(va, c1000)
+        self.assertAlmostEqual(min_v_double[0].value(0), -c1000.value(0))
+        self.assertAlmostEqual(max_v_double[0].value(0), c1000.value(0))
+
+        v1000 = va*1000.0
+        min_v_double = va.min(-v1000)
+        max_v_double = va.max(v1000)
+        self.assertAlmostEqual(min_v_double[0].value(0), -v1000[0].value(0))
+        self.assertAlmostEqual(max_v_double[0].value(0), v1000[0].value(0))
+        min_v_double = api.min(va, -v1000)
+        max_v_double = api.max(va, v1000)
+        self.assertAlmostEqual(min_v_double[0].value(0), -v1000[0].value(0))
+        self.assertAlmostEqual(max_v_double[0].value(0), v1000[0].value(0))
+
         # finally, test that exception is raised if we try to multiply two unequal sized vectors
 
         try:

--- a/shyft/tests/api/test_time_series.py
+++ b/shyft/tests/api/test_time_series.py
@@ -200,8 +200,9 @@ class TimeSeries(unittest.TestCase):
         e = a.average(ta)  # average
         f = api.max(c, 300.0)
         g = api.min(c, -300.0)
-        h = a.max(c, 300)
-        k = a.min(c, -300)
+        #h = a.max(c, 300) # class static method not supported
+        h = c.max(300.0)
+        k = c.min( -300)
 
         self.assertEqual(a.size(), n)
         self.assertEqual(b.size(), n)

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -257,7 +257,7 @@ TEST_CASE("cell_builder_test::test_read_and_run_region_model") {
     //cout << "partial:avg precip for selected    catchments is:" << avg_precip_ip_set_value << endl;
     //cout << "partial:avg precip for unselected  catchments is:" << avg_precip_ip_o_set_value << endl;
     FAST_CHECK_GT(avg_precip_ip_set_value, 0.05);
-    FAST_CHECK_EQ(finite(avg_precip_ip_o_set_value),false);
+    FAST_CHECK_EQ(std::isfinite(avg_precip_ip_o_set_value),false);
     rm.set_catchment_calculation_filter(all_catchment_ids);
     ti1 = timing::now();
     rm.interpolate(ip, re);

--- a/test/cell_builder_test.cpp
+++ b/test/cell_builder_test.cpp
@@ -215,9 +215,10 @@ TEST_CASE("cell_builder_test::test_read_and_run_region_model") {
 
     auto cal = ec::calendar();
 	auto start = cal.time(2010, 9, 1, 0, 0, 0);
-	auto dt = ec::deltahours(3);
+	auto dt_hours=3;
+	auto dt = ec::deltahours(dt_hours);
 	auto ndays = atoi(getenv("NDAYS") ? getenv("NDAYS") : "90");
-	size_t n = 24 * ndays;//365;// 365 takes 20 seconds at cell stage 8core
+	size_t n = 24 * ndays/dt_hours;//365;// 365 takes 20 seconds at cell stage 8core
 	ta::fixed_dt ta(start, dt, n);
     ta::fixed_dt ta_one_step(start, dt*n, 1);
 
@@ -235,12 +236,12 @@ TEST_CASE("cell_builder_test::test_read_and_run_region_model") {
 	}
     //return;
 	// Step 3: make a region model
-	cout << "3. creating a region model and run it for a short period" << endl;
+	cout << "3. creating a region model and run t0="<<cal.to_string(start)<<",dt="<<dt_hours<<"h, n= "<<n<<" ~"<<ndays<<" days" << endl;
 	region_model_t rm(cells, *global_parameter);
 	rm.ncore = atoi(getenv("NCORE") ? getenv("NCORE") : "8");
 	cout << " - ncore set to " << rm.ncore << endl;
 	ec::interpolation_parameter ip;
-	ip.use_idw_for_temperature = true;
+	ip.use_idw_for_temperature = false;
     vector<int> all_catchment_ids;// empty vector means no filtering
     vector<int> catchment_ids{ 87,115 };
     vector<int> other_ids{ 38,188,259,295,389,465,496,516,551,780 };
@@ -260,9 +261,10 @@ TEST_CASE("cell_builder_test::test_read_and_run_region_model") {
     FAST_CHECK_EQ(std::isfinite(avg_precip_ip_o_set_value),false);
     rm.set_catchment_calculation_filter(all_catchment_ids);
     ti1 = timing::now();
-    rm.interpolate(ip, re);
+    auto ok_ip = rm.interpolate(ip, re);
     ipt = elapsed_ms(ti1, timing::now());
-    cout << "3. a Done with interpolation step *all* catchments used = " << ipt << "[ms]" << endl;
+    cout << "3. b Done with interpolation step *all* catchments used = " << ipt << "[ms]" << endl;
+    REQUIRE(ok_ip);
     // now verify we got same results for the limited set, and non-zero for the others.
     auto avg_precip_ip_set2 = ec::cell_statistics::average_catchment_feature(*rm.get_cells(), catchment_ids, [](const cell_t&c) {return c.env_ts.precipitation; });
     auto avg_precip_ip_set_value2 = et::average_accessor<et::pts_t, ta::fixed_dt>(avg_precip_ip_set2, ta_one_step).value(0);
@@ -272,8 +274,35 @@ TEST_CASE("cell_builder_test::test_read_and_run_region_model") {
     FAST_CHECK_GT(avg_precip_ip_o_set_value2, 0.05);
     //cout << "full:avg precip for selected    catchments is:" << avg_precip_ip_set_value2 << endl;
     //cout << "full:avg precip for unselected  catchments is:" << avg_precip_ip_o_set_value2 << endl;
+    cout << "3. c Verify best_effort interpolation";
+    auto re_temperature = *(re.temperature);
+    for(auto& gts:*(re.temperature)) {
+        for(size_t i=100;i<gts.ts.size();++i)
+            gts.ts.set(i,shyft::nan);
+    }
+    auto ok=rm.interpolate(ip,re);
+    cout<<"\ndone "<<(ok?", all ok":", with problems")<<", exit"<<endl;
+    REQUIRE(!ok);
+    try {
+        ok=rm.interpolate(ip,re,false);
+        REQUIRE(false);// REQUIRE the above to throw
+    } catch(exception const &ex) {
+        // we should get an exception here
+        if(verbose) cout<<"ok, got expected exception : "<<ex.what()<<endl;
+    }
+    ip.use_idw_for_temperature = true;// test for idw (more forgiving)
+    try {
+        ok=rm.interpolate(ip,re,false);
+    } catch(exception const &ex) {
+        // we should get an exception here
+        if(verbose) cout<<"ok, got expected exception : "<<ex.what()<<endl;
+        REQUIRE(false);// REQUIRE the above to not throw (idw is best effort by design)
+    }
+    *re.temperature = re_temperature; // restore ok temperatures
     if (getenv("SHYFT_IP_ONLY"))
 		return;
+	ok_ip = rm.interpolate(ip, re);
+	REQUIRE(ok_ip);
 	vector<shyft::core::pt_gs_k::state_t> s0;
 	// not needed, the rm will provide the initial_state for us.rm.get_states(s0);
     //

--- a/test/dtss_test.cpp
+++ b/test/dtss_test.cpp
@@ -170,10 +170,10 @@ TEST_CASE("dlib_server_performance") {
                     int kilo_points= tsl.size()*ta.size()/1000;
                     while (elapsed_ms(t0, timing::now()) < test_duration_ms) {
                         // burn cpu server side, save time on serialization
-                        //std::vector<int> percentile_spec{ 0,25,50,-1,75,100 };
-                        //auto percentiles = dtss.percentiles(tsl, ta.total_period(), ta24, percentile_spec);
+                        std::vector<int> percentile_spec{ -1 };
+                        auto percentiles = dtss.percentiles(tsl, ta.total_period(), ta24, percentile_spec);
                         //slower due to serialization:
-                        auto ts_b = dtss.evaluate(tsl, ta.total_period());
+                        //auto ts_b = dtss.evaluate(tsl, ta.total_period());
                         ++eval_count;
                     }
                     auto total_ms = double(elapsed_ms(t0, timing::now()));

--- a/test/dtss_test.cpp
+++ b/test/dtss_test.cpp
@@ -123,7 +123,7 @@ TEST_CASE("dlib_server_performance") {
         bool throw_exception = false;
 		ts_vector_t from_disk; from_disk.reserve(n_ts);
 		double fv = 1.0;
-		for (size_t i = 0; i < n_ts; ++i)
+		for (int i = 0; i < n_ts; ++i)
 			from_disk.emplace_back(ta, fv += 1.0,shyft::time_series::ts_point_fx::POINT_AVERAGE_VALUE);
 
         call_back_t cb = [&from_disk, &throw_exception](id_vector_t ts_ids, core::utcperiod p)
@@ -150,7 +150,7 @@ TEST_CASE("dlib_server_performance") {
                     string host_port = string("localhost:") + to_string(port_no);
                     dlog << dlib::LINFO << "sending an expression ts to " << host_port;
                     std::vector<api::apoint_ts> tsl;
-					for (size_t x = 1; x <= n_ts; ++x) {// just make a  very thin request, that get loads of data back
+					for (int x = 1; x <= n_ts; ++x) {// just make a  very thin request, that get loads of data back
 #if 0
 						auto ts_expr = api::apoint_ts(string("netcdf://group/path/ts_") + std::to_string(x));
 						tsl.push_back(ts_expr);

--- a/test/serialization_test.cpp
+++ b/test/serialization_test.cpp
@@ -389,18 +389,20 @@ TEST_CASE("apoint_ts_expression_speed") {
     // case from LTM: 200 time-series, each with 5 years 3h data, reduce(add,..) -> 1 ts.
     // optimal speed using vector + vector show that this is a memory-bus limited operation
     // (so multiple threads on same memory system do not scale)
+    // the purpose of this part is (to study) performance only
     bool verbose = getenv("SHYFT_VERBOSE") ? true : false;
     calendar utc;
-    auto dt=deltahours(3);
-    size_t n = 5*365*deltahours(24)/dt;
+    size_t n_steps_pr_day = 8;
+    auto dt=deltahours(24/n_steps_pr_day);
+    size_t n = 5*365*n_steps_pr_day;
     size_t n_ts= 200;
     time_axis::generic_dt ta(utc.time(2016,1,1),dt,n);
-    time_axis::generic_dt ta24(utc.time(2016,1,1),deltahours(24),n/8);
+    time_axis::generic_dt ta24(utc.time(2016,1,1),deltahours(24),n/n_steps_pr_day);
 
     api::apoint_ts ts_expr(ta,1.0,time_series::ts_point_fx::POINT_AVERAGE_VALUE);
-    for(size_t i=0;i<n_ts;++i)
-        ts_expr = ts_expr + 3.14*api::apoint_ts (ta,double((i+1)*1.0),time_series::ts_point_fx::POINT_AVERAGE_VALUE);
-
+    for (size_t i = 0;i < n_ts;++i) 
+        ts_expr = ts_expr + 3.14*api::apoint_ts(ta, double((i + 1)*1.0), time_series::ts_point_fx::POINT_AVERAGE_VALUE);
+    auto ts_sum_expr = ts_expr;
     ts_expr = ts_expr.average(ta24);
     std::vector<double> avg_v;avg_v.reserve(n);
     double xz;
@@ -418,5 +420,22 @@ TEST_CASE("apoint_ts_expression_speed") {
         <<",\nsize of final result is "<<avg_v.size()
         <<endl;
     }
+    FAST_WARN_LE(ms, 1000);
+    vector<int> pct = {10, 50,75 };
+    api::ats_vector atsv;
+    atsv.push_back(ts_sum_expr);
+    atsv.push_back(ts_sum_expr*1.1);
+    atsv.push_back(ts_sum_expr*0.9);
+    atsv.push_back(ts_sum_expr*1.3);
+    t0 = clock();
+    auto pct_result = atsv.percentiles(ta24, pct);
+    ms = (clock() - t0)*1000.0 / double(CLOCKS_PER_SEC);
+    if (verbose) {
+        cout << "percentile " << n_ts << " ts, each with "
+            << n << " values to one ts took " << ms << " ms" << " xz=" << xz
+            << ",\nsize of final result is " << pct_result.size()
+            << endl;
+    }
+    FAST_WARN_LE(ms, 1000);
 }
 }

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -12,7 +12,7 @@
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="-nv -tc=cell_builder_test::test_read_and_run_region_model" />
+				<Option parameters="-nv -tc=core_average_ts" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>

--- a/test/test.cbp
+++ b/test/test.cbp
@@ -12,7 +12,7 @@
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters="-nv -tc=test_ts_statistics_calculations" />
+				<Option parameters="-nv -tc=cell_builder_test::test_read_and_run_region_model" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -66,6 +66,8 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -98,6 +100,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/test/time_series_test.cpp
+++ b/test/time_series_test.cpp
@@ -71,45 +71,48 @@ using namespace shyfttest;
 
 typedef point_ts<time_axis::point_dt> xts_t;
 namespace shyfttest {
-    class ts_source {
-            utctime start;
-            utctimespan dt;
-            size_t n;
-          public:
-            ts_source(utctime start=no_utctime, utctimespan dt=0, size_t n=0) : start(start),dt(dt),n(n) {}
-            utcperiod total_period() const { return utcperiod(start,start+n*dt);}
-            size_t size() const { return n; }
-            utctimespan delta() const {return dt;}
+	class ts_source {
+		utctime start;
+		utctimespan dt;
+		size_t n;
+	public:
+		ts_source(utctime start = no_utctime, utctimespan dt = 0, size_t n = 0) : start(start), dt(dt), n(n) {}
+		utcperiod total_period() const { return utcperiod(start, start + n*dt); }
+		size_t size() const { return n; }
+		utctimespan delta() const { return dt; }
 
-            mutable size_t n_period_calls=0;
-            mutable size_t n_time_calls=0;
-            mutable size_t n_index_of_calls=0;
-            mutable size_t n_get_calls=0;
-            size_t total_calls()const {return n_get_calls+n_period_calls+n_time_calls+n_index_of_calls;}
-            void reset_call_count() {n_get_calls=n_period_calls=n_time_calls=n_index_of_calls=0;}
+		mutable size_t n_period_calls = 0;
+		mutable size_t n_time_calls = 0;
+		mutable size_t n_index_of_calls = 0;
+		mutable size_t n_get_calls = 0;
+		size_t total_calls()const { return n_get_calls + n_period_calls + n_time_calls + n_index_of_calls; }
+		void reset_call_count() { n_get_calls = n_period_calls = n_time_calls = n_index_of_calls = 0; }
 
-            utcperiod operator()(size_t i) const {
-                n_period_calls++;
-                if(i>n) throw runtime_error("index out of range called");
-                return utcperiod(start + i*dt, start + (i + 1)*dt);
-            }
-            utctime   operator[](size_t i) const {
-                n_time_calls++;
-                if(i>n) throw runtime_error("index out of range called");
-                return utctime(start + i*dt);
-            }
-            point get(size_t i) const {
-                n_get_calls++;
-                if(i>n) throw runtime_error("index out of range called");
+		utcperiod operator()(size_t i) const {
+			n_period_calls++;
+			if (i > n) throw runtime_error("index out of range called");
+			return utcperiod(start + i*dt, start + (i + 1)*dt);
+		}
+		utctime   operator[](size_t i) const {
+			n_time_calls++;
+			if (i > n) throw runtime_error("index out of range called");
+			return utctime(start + i*dt);
+		}
+		point get(size_t i) const {
+			n_get_calls++;
+			if (i > n) throw runtime_error("index out of range called");
 
-                return point(start+i*dt,i);}
-            size_t index_of(utctime tx) const {
-                n_index_of_calls++;
-                if(tx < start) return string::npos;
-                auto ix = size_t((tx - start)/dt);
-                return ix < n ? ix : n - 1;
-            }
-        };
+			return point(start + i*dt, i);
+		}
+		size_t index_of(utctime tx) const {
+			n_index_of_calls++;
+			if (tx < start) return string::npos;
+			auto ix = size_t((tx - start) / dt);
+			return ix < n ? ix : n - 1;
+		}
+	};
+
+
 };
 
 TEST_SUITE("time_series") {


### PR DESCRIPTION
# Overview

The interpolation step, when using the btk method throws exception if there are to few non-nan neighbors to produce the needed non-singular matrixes for computation.

In practical operation, this often occurs at the end of the forecast-period, e.g. EC forecasts,
in these circumstance, we want the run to continue and produce results as long as possible.
It is acceptable that the model produces nan's at the trailing parts of the computations.

During initialization/preparation of the region-model, the fill-values into the results, and the cell.environment is set to nan (formerly 0.0), to ease detection of this situation as well as for consistency and common sense.

The default behavior is best_effort, since the IDW algoritms was already best-effort.
For the sake of possible backward issues,  this can be overridden by passing best_effort=false as
last argument to the RegionModel.run_interplation(..) and RegionModel.interpolate()

Both these routines now returns True if no exceptions was thrown during best_effort interpolation,
otherwise false.

**Possible impacts**

This PR is backward compatible in interfaces, but the semantics for the interpolation run is 
slightly harmonized, giving best_effort by default.

Also note that the result-values, etc. now by default is set to nan, this could lead to required changes for code that relied on 0.0 for these values.


