### PR TITLE
fixup precip scaling from mm/h to time-step, and mm to mm/h response …

### DIFF
--- a/core/hbv_snow.h
+++ b/core/hbv_snow.h
@@ -192,18 +192,20 @@ namespace shyft {
                     return p.intervals.size();
                 }
 
-                template <class R> void step(S& s, R& r, utctime t0, utctime t1, double prec, double temp) const {
+                template <class R> void step(S& s, R& r, utctime t0, utctime t1, double prec_mm_h, double temp) const {
                     double swe = s.swe;
                     double sca = s.sca;
                     const auto &I = p.intervals;
-                    const double total_water = prec + swe;
+					double step_in_days = (t1 - t0) / 86400.0;
+					const double dt_hours = (t1-t0)/3600.0;
+					const double prec = prec_mm_h*dt_hours;// from mm/h to mm
+					const double total_water = prec + swe;
                     double snow,rain;
                     if( temp < p.tx ) {snow=prec;rain= 0.0;}
                     else              {snow= 0.0;rain=prec;}
-                    double step_in_days = (t1 - t0)/86400.0;
                     swe += snow + sca*rain;
                     if (swe < 0.1) {
-                        r.outflow = total_water;
+                        r.outflow = total_water/dt_hours;
                         fill(begin(s.sp), end(s.sp), 0.0);
                         fill(begin(s.sw), end(s.sw), 0.0);
                         s.swe = 0.0;
@@ -267,7 +269,7 @@ namespace shyft {
                         } else
                             swe = total_water;
                     }
-                    r.outflow = total_water - swe;
+                    r.outflow = (total_water - swe)/dt_hours;// output is mm/h
                     s.swe = swe;
                     s.sca = sca;
                 }

--- a/shyft/repository/netcdf/time_conversion.py
+++ b/shyft/repository/netcdf/time_conversion.py
@@ -1,7 +1,7 @@
 # This file is part of Shyft. Copyright 2015-2018 SiH, JFB, OS, YAS, Statkraft AS
 # See file COPYING for more details **/
 from shyft import api
-from netcdftime import utime
+from cftime import utime
 import numpy as np
 
 """ These are the current supported regular time-step intervals """

--- a/shyft/tests/test_netcdftime.py
+++ b/shyft/tests/test_netcdftime.py
@@ -1,7 +1,7 @@
 import unittest
 from shyft import api
 from shyft.repository.netcdf.time_conversion import convert_netcdf_time
-from netcdftime import utime
+from cftime import utime
 import numpy as np
 
 

--- a/test/hbv_snow_test.cpp
+++ b/test/hbv_snow_test.cpp
@@ -163,6 +163,40 @@ TEST_CASE("test_mass_balance_rain_no_snow") {
     TS_ASSERT_DELTA(state.swe, 0.0, 1.0e-8);
 }
 
+TEST_CASE("test_mass_balance_rain_no_snow_24h_step") {
+	vector<double> s = { 1.0, 1.0, 1.0, 1.0, 1.0 };
+	vector<double> a = { 0.0, 0.25, 0.5, 0.75, 1.0 };
+	parameter p(s, a);
+	state state;
+	response r;
+
+	utctime t0 = 0;
+	utctime t1 = 3600*24; // One day
+	double precipitation = 0.15;
+	double temperature = p.tx;
+	double sca = 0.0;
+	double swe = 0.0;
+	state.swe = swe;
+	state.sca = sca;
+	state.distribute(p);
+	double total_water_before = precipitation + swe;
+	SnowModel snow_model(p);
+	snow_model.step(state, r, t0, t1, precipitation, temperature);
+	double total_water_after = state.swe + r.outflow;
+	TS_ASSERT_DELTA(total_water_before, total_water_after, 1.0e-8);
+	TS_ASSERT_DELTA(state.sca, 0.0, 1.0e-8);
+	TS_ASSERT_DELTA(state.swe, 0.0, 1.0e-8);
+	// now snow and freeze water 1 day
+	snow_model.step(state, r, t0, t1, precipitation, -10.0);
+	TS_ASSERT_DELTA(state.swe / 24.0, precipitation, 1.0e-8); //ensure all rain stored as snow
+	TS_ASSERT_DELTA(r.outflow, 0.0, 1e-8);// should be 0.0 outflow
+	// now melt the snow in one timestep
+	snow_model.step(state, r, t0, t1, 0.0, 30.0);// very hot one day
+	TS_ASSERT_DELTA(state.swe / 24.0, 0.0, 1.0e-8); //ensure all rain stored as snow
+	TS_ASSERT_DELTA(r.outflow, precipitation, 1e-8);// should be 0.0 outflow
+
+}
+
 TEST_CASE("test_mass_balance_melt_no_precip") {
     vector<double> s = {1.0, 1.0, 1.0, 1.0, 1.0};
     vector<double> a = {0.0, 0.25, 0.5, 0.75, 1.0};

--- a/test/skaugen_test.cpp
+++ b/test/skaugen_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE("test_melt") {
     // Model input
     shyft::time_series::utctimespan dt = 24*60*60;
     double temp = -10.0;
-    double prec = 10.0;
+    double prec = 10.0/24.0;
     double radiation = 0.0;
     double wind_speed = 0.0;
     std::vector<std::pair<double, double>> tp(10, std::pair<double, double>(temp, prec));
@@ -91,18 +91,18 @@ TEST_CASE("test_melt") {
     tp = std::vector<std::pair<double, double>>(1, std::pair<double, double>{10.0, 0.0}); // No precip, but 10.0 degrees for one day
 	for_each(tp.begin(), tp.end(), [&dt, &p, &model, &radiation, &wind_speed, &s, &r, &agg_outflow](std::pair<double, double> pair) {
             model.step(dt, p, pair.first, pair.second, radiation, wind_speed, s, r);
-            agg_outflow += r.outflow;
+            agg_outflow += r.outflow*24.0;// dt=24h, r.outflow is in mm/h
         });
     const double total_water_after_melt = s.sca*(s.swe + s.free_water);
     TS_ASSERT_LESS_THAN(total_water_after_melt , total_water); // Less water after melt due to runoff
-    TS_ASSERT(r.outflow + s.free_water >= 1.0); // Some runoff or free water in snow
-    TS_ASSERT_DELTA(r.outflow + s.sca*(s.free_water + s.swe), total_water, 1.0e-6);
+    TS_ASSERT(r.outflow*24.0 + s.free_water >= 1.0); // Some runoff or free water in snow
+    TS_ASSERT_DELTA(r.outflow*24.0 + s.sca*(s.free_water + s.swe), total_water, 1.0e-6);
 
     // One hundred melt events, that should melt everything
     tp = std::vector<std::pair<double, double>>(100, std::pair<double, double>(10.0, 0.0));
     for_each(tp.begin(), tp.end(), [&dt , &p, &model, &radiation, &wind_speed, &s, &r, &agg_outflow] (std::pair<double, double> pair) {
             model.step(dt, p, pair.first, pair.second, radiation, wind_speed, s, r);
-            agg_outflow += r.outflow;
+            agg_outflow += r.outflow*24.0;// mm/h *24h-> mm
         });
 
     TS_ASSERT_DELTA(s.sca, 0.0, 1.0e-6);
@@ -138,7 +138,7 @@ TEST_CASE("test_lwc") {
     // Model input
     shyft::time_series::utctimespan dt = 24*60*60;
     double temp = -10.0;
-    double prec = 10.0;
+    double prec = 10.0/24.0;
     double radiation = 0.0;
     double wind_speed = 0.0;
     std::vector<std::pair<double, double>> tp(10, std::pair<double, double>(temp, prec));
@@ -153,7 +153,7 @@ TEST_CASE("test_lwc") {
     TS_ASSERT_DELTA(s.free_water, 0.0, 1.0e-6);  // No free water when dry snow precip
     model.step(dt, p, 10.0, 0.0, radiation, wind_speed, s, r);
     TS_ASSERT(s.free_water <= s.swe*max_water_fraction);  // Can not have more free water in the snow than the capacity of the snowpack
-    tp = std::vector<std::pair<double, double>>(5, std::pair<double, double>(10.0, 0.0));
+    tp = std::vector<std::pair<double, double>>(5, std::pair<double, double>(2.0, 0.0));
     for_each(tp.begin(), tp.end(), [&dt , &p, &model, &radiation, &wind_speed, &s, &r] (std::pair<double, double> pair) {
             model.step(dt, p, pair.first, pair.second, radiation, wind_speed, s, r);
         });


### PR DESCRIPTION
#Overview

This PR resolves issue for hbv_snow and skaugen snow reported for time-resolutions other than 1h.

The solution is simply scale precipitation (mm/h) to mm @ timestep, 
and to ensure that response is mm/h.

Added test to cover issue, re-run the examples provided in PR, with reasonable results.

Ref #315 

I provide a windows build for this branch, on conda channel sigbjorn.

Then after the micro-seconds branch is done and merged, I will apply this patch to master, and provide a new 'master' version with the fix.

So in practice, this branch will not be merged to master until the us/microseconds branch is merged, but the resulting package is provided as patch/source ASAP. 