### PR TITLE
Dict config in CFRegionModelRepository

### DIFF
--- a/shyft/orchestration/configuration/dict_configs.py
+++ b/shyft/orchestration/configuration/dict_configs.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+
+from shyft import api
+
+from . import config_interfaces
+
+def utctime_from_datetime(dt):
+    utc_calendar = api.Calendar()
+    return utc_calendar.time(api.YMDhms(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second))
+
+
+class DictRegionConfig(config_interfaces.RegionConfig):
+    """
+    Dict based region configuration, using a Dictionary instance
+    for holding the content.
+    """
+
+    def __init__(self, config_dict):
+        self._config = config_dict
+
+    def parameter_overrides(self):
+        return self._config.get("parameter_overrides", {})
+
+    def domain(self):
+        return self._config['domain']
+
+    def repository(self):
+        return self._config['repository']
+
+    def catchments(self):
+        return self._config.get("catchment_indices", None)
+
+
+class DictModelConfig(config_interfaces.ModelConfig):
+    """
+    Dict based model configuration, using a Dictionary instance
+    for holding the content.
+    """
+
+    def __init__(self, config_dict, overrides=None):
+        self._config = config_dict
+        if overrides is not None:
+            self._config.update(overrides)
+
+    def model_parameters(self):
+        return self._config['model_parameters']
+
+    def model_type(self):
+        return self._config['model_t']
+
+
+class InterpolationConfig(object):
+    """
+    Dict based model configuration, using a YamlContent instance
+    for holding the content.
+    """
+
+    def __init__(self, config_file):
+        pass
+
+    def interpolation_parameters(self):
+        pass
+
+
+class ConfigError(Exception):
+    pass
+

--- a/shyft/repository/netcdf/cf_geo_ts_repository.py
+++ b/shyft/repository/netcdf/cf_geo_ts_repository.py
@@ -26,7 +26,7 @@ class CFDataRepository(interfaces.GeoTsRepository):
     """
                      
     #def __init__(self, params, region_config):
-    def __init__(self, epsg, stations_met, selection_criteria=None):
+    def __init__(self, epsg, stations_met, selection_criteria=None)->None:
         """
         Construct the netCDF4 dataset reader for data from Arome NWP model,
         and initialize data retrieval.

--- a/shyft/repository/netcdf/cf_geo_ts_repository.py
+++ b/shyft/repository/netcdf/cf_geo_ts_repository.py
@@ -26,7 +26,7 @@ class CFDataRepository(interfaces.GeoTsRepository):
     """
                      
     #def __init__(self, params, region_config):
-    def __init__(self, epsg, stations_met, selection_criteria=None)->None:
+    def __init__(self, epsg, stations_met, selection_criteria=None):
         """
         Construct the netCDF4 dataset reader for data from Arome NWP model,
         and initialize data retrieval.

--- a/shyft/repository/netcdf/cf_region_model_repository.py
+++ b/shyft/repository/netcdf/cf_region_model_repository.py
@@ -17,6 +17,7 @@ from .. import interfaces
 from shyft import api
 from shyft import shyftdata_dir
 from shyft.orchestration.configuration.config_interfaces import RegionConfig, ModelConfig, RegionConfigError
+from shyft.orchestration.configuration.dict_configs import DictModelConfig, DictRegionConfig
 
 class CFRegionModelRepositoryError(Exception):
     pass
@@ -27,18 +28,29 @@ class CFRegionModelRepository(interfaces.RegionModelRepository):
     based on data found in netcdf files.
     """
 
-    def __init__(self, region_config, model_config):
+    def __init__(self, region, model):
         """
         Parameters
         ----------
-        region_config: subclass of interface RegionConfig
-            Object containing regional information, like
+        region: either a dictionary suitable to be instantiated as a
+            RegionConfig Object or a sublcass of the interface RegionConfig
+            containing regional information, like
             catchment overrides, and which netcdf file to read
-        model_config: subclass of interface ModelConfig
+        model: either a dictionary suitable to be instantiated as a
+            ModelConfig Object or a subclass of interface ModelConfig
             Object containing model information, i.e.
             information concerning interpolation and model
             parameters
         """
+
+        if not isinstance(region, RegionConfig):
+            region_config = DictRegionConfig(region)
+        if not isinstance(model, ModelConfig):
+            model_config = DictModelConfig(model)
+        else:
+            region_config = region
+            model_config = model
+
         if not isinstance(region_config, RegionConfig) or \
            not isinstance(model_config, ModelConfig):
             raise interfaces.InterfaceError()


### PR DESCRIPTION
Modified the example CFRegionModelRepository to enable instantiation with dictionaries OR yaml config objects.