### PR TITLE
#323 interpolation parameters from interpolation_parameter_repo should be …

### DIFF
--- a/shyft/orchestration/simulator.py
+++ b/shyft/orchestration/simulator.py
@@ -84,6 +84,7 @@ class DefaultSimulator(object):
                                                                      catchments=catchments)
         self.epsg = self.region_model.bounding_region.epsg()
         self.initial_state_repo = initial_state_repository
+        self.region_model.interpolation_parameter = self.ip_repos.get_parameters(self.interpolation_id)
         if isinstance(self.initial_state_repo, GeneratedStateRepository):  # special case!
             self.initial_state_repo.model = self.region_model  # have to ensure that the generated state match this model
         if hasattr(self.region_model, "optimizer_t"):
@@ -159,7 +160,6 @@ class DefaultSimulator(object):
         sources = self.geo_ts_repository.get_timeseries(self._geo_ts_names, period,
                                                         geo_location_criteria=bbox)
         self.region_model.region_env = self._get_region_environment(sources)
-        self.region_model.interpolation_parameter = self.ip_repos.get_parameters(self.interpolation_id)
         self.simulate()
 
     def run_forecast(self, time_axis, t_c, state):
@@ -169,7 +169,6 @@ class DefaultSimulator(object):
                                                       geo_location_criteria=bbox)
         self.region_model.initialize_cell_environment(time_axis)
         self.region_model.region_env = self._get_region_environment(sources)
-        self.region_model.interpolation_parameter = self.ip_repos.get_parameters(self.interpolation_id)
         self.region_model.state.apply_state(self.get_initial_state_from_repo() if state is None else state, [])
         self.region_model.initial_state = self.region_model.current_state
         self.simulate()
@@ -182,7 +181,6 @@ class DefaultSimulator(object):
         self.region_model.initialize_cell_environment(time_axis)
         self.region_model.state.apply_state(self.get_initial_state_from_repo() if state is None else state, [])
         self.region_model.initial_state = self.region_model.current_state
-        self.region_model.interpolation_parameter = self.ip_repos.get_parameters(self.interpolation_id)
         runnables = []
         for source in sources:
             simulator = self.copy()

--- a/shyft/tests/netcdf/neanidelva_calibration.yaml
+++ b/shyft/tests/netcdf/neanidelva_calibration.yaml
@@ -17,7 +17,7 @@
       uid: /TEV.-Tya...........-D9100A3B1060R123.999
       start_datetime: 2013-09-01T00:00:00
       run_time_step: 86400 # 3600
-      number_of_steps: 365 # 26280
+      number_of_steps: 364 # 26280
       weight: 1.0
       obj_func:
         name: NSE # Nash–Sutcliffe efficiency (NSE) or Kling–Gupta efficiency (KGE)
@@ -29,7 +29,7 @@
       uid: /TEV.-Selbu-lok.....-D9100A3B1070R123.020
       start_datetime: 2013-09-01T00:00:00
       run_time_step: 86400 # 3600
-      number_of_steps: 365 # 26280
+      number_of_steps: 364 # 26280
       weight: 1.0
       obj_func:
         name: NSE # Nash–Sutcliffe efficiency (NSE) or Kling–Gupta efficiency (KGE)
@@ -41,7 +41,7 @@
       uid: /TEV.-Nea...........-D9100A3B1050R123.998
       start_datetime: 2013-09-01T00:00:00
       run_time_step: 86400 # 3600
-      number_of_steps: 365 # 26280
+      number_of_steps: 364 # 26280
       weight: 1.0
       obj_func:
         name: NSE # Nash–Sutcliffe efficiency (NSE) or Kling–Gupta efficiency (KGE)
@@ -107,6 +107,33 @@
     gs.glacier_albedo:
       min: 0.4
       max: 0.4
