### PR TITLE
Minor change in ConcatDataRepository

### DIFF
--- a/shyft/repository/netcdf/concat_data_repository.py
+++ b/shyft/repository/netcdf/concat_data_repository.py
@@ -681,7 +681,7 @@ class ConcatDataRepository(interfaces.GeoTsRepository):
         elif k == 'forecasts_that_cover_period':
             v_shift_first = int(v.start - lead_times_in_sec[nb_lead_intervals_to_drop])
             v_shift_last = int(v.end - lead_times_in_sec[nb_lead_intervals_to_drop + nb_lead_intervals])
-            time_slice = ((time <= v_shift_first) & (time > v_shift_last))
+            time_slice = ((time <= v_shift_first) & (time >= v_shift_last))
             if not any(time_slice):
                 raise ConcatDataRepositoryError(
                     "No forecasts found that cover period {} with restrictions 'nb_lead_intervals_to_drop'={} "


### PR DESCRIPTION
When fetching forecasts with criterion 'forecasts_that_cover_period', the current repo is unable to return a forecast that starts exactly at t_run, and has a length equal to the requested utc_period (v_shift_first == v_shift_last)

This PR includes the end time in the slice boundary, and a forecast which is "perfectly aligned" with t_run and utc_period will be returned.