+    gs.initial_bare_ground_fraction:
+      min: 0.04
+      max: 0.04
+    gs.winter_end_day_of_year:
+      min: 100
+      max: 100
+    gs.calculate_iso_pot_energy:
+      min: 0
+      max: 0
+    gs.n_winter_days:
+      min: 100
+      max: 100
+    gm.dtf:
+      min: 5
+      max: 5 
+    gm.direct_response:
+      min: 0.0
+      max: 0.0
+    routing.velocity:
+      min: 0
+      max: 0
+    routing.alpha:
+      min: 0.9
+      max: 0.9
+    routing.beta:
+      min: 3.0
+      max: 3.0
     p_corr.scale_factor:
       min: 1.0
       max: 1.0

--- a/shyft/tests/netcdf/neanidelva_interpolation.yaml
+++ b/shyft/tests/netcdf/neanidelva_interpolation.yaml
@@ -21,7 +21,7 @@ interpolation_parameters:
       max_distance: 600000.0
       max_members: 10
       distance_measure_factor: 1
-      scale_factor: 1.02
+      scale_factor: 1.01
   radiation:
     method: idw
     params:

--- a/shyft/tests/test_config_simulator.py
+++ b/shyft/tests/test_config_simulator.py
@@ -3,7 +3,10 @@ import unittest
 
 from shyft.repository.default_state_repository import DefaultStateRepository
 from shyft.orchestration.configuration.yaml_configs import YAMLSimConfig
+from shyft.orchestration.configuration.yaml_configs import YAMLCalibConfig
 from shyft.orchestration.simulators.config_simulator import ConfigSimulator
+from shyft.orchestration.simulators.config_simulator import ConfigCalibrator
+
 from shyft.api import IntVector, Calendar
 from shyft.orchestration.configuration.yaml_configs import utctime_from_datetime
 import datetime as dt
@@ -26,6 +29,10 @@ class ConfigSimulationTestCase(unittest.TestCase):
         # These config files are versioned in shyft-data git. Read from ${SHYFTDATA}/netcdf/orchestration-testdata/
         # TODO: Put all config files needed to run this test under the same versioning system (shyft git)
         simulator = ConfigSimulator(cfg)
+
+        # Regression tests on interpolation parameters
+        self.assertAlmostEqual(simulator.region_model.interpolation_parameter.precipitation.scale_factor, 1.01, 3)
+
         #n_cells = simulator.region_model.size()
         state_repos = DefaultStateRepository(simulator.region_model)
         simulator.run(cfg.time_axis, state_repos.get_state(0))
@@ -33,13 +40,25 @@ class ConfigSimulationTestCase(unittest.TestCase):
         discharge = simulator.region_model.statistics.discharge(cids)
 
         # Regression tests on discharge values
-        self.assertAlmostEqual(discharge.values[0], 0.1001063, 3)
-        self.assertAlmostEqual(discharge.values[3], 3.9141928, 3)
+        self.assertAlmostEqual(discharge.values[0], 0.1000929, 3)
+        self.assertAlmostEqual(discharge.values[3], 3.9918816, 3)
         # Regression tests on geo fractions
         self.assertAlmostEqual(simulator.region_model.cells[0].geo.land_type_fractions_info().unspecified(), 1.0, 3)
         self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().unspecified(), 0.1433, 3)
         self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().forest(), 0.0, 3)
         self.assertAlmostEqual(simulator.region_model.cells[2].geo.land_type_fractions_info().reservoir(), 0.8566, 3)
+
+    def test_run_geo_ts_data_config_calibrator(self):
+        # These config files are versioned in shyft git
+        config_dir = path.join(path.dirname(__file__), "netcdf")
+        config_file = path.join(config_dir, "neanidelva_calibration.yaml")
+        print(config_file)
+        config_section = "neanidelva"
+        cfg = YAMLCalibConfig(config_file, config_section)
+        calibrator = ConfigCalibrator(cfg)
+
+        # Regression tests on interpolation parameters
+        self.assertAlmostEqual(calibrator.region_model.interpolation_parameter.precipitation.scale_factor, 1.01, 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…attributed to region_model when it is constructed, not when region model is run.
@felixmatt created this fix for #323 in discussion with @yisak and others. Seems ready to go